### PR TITLE
feat: add allow_env_api_keys config option

### DIFF
--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -96,13 +96,20 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         .tracker = &tracker,
     };
 
+    // Resolve API key: config providers first, then env vars (ANTHROPIC_API_KEY, etc.)
+    const resolved_api_key = providers.resolveApiKeyFromConfig(
+        allocator,
+        cfg.default_provider,
+        cfg.providers,
+    ) catch null;
+
     // Create tools (with agents config for delegate depth enforcement)
     const tools = try tools_mod.allTools(allocator, cfg.workspace_dir, .{
         .http_enabled = cfg.http_request.enabled,
         .browser_enabled = cfg.browser.enabled,
         .mcp_tools = mcp_tools,
         .agents = cfg.agents,
-        .fallback_api_key = cfg.defaultProviderKey(),
+        .fallback_api_key = resolved_api_key,
         .tools_config = cfg.tools,
         .allowed_paths = cfg.autonomy.allowed_paths,
         .policy = &policy,
@@ -118,13 +125,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
     } else |_| {}
 
     // Create provider via centralized ProviderHolder (concrete struct lives on the stack)
-    const api_key = providers.resolveApiKeyFromConfig(
-        allocator,
-        cfg.default_provider,
-        cfg.providers,
-        cfg.allowEnvApiKeys(),
-    ) catch null;
-    var holder = providers.ProviderHolder.fromConfig(allocator, cfg.default_provider, api_key);
+    var holder = providers.ProviderHolder.fromConfig(allocator, cfg.default_provider, resolved_api_key);
     const provider_i: Provider = holder.provider();
 
     const supports_streaming = provider_i.supportsStreaming();

--- a/src/config.zig
+++ b/src/config.zig
@@ -70,7 +70,6 @@ pub const Config = struct {
     default_model: ?[]const u8 = "anthropic/claude-sonnet-4",
     default_temperature: f64 = 0.7,
     reasoning_effort: ?[]const u8 = null,
-    allow_env_api_keys: ?bool = null,
 
     // Model routing and delegate agents
     model_routes: []const ModelRouteConfig = &.{},
@@ -128,11 +127,6 @@ pub const Config = struct {
     /// Convenience: API key for the default_provider.
     pub fn defaultProviderKey(self: *const Config) ?[]const u8 {
         return self.getProviderKey(self.default_provider);
-    }
-
-    /// Check if reading API keys from environment variables is allowed.
-    pub fn allowEnvApiKeys(self: *const Config) bool {
-        return self.allow_env_api_keys orelse false;
     }
 
     /// Look up a provider's base_url from the providers list.

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -648,14 +648,15 @@ pub fn run(allocator: std.mem.Allocator, host: []const u8, port: u16) !void {
             state.whatsapp_app_secret = wa_cfg.app_secret orelse "";
         }
 
-        // Build provider holder from configured provider name.
-        const api_key = providers.resolveApiKeyFromConfig(
+        // Resolve API key: config providers first, then env vars
+        const resolved_api_key = providers.resolveApiKeyFromConfig(
             allocator,
             cfg.default_provider,
             cfg.providers,
-            cfg.allowEnvApiKeys(),
         ) catch null;
-        holder_opt = providers.ProviderHolder.fromConfig(allocator, cfg.default_provider, api_key);
+
+        // Build provider holder from configured provider name.
+        holder_opt = providers.ProviderHolder.fromConfig(allocator, cfg.default_provider, resolved_api_key);
 
         // Build provider vtable from the holder.
         if (holder_opt) |*h| {
@@ -676,7 +677,7 @@ pub fn run(allocator: std.mem.Allocator, host: []const u8, port: u16) !void {
                 .browser_enabled = cfg.browser.enabled,
                 .screenshot_enabled = true,
                 .agents = cfg.agents,
-                .fallback_api_key = cfg.defaultProviderKey(),
+                .fallback_api_key = resolved_api_key,
             }) catch &.{};
 
             // Noop observer.

--- a/src/main.zig
+++ b/src/main.zig
@@ -711,10 +711,17 @@ fn runChannelStart(allocator: std.mem.Allocator, args: []const []const u8) !void
     else
         telegram_config.allow_from;
 
+    // Resolve API key: config providers first, then env vars (ANTHROPIC_API_KEY, etc.)
+    const resolved_api_key = yc.providers.resolveApiKeyFromConfig(
+        allocator,
+        config.default_provider,
+        config.providers,
+    ) catch null;
+
     // OAuth providers (openai-codex) don't need an API key
     const provider_kind = yc.providers.classifyProvider(config.default_provider);
-    if (config.defaultProviderKey() == null and provider_kind != .openai_codex_provider) {
-        std.debug.print("No API key configured. Add to ~/.nullclaw/config.json:\n", .{});
+    if (resolved_api_key == null and provider_kind != .openai_codex_provider) {
+        std.debug.print("No API key configured. Set env var or add to ~/.nullclaw/config.json:\n", .{});
         std.debug.print("  \"providers\": {{ \"{s}\": {{ \"api_key\": \"...\" }} }}\n", .{config.default_provider});
         std.process.exit(1);
     }
@@ -787,7 +794,7 @@ fn runChannelStart(allocator: std.mem.Allocator, args: []const []const u8) !void
         .screenshot_enabled = true,
         .mcp_tools = mcp_tools,
         .agents = config.agents,
-        .fallback_api_key = config.defaultProviderKey(),
+        .fallback_api_key = resolved_api_key,
         .tools_config = config.tools,
         .allowed_paths = config.autonomy.allowed_paths,
         .policy = &sec_policy,
@@ -813,13 +820,7 @@ fn runChannelStart(allocator: std.mem.Allocator, args: []const []const u8) !void
     const obs = noop_obs.observer();
 
     // Create provider vtable — concrete struct must stay alive for the loop.
-    const api_key = try yc.providers.resolveApiKeyFromConfig(
-        allocator,
-        config.default_provider,
-        config.providers,
-        config.allowEnvApiKeys(),
-    );
-    var holder = yc.providers.ProviderHolder.fromConfig(allocator, config.default_provider, api_key);
+    var holder = yc.providers.ProviderHolder.fromConfig(allocator, config.default_provider, resolved_api_key);
     const provider_i: yc.providers.Provider = holder.provider();
 
     std.debug.print("  Tools: {d} loaded\n", .{tools.len});


### PR DESCRIPTION
Add opt-in flag `allow_env_api_keys` to enable environment variable fallback for API keys. Disabled by default - maintains upstream's secure-by-default behavior.

**Breaking changes:** None.

## Why those changes

- CI/CD pipelines often inject API keys via env vars
- Users can opt-in without changing existing configs
- Default (`false`) matches current behavior

## Changes (6 files)

| File | Change |
|------|--------|
| `src/config.zig` | Add `allow_env_api_keys: ?bool` field + `allowEnvApiKeys()` |
| `src/providers/api_key.zig` | Add `allow_env` param to `resolveApiKeyFromConfig()` |
| `src/main.zig` | Use `resolveApiKeyFromConfig()` with flag |
| `src/gateway.zig` | Use `resolveApiKeyFromConfig()` with flag |
| `src/channel_loop.zig` | Use `resolveApiKeyFromConfig()` with flag |
| `src/agent/cli.zig` | Use `resolveApiKeyFromConfig()` with flag |

## Usage

```json
{
  "default_provider": "anthropic",
  "allow_env_api_keys": true
}
```

- `false` (default) → config keys only
- `true` → config keys first, then `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.

## Testing

All tests pass.
