### PR TITLE
feat: integrate SecurityPolicy into runtime execution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,7 @@ Config: `~/.nullclaw/config.json` (created by `onboard`)
   "autonomy": {
     "level": "supervised",
     "workspace_only": true,
-    "max_actions_per_hour": 20,
-    "max_cost_per_day_cents": 500
+    "max_actions_per_hour": 20
   },
 
   "runtime": {

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -247,9 +247,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
             if (aut.object.get("max_actions_per_hour")) |v| {
                 if (v == .integer) self.autonomy.max_actions_per_hour = @intCast(v.integer);
             }
-            if (aut.object.get("max_cost_per_day_cents")) |v| {
-                if (v == .integer) self.autonomy.max_cost_per_day_cents = @intCast(v.integer);
-            }
+            // max_cost_per_day_cents: ignored (removed — never enforced at runtime)
             if (aut.object.get("require_approval_for_medium_risk")) |v| {
                 if (v == .bool) self.autonomy.require_approval_for_medium_risk = v.bool;
             }
@@ -258,21 +256,15 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
             }
             if (aut.object.get("level")) |v| {
                 if (v == .string) {
-                    if (std.mem.eql(u8, v.string, "read_only")) {
-                        self.autonomy.level = .read_only;
-                    } else if (std.mem.eql(u8, v.string, "supervised")) {
-                        self.autonomy.level = .supervised;
-                    } else if (std.mem.eql(u8, v.string, "full")) {
-                        self.autonomy.level = .full;
+                    if (types.AutonomyLevel.fromString(v.string)) |lvl| {
+                        self.autonomy.level = lvl;
                     }
                 }
             }
             if (aut.object.get("allowed_commands")) |v| {
                 if (v == .array) self.autonomy.allowed_commands = try parseStringArray(self.allocator, v.array);
             }
-            if (aut.object.get("forbidden_paths")) |v| {
-                if (v == .array) self.autonomy.forbidden_paths = try parseStringArray(self.allocator, v.array);
-            }
+            // forbidden_paths: ignored (removed — path security handled by path_security.zig)
             if (aut.object.get("allowed_paths")) |v| {
                 if (v == .array) self.autonomy.allowed_paths = try parseStringArray(self.allocator, v.array);
             }

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -2,11 +2,8 @@ const std = @import("std");
 
 // ── Autonomy Level ──────────────────────────────────────────────
 
-pub const AutonomyLevel = enum {
-    read_only,
-    supervised,
-    full,
-};
+/// Re-exported from security/policy.zig — single source of truth (with methods).
+pub const AutonomyLevel = @import("security/policy.zig").AutonomyLevel;
 
 // ── Hardware Transport ──────────────────────────────────────────
 
@@ -58,11 +55,9 @@ pub const AutonomyConfig = struct {
     level: AutonomyLevel = .supervised,
     workspace_only: bool = true,
     max_actions_per_hour: u32 = 20,
-    max_cost_per_day_cents: u32 = 500,
     require_approval_for_medium_risk: bool = true,
     block_high_risk_commands: bool = true,
     allowed_commands: []const []const u8 = &.{},
-    forbidden_paths: []const []const u8 = &.{},
     /// Additional directories (absolute paths) the agent may access beyond workspace_dir.
     /// Resolved via realpath at check time; system-critical paths are always blocked.
     allowed_paths: []const []const u8 = &.{},

--- a/src/tools/root.zig
+++ b/src/tools/root.zig
@@ -254,6 +254,7 @@ pub fn allTools(
         subagent_manager: ?*@import("../subagent.zig").SubagentManager = null,
         allowed_paths: []const []const u8 = &.{},
         tools_config: @import("../config.zig").ToolsConfig = .{},
+        policy: ?*const @import("../security/policy.zig").SecurityPolicy = null,
     },
 ) ![]Tool {
     var list: std.ArrayList(Tool) = .{};
@@ -268,6 +269,7 @@ pub fn allTools(
         .allowed_paths = opts.allowed_paths,
         .timeout_ns = tc.shell_timeout_secs * std.time.ns_per_s,
         .max_output_bytes = tc.shell_max_output_bytes,
+        .policy = opts.policy,
     };
     try list.append(allocator, st.tool());
 
@@ -387,13 +389,14 @@ pub fn subagentTools(
     opts: struct {
         http_enabled: bool = false,
         allowed_paths: []const []const u8 = &.{},
+        policy: ?*const @import("../security/policy.zig").SecurityPolicy = null,
     },
 ) ![]Tool {
     var list: std.ArrayList(Tool) = .{};
     errdefer list.deinit(allocator);
 
     const st = try allocator.create(shell.ShellTool);
-    st.* = .{ .workspace_dir = workspace_dir, .allowed_paths = opts.allowed_paths };
+    st.* = .{ .workspace_dir = workspace_dir, .allowed_paths = opts.allowed_paths, .policy = opts.policy };
     try list.append(allocator, st.tool());
 
     const ft = try allocator.create(file_read.FileReadTool);


### PR DESCRIPTION
## Summary
- Wire `SecurityPolicy` into `ShellTool` (command validation before shell execution) and `Agent` (`canAct` + `recordAction` rate limiting in `executeTool`)
- Construct `SecurityPolicy` from `AutonomyConfig` in both CLI and channel startup paths, propagate through `SessionManager`
- Unify duplicate `AutonomyLevel` enum — single source of truth in `security/policy.zig`, re-exported from `config_types.zig`
- Remove dead code: `isPathAllowed`, `forbidden_paths`, `max_cost_per_day_cents`
- Migrate URL-encoded traversal check (`..%2f`, `%2f..`, etc.) from dead `isPathAllowed` to active `path_security.isPathSafe`
- Wire `allowed_paths` from config to `allTools()` (was always `&.{}` before)

## Files changed (11)
- `src/security/policy.zig` — remove dead code, export `RateTracker`
- `src/tools/shell.zig` — add `policy` field, validate commands before execution
- `src/tools/path_security.zig` — add URL-encoded traversal detection
- `src/tools/root.zig` — thread `policy` param through `allTools()`
- `src/agent/root.zig` — add `policy` field, gate `executeTool()` with canAct + rate limit
- `src/agent/cli.zig` — construct SecurityPolicy from config, pass to tools + agent
- `src/main.zig` — same for channel mode startup
- `src/session.zig` — propagate policy to new agent sessions
- `src/config_types.zig` — unify AutonomyLevel, remove dead fields
- `src/config_parse.zig` — remove dead field parsing
- `src/config.zig` — remove dead field serialization/tests

## Test plan
- [x] `zig build test` — 2933/2934 passed (1 skipped)
- [x] `zig build` — clean
- [x] `zig build -Doptimize=ReleaseSmall` — 1.8 MB binary
- [x] Review: SecurityPolicy nullable pattern doesn't break existing tests
- [x] Review: No regressions in command risk classification
- [x] Review: URL-encoded traversal check coverage
- [x] Review: Config wiring completeness (CLI + channel + session)