### PR TITLE
security: prevent file_write hard-link path-policy bypass

### DIFF
--- a/src/tools/file_write.zig
+++ b/src/tools/file_write.zig
@@ -155,12 +155,14 @@ pub const FileWriteTool = struct {
         var file = tmp_file.?;
         defer file.close();
 
-        if (existing_mode) |mode| {
-            if (mode != 0) {
-                file.chmod(mode) catch |err| {
-                    const msg = try std.fmt.allocPrint(allocator, "Failed to preserve file mode: {}", .{err});
-                    return ToolResult{ .success = false, .output = "", .error_msg = msg };
-                };
+        if (comptime std.fs.has_executable_bit) {
+            if (existing_mode) |mode| {
+                if (mode != 0) {
+                    file.chmod(mode) catch |err| {
+                        const msg = try std.fmt.allocPrint(allocator, "Failed to preserve file mode: {}", .{err});
+                        return ToolResult{ .success = false, .output = "", .error_msg = msg };
+                    };
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- harden `file_write` path enforcement to prevent workspace escape side effects before validation
- replace in-place writes with temp-file + rename to prevent mutating outside files through workspace hard links
- add regression coverage for symlink escapes, hard-link inode mutation, and disallowed absolute-path side effects

## Root cause
`file_write` previously used path-prefix checks and then wrote directly to the destination path. That blocked symlink escapes but still allowed hard-link inode mutation because hard links do not alter path resolution.

## Changes
- pre-validate resolved target/nearest existing ancestor before creating parent directories
- write to a unique temp file in the destination directory and rename into place
- keep post-write resolved-path policy validation
- add hard-link regression test proving outside inode content is unchanged

## Validation
- `zig test src/root.zig -I/usr/local/opt/sqlite/include -L/usr/local/opt/sqlite/lib -lsqlite3 --test-filter "file_write"` -> 21/21 passed

## Residual gaps
- `zig build test --summary all` hangs in this environment at `doctor.test.checkEnvironment finds existing commands`; when terminated, summary reported `2993/2993 tests passed` before signal termination.
- Windows runtime behavior was not validated in this environment.
