### PR TITLE
gateway: run full runtime; keep channel start single-channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ nullclaw agent -m "Hello, nullclaw!"
 # Interactive mode
 nullclaw agent
 
-# Start gateway runtime (gateway + all configured channels/accounts)
+# Start gateway runtime (gateway + all configured channels/accounts + heartbeat + scheduler)
 nullclaw gateway                # default: 127.0.0.1:3000
 nullclaw gateway --port 8080    # custom port
 
-# Start full autonomous runtime (adds scheduler + heartbeat)
+# Alias (same runtime path)
 nullclaw daemon
 
 # Check status


### PR DESCRIPTION
## Summary
- keep `nullclaw channel start` semantics single-channel:
  - `nullclaw channel start <channel>` is unchanged
  - `nullclaw channel start` (no arg) keeps fallback order (Telegram -> Signal -> other configured)
- route `nullclaw gateway` through the daemon runtime path (`yc.daemon.run(...)`)
- explicitly: **`nullclaw gateway` and `nullclaw daemon` currently start the same runtime**:
  - gateway server
  - all configured channels and all configured accounts
  - scheduler
  - heartbeat
- `channel start --all` now points users to `nullclaw gateway`
- help/README text updated accordingly

## Why
- align behavior with OpenClaw expectations for gateway startup
- avoid misleading all-channels behavior under `channel start`

## Validation
- `zig fmt src/main.zig`
- `zig build test --summary all` (3391/3392 passed, 1 skipped)
