### PR TITLE
Fix Config memory leaks: arena-based deinit for all 17 call sites

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -1050,10 +1050,11 @@ fn cliStreamCallback(_: *anyopaque, chunk: providers.StreamChunk) void {
 /// Run the agent in single-message or interactive REPL mode.
 /// This is the main entry point called by `nullclaw agent`.
 pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
-    const cfg = Config.load(allocator) catch {
+    var cfg = Config.load(allocator) catch {
         log.err("No config found. Run `nullclaw onboard` first.", .{});
         return;
     };
+    defer cfg.deinit();
 
     var out_buf: [4096]u8 = undefined;
     var bw = std.fs.File.stdout().writer(&out_buf);

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -620,7 +620,8 @@ pub fn run(allocator: std.mem.Allocator, host: []const u8, port: u16) !void {
     defer state.deinit();
 
     // Load config and set up in-process SessionManager (graceful degradation if no config).
-    const config_opt: ?Config = Config.load(allocator) catch null;
+    var config_opt: ?Config = Config.load(allocator) catch null;
+    defer if (config_opt) |*c| c.deinit();
 
     // ProviderHolder: concrete provider struct must outlive the accept loop.
     const ProviderHolder = union(enum) {

--- a/src/status.zig
+++ b/src/status.zig
@@ -8,12 +8,13 @@ pub fn run(allocator: std.mem.Allocator) !void {
     var bw = std.fs.File.stdout().writer(&buf);
     const w = &bw.interface;
 
-    const cfg = Config.load(allocator) catch {
+    var cfg = Config.load(allocator) catch {
         try w.print("nullclaw Status (no config found -- run `nullclaw onboard` first)\n", .{});
         try w.print("\nVersion: {s}\n", .{version});
         try w.flush();
         return;
     };
+    defer cfg.deinit();
 
     try w.print("nullclaw Status\n\n", .{});
     try w.print("Version:     {s}\n", .{version});

--- a/src/tools/delegate.zig
+++ b/src/tools/delegate.zig
@@ -125,11 +125,10 @@ pub const DelegateTool = struct {
         }
 
         // Fallback: no agent config found — load global config
-        var cfg_arena = std.heap.ArenaAllocator.init(allocator);
-        defer cfg_arena.deinit();
-        const cfg = Config.load(cfg_arena.allocator()) catch {
+        var cfg = Config.load(allocator) catch {
             return ToolResult.fail("Failed to load config — run `nullclaw onboard` first");
         };
+        defer cfg.deinit();
 
         const agent_prompt = std.fmt.allocPrint(
             allocator,


### PR DESCRIPTION
Config.load() creates an ArenaAllocator internally — all allocations (string dupes, arrays, env overrides) live in the arena. Added Config.deinit() that destroys the arena in one shot, and wired up defer deinit at every Config.load() call site across the codebase.