### PR TITLE
Add OpenAI Codex provider for ChatGPT subscription API (#23)

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -1130,6 +1130,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         compatible: providers.compatible.OpenAiCompatibleProvider,
         claude_cli: providers.claude_cli.ClaudeCliProvider,
         codex_cli: providers.codex_cli.CodexCliProvider,
+        openai_codex: providers.openai_codex.OpenAiCodexProvider,
     };
 
     const kind = providers.classifyProvider(cfg.default_provider);
@@ -1164,6 +1165,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
             .{ .codex_cli = p }
         else |_|
             .{ .openrouter = providers.openrouter.OpenRouterProvider.init(allocator, cfg.defaultProviderKey()) },
+        .openai_codex_provider => .{ .openai_codex = providers.openai_codex.OpenAiCodexProvider.init(allocator, null) },
         .unknown => .{ .openrouter = providers.openrouter.OpenRouterProvider.init(allocator, cfg.defaultProviderKey()) },
     };
 
@@ -1176,6 +1178,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         .compatible => |*p| p.provider(),
         .claude_cli => |*p| p.provider(),
         .codex_cli => |*p| p.provider(),
+        .openai_codex => |*p| p.provider(),
     };
 
     const supports_streaming = provider_i.supportsStreaming();

--- a/src/channel_loop.zig
+++ b/src/channel_loop.zig
@@ -50,6 +50,7 @@ pub const ProviderHolder = union(enum) {
     gemini: providers.gemini.GeminiProvider,
     ollama: providers.ollama.OllamaProvider,
     compatible: providers.compatible.OpenAiCompatibleProvider,
+    openai_codex: providers.openai_codex.OpenAiCodexProvider,
 
     pub fn provider(self: *ProviderHolder) providers.Provider {
         return switch (self.*) {
@@ -59,6 +60,7 @@ pub const ProviderHolder = union(enum) {
             .gemini => |*p| p.provider(),
             .ollama => |*p| p.provider(),
             .compatible => |*p| p.provider(),
+            .openai_codex => |*p| p.provider(),
         };
     }
 };
@@ -106,6 +108,7 @@ pub const ChannelRuntime = struct {
                 api_key,
                 .bearer,
             ) },
+            .openai_codex_provider => .{ .openai_codex = providers.openai_codex.OpenAiCodexProvider.init(allocator, null) },
             .claude_cli_provider, .codex_cli_provider, .unknown => .{ .openrouter = providers.openrouter.OpenRouterProvider.init(allocator, api_key) },
         };
 
@@ -330,4 +333,5 @@ test "ProviderHolder tagged union fields" {
     try std.testing.expect(@hasField(ProviderHolder, "gemini"));
     try std.testing.expect(@hasField(ProviderHolder, "ollama"));
     try std.testing.expect(@hasField(ProviderHolder, "compatible"));
+    try std.testing.expect(@hasField(ProviderHolder, "openai_codex"));
 }

--- a/src/providers/root.zig
+++ b/src/providers/root.zig
@@ -15,6 +15,7 @@ pub const router = @import("router.zig");
 pub const sse = @import("sse.zig");
 pub const claude_cli = @import("claude_cli.zig");
 pub const codex_cli = @import("codex_cli.zig");
+pub const openai_codex = @import("openai_codex.zig");
 
 // ════════════════════════════════════════════════════════════════════════════
 // Core Types
@@ -682,6 +683,7 @@ pub const ProviderKind = enum {
     compatible_provider,
     claude_cli_provider,
     codex_cli_provider,
+    openai_codex_provider,
     unknown,
 };
 
@@ -697,6 +699,7 @@ pub fn classifyProvider(name: []const u8) ProviderKind {
         .{ "google-gemini", .gemini_provider },
         .{ "claude-cli", .claude_cli_provider },
         .{ "codex-cli", .codex_cli_provider },
+        .{ "openai-codex", .openai_codex_provider },
         // OpenAI-compatible providers
         .{ "venice", .compatible_provider },
         .{ "vercel", .compatible_provider },
@@ -1308,6 +1311,7 @@ test "classifyProvider identifies known providers" {
     try std.testing.expect(classifyProvider("deepseek") == .compatible_provider);
     try std.testing.expect(classifyProvider("venice") == .compatible_provider);
     try std.testing.expect(classifyProvider("custom:https://example.com") == .compatible_provider);
+    try std.testing.expect(classifyProvider("openai-codex") == .openai_codex_provider);
     try std.testing.expect(classifyProvider("nonexistent") == .unknown);
 }
 


### PR DESCRIPTION
New provider connecting to chatgpt.com/backend-api/codex/responses via OAuth tokens, allowing ChatGPT Plus/Pro users to use nullClaw without separate API keys.

- New src/providers/openai_codex.zig (~380 lines, 18 tests): provider with vtable interface, Codex SSE streaming, JWT parsing, auto-refresh token management
- auth.zig: add refreshAccessToken() and deleteCredential()
- providers/root.zig: register openai_codex_provider
- agent/root.zig, channel_loop.zig, main.zig: wire ProviderHolder
- main.zig: `nullclaw auth <login|status|logout> <provider>` command with device code flow, --manual interactive (raw mode stdin), and --token direct input; API key check bypass for OAuth providers