### PR TITLE
feat(cli): add version command, centralize version metadata

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,6 +5,8 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const app_version = b.option([]const u8, "version", "Version string embedded in the binary") orelse "2026.2.20";
+
     const sqlite3_dep = b.dependency("sqlite3", .{
         .target = target,
         .optimize = optimize,
@@ -12,12 +14,17 @@ pub fn build(b: *std.Build) void {
     const sqlite3 = sqlite3_dep.artifact("sqlite3");
     sqlite3.root_module.addCMacro("SQLITE_ENABLE_FTS5", "1");
 
+    var build_options = b.addOptions();
+    build_options.addOption([]const u8, "version", app_version);
+    const build_options_module = build_options.createModule();
+
     // ---------- library module (importable by consumers) ----------
     const lib_mod = b.addModule("nullclaw", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
+    lib_mod.addImport("build_options", build_options_module);
     lib_mod.linkLibrary(sqlite3);
 
     // ---------- executable ----------
@@ -32,6 +39,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    exe.root_module.addImport("build_options", build_options_module);
 
     // Link SQLite on the compile step (not the module)
     exe.linkLibrary(sqlite3);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .nullclaw,
-    .version = "0.1.0",
+    .version = "2026.2.20",
     .fingerprint = 0xe73e13d1c95956c2,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -29,6 +29,7 @@ const Command = enum {
     models,
     auth,
     help,
+    version,
 };
 
 fn parseCommand(arg: []const u8) ?Command {
@@ -50,6 +51,9 @@ fn parseCommand(arg: []const u8) ?Command {
         .{ "help", .help },
         .{ "--help", .help },
         .{ "-h", .help },
+        .{ "version", .version },
+        .{ "--version", .version },
+        .{ "-V", .version },
     });
     return command_map.get(arg);
 }
@@ -86,6 +90,7 @@ pub fn main() !void {
         .onboard => try runOnboard(allocator, sub_args),
         .doctor => try yc.doctor.run(allocator),
         .help => printUsage(),
+        .version => std.debug.print("nullclaw {s}\n", .{yc.version.string}),
         .gateway => try runGateway(allocator, sub_args),
         .daemon => try runDaemon(allocator, sub_args),
         .service => try runService(allocator, sub_args),
@@ -1232,6 +1237,7 @@ fn printUsage() void {
         \\  daemon      Start long-running runtime (gateway + channels + heartbeat)
         \\  service     Manage OS service lifecycle (install/start/stop/status/uninstall)
         \\  status      Show system status
+        \\  version     Show CLI version
         \\  doctor      Run diagnostics
         \\  cron        Manage scheduled tasks
         \\  channel     Manage channels (Telegram, Discord, Slack, ...)
@@ -1247,6 +1253,7 @@ fn printUsage() void {
         \\  agent [-m MESSAGE] [-s SESSION] [--provider PROVIDER] [--model MODEL] [--temperature TEMP]
         \\  gateway [--port PORT] [--host HOST]
         \\  daemon [--port PORT] [--host HOST]
+        \\  version | --version | -V
         \\  service <install|start|stop|status|uninstall>
         \\  cron <list|add|once|remove|pause|resume> [ARGS]
         \\  channel <list|start|doctor|add|remove> [ARGS]
@@ -1263,6 +1270,9 @@ fn printUsage() void {
 test "parse known commands" {
     try std.testing.expectEqual(.agent, parseCommand("agent").?);
     try std.testing.expectEqual(.status, parseCommand("status").?);
+    try std.testing.expectEqual(.version, parseCommand("version").?);
+    try std.testing.expectEqual(.version, parseCommand("--version").?);
+    try std.testing.expectEqual(.version, parseCommand("-V").?);
     try std.testing.expectEqual(.service, parseCommand("service").?);
     try std.testing.expectEqual(.migrate, parseCommand("migrate").?);
     try std.testing.expectEqual(.models, parseCommand("models").?);

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const tools_mod = @import("tools/root.zig");
 const config_mod = @import("config.zig");
 const yc = @import("root.zig");
+const ver = @import("version.zig");
 const Allocator = std.mem.Allocator;
 
 const log = std.log.scoped(.mcp);
@@ -79,9 +80,14 @@ pub const McpServer = struct {
         self.child = child;
 
         // Send initialize request
-        const init_resp = try self.sendRequest(self.allocator, "initialize",
-            \\{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"nullclaw","version":"0.1.0"}}
+        const init_params = try std.fmt.allocPrint(
+            self.allocator,
+            "{{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{{}},\"clientInfo\":{{\"name\":\"nullclaw\",\"version\":\"{s}\"}}}}",
+            .{ver.string},
         );
+        defer self.allocator.free(init_params);
+
+        const init_resp = try self.sendRequest(self.allocator, "initialize", init_params);
         defer self.allocator.free(init_resp);
 
         // Verify we got a valid response (has protocolVersion in result)

--- a/src/root.zig
+++ b/src/root.zig
@@ -15,6 +15,7 @@ pub const websocket = @import("websocket.zig");
 pub const bus = @import("bus.zig");
 pub const config = @import("config.zig");
 pub const util = @import("util.zig");
+pub const version = @import("version.zig");
 pub const state = @import("state.zig");
 pub const status = @import("status.zig");
 pub const onboard = @import("onboard.zig");

--- a/src/status.zig
+++ b/src/status.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const Config = @import("config.zig").Config;
-
-const version = "0.1.0";
+const version = @import("version.zig");
 
 pub fn run(allocator: std.mem.Allocator) !void {
     var buf: [4096]u8 = undefined;
@@ -10,14 +9,14 @@ pub fn run(allocator: std.mem.Allocator) !void {
 
     var cfg = Config.load(allocator) catch {
         try w.print("nullclaw Status (no config found -- run `nullclaw onboard` first)\n", .{});
-        try w.print("\nVersion: {s}\n", .{version});
+        try w.print("\nVersion: {s}\n", .{version.string});
         try w.flush();
         return;
     };
     defer cfg.deinit();
 
     try w.print("nullclaw Status\n\n", .{});
-    try w.print("Version:     {s}\n", .{version});
+    try w.print("Version:     {s}\n", .{version.string});
     try w.print("Workspace:   {s}\n", .{cfg.workspace_dir});
     try w.print("Config:      {s}\n", .{cfg.config_path});
     try w.print("\n", .{});

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,0 +1,3 @@
+const build_options = @import("build_options");
+
+pub const string: []const u8 = build_options.version;


### PR DESCRIPTION
Fixes #27

## Supersedes
- #32 by @chenrui333

## Integrated Scope
- From #32: `version.zig` + build_options approach, version centralization in `status.zig` and `mcp.zig`, `version` subcommand, help text, test

## Summary
- `nullclaw --version` / `-V` / `version` prints `nullclaw 2026.2.20` and exits with code 0
- New `src/version.zig` centralizes version via `build_options` (injectable with `-Dversion=...`)
- Removed hardcoded `"0.1.0"` from `status.zig` and `mcp.zig`
- Updated `build.zig.zon` to CalVer `2026.2.20` matching release tags
- Added `--version` and `-V` flags (not in #32), matching conventions from zeroclaw, picoclaw, nanobot, openclaw

## Test plan
- [x] `nullclaw --version` → `nullclaw 2026.2.20` (exit 0)
- [x] `nullclaw -V` → same
- [x] `nullclaw version` → same
- [x] All 2920 tests pass
- [x] Build succeeds

## Attribution
- Co-authored-by trailer added for @chenrui333: Yes

## Risk and Rollback
- Risk: low — additive CLI change, no behavior change for existing commands
- Rollback: revert commit