### PR TITLE
fix: use Alpine runtime to match musl-linked binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,10 @@ EOF
 
 RUN chown -R 65534:65534 /nullclaw-data
 
-# ── Stage 3: Production Runtime (Distroless) ─────────────────
-FROM gcr.io/distroless/cc-debian13:nonroot AS release
+# ── Stage 3: Production Runtime (Alpine/musl) ────────────────
+FROM alpine:3.23 AS release
+
+RUN apk add --no-cache ca-certificates tzdata
 
 COPY --from=builder /app/zig-out/bin/nullclaw /usr/local/bin/nullclaw
 COPY --from=permissions /nullclaw-data /nullclaw-data


### PR DESCRIPTION
## Summary

The build stage uses Alpine (musl libc) but the runtime stage used distroless Debian (glibc). A musl-linked binary cannot run on glibc — the dynamic linker path differs (`/lib/ld-musl-x86_64.so.1` vs `/lib64/ld-linux-x86-64.so.2`) and the libc ABI is incompatible.

- Switch runtime from `gcr.io/distroless/cc-debian13:nonroot` to `alpine:3.23`
- Add only `ca-certificates` (TLS) and `tzdata` (timezones)

Fixes #51