### PR TITLE
feat(telegram): add document/file message handling with media group s…

### DIFF
--- a/src/channels/telegram.zig
+++ b/src/channels/telegram.zig
@@ -1002,10 +1002,8 @@ pub const TelegramChannel = struct {
         var media_group_ids: std.ArrayListUnmanaged(?[]const u8) = .empty;
         errdefer {
             for (messages.items) |msg| {
-                allocator.free(msg.id);
-                allocator.free(msg.sender);
-                allocator.free(msg.content);
-                if (msg.first_name) |fn_| allocator.free(fn_);
+                var tmp = msg;
+                tmp.deinit(allocator);
             }
             messages.deinit(allocator);
             for (media_group_ids.items) |mg| if (mg) |s| allocator.free(s);
@@ -1366,10 +1364,8 @@ pub const TelegramChannel = struct {
         media_group_ids.append(allocator, mg_dup) catch {
             // Rollback to keep messages and media_group_ids synchronized
             const popped = messages.pop().?;
-            allocator.free(popped.id);
-            allocator.free(popped.sender);
-            allocator.free(popped.content);
-            if (popped.first_name) |f| allocator.free(f);
+            var tmp = popped;
+            tmp.deinit(allocator);
             if (mg_dup) |m| allocator.free(m);
             return;
         };


### PR DESCRIPTION
Add support for receiving documents (PDF, DOCX, CSV, etc.) via Telegram. Files are downloaded and passed to the agent as [FILE:path] markers.

Multi-file uploads (media groups) are buffered across poll cycles with a 3-second deadline instead of blocking the event loop. Text messages are never delayed.

Extracted processUpdate() and mergeMediaGroups() helpers to eliminate duplication and improve memory safety. Hardened all parallel array operations with rollback-on-OOM to prevent desync panics. Added shutdown cleanup in vtableStop.