### PR TITLE
feat(audit): add AuditObserver for full LLM reasoning flow logging

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -59,7 +59,10 @@
       "backend": "auto"
     },
     "audit": {
-      "enabled": true
+      "enabled": true,
+      "log_requests": true,
+      "log_full_content": false,
+      "content_preview_len": 200
     }
   }
 }

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -1044,6 +1044,15 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                     if (aud.object.get("sign_events")) |v| {
                         if (v == .bool) self.security.audit.sign_events = v.bool;
                     }
+                    if (aud.object.get("log_requests")) |v| {
+                        if (v == .bool) self.security.audit.log_requests = v.bool;
+                    }
+                    if (aud.object.get("log_full_content")) |v| {
+                        if (v == .bool) self.security.audit.log_full_content = v.bool;
+                    }
+                    if (aud.object.get("content_preview_len")) |v| {
+                        if (v == .integer and v.integer >= 0) self.security.audit.content_preview_len = @intCast(v.integer);
+                    }
                 }
             }
         }

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -578,6 +578,9 @@ pub const AuditConfig = struct {
     retention_days: u32 = 90,
     max_size_mb: u32 = 100,
     sign_events: bool = false,
+    log_requests: bool = true,
+    log_full_content: bool = false,
+    content_preview_len: u32 = 200,
 };
 
 pub const SecurityConfig = struct {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -611,7 +611,7 @@ fn inboundDispatcherThread(
             indicator_mode,
         );
 
-        const reply = runtime.session_mgr.processMessage(session_key, msg.content) catch |err| {
+        const reply = runtime.session_mgr.processMessageWithMeta(session_key, msg.content, msg.channel, msg.sender_id, msg.chat_id) catch |err| {
             log.warn("inbound dispatch process failed: {}", .{err});
 
             // Send user-visible error reply back to the originating channel


### PR DESCRIPTION
## Summary

Adds structured JSONL audit logging that captures the complete LLM reasoning lifecycle per request. An admin can now trace: what came in, what the LLM was asked, what tools it called, and what went back to the user.

- New `AuditObserver` implementing the `Observer` vtable, writing JSONL enriched with per-request session/channel context
- 5 new `ObserverEvent` variants: `message_received`, `message_sent`, `session_created`, `session_evicted`, `context_compacted`
- `processMessageWithMeta()` on `SessionManager` for passing channel metadata (channel, sender_id, chat_id)
- Wired into `MultiObserver` chain in daemon, channel_loop, and standalone Signal/Telegram paths
- `context_compacted` events emitted at all 3 compaction sites in agent turn loop
- JSON escaping for all control characters (RFC 8259) and UTF-8-safe content truncation

## Configuration

Three new fields in `security.audit`:

```json
"security": {
  "audit": {
    "enabled": true,
    "log_requests": true,
    "log_full_content": false,
    "content_preview_len": 200
  }
}
```

| Field | Default | Description |
|-------|---------|-------------|
| `log_requests` | `true` | Enable LLM reasoning flow audit logging |
| `log_full_content` | `false` | Log full message content instead of truncated preview |
| `content_preview_len` | `200` | Max chars for content previews (0 = no limit) |

**Impact on existing configs:** None — all new fields have backwards-compatible defaults. Existing `security.audit` configs continue to work unchanged. Setting `log_requests: true` (the default) activates audit logging automatically when `audit.enabled` is also true.

**Audit log location:** Uses existing `audit.log_path` (default: `audit.log` in working directory).

## Audit event flow

Each request produces a sequence of JSONL entries:

```
message_received  → inbound user message with channel/sender metadata
llm_request       → request sent to LLM provider (provider, model, message count)
llm_response      → response received (duration, success, error if any)
tool_call         → tool invocation (tool name, duration, success) — 0 or more
context_compacted → history auto-compacted (messages before/after) — if triggered
message_sent      → outbound response with content preview
```

Session lifecycle events: `session_created`, `session_evicted`.

## Thread safety

`AuditObserver` uses a per-thread context map (`AutoHashMap(Thread.Id, AuditContext)`) so concurrent sessions on different threads don't corrupt each other's audit metadata. The context is set before `agent.turn()` and cleared after, per-thread.

## Files changed

| File | Change |
|------|--------|
| `src/observability.zig` | New event variants, `AuditObserver` struct, tests |
| `src/config_types.zig` | 3 new `AuditConfig` fields |
| `src/config_parse.zig` | Parse new fields (with negative value guard) |
| `src/session.zig` | `processMessageWithMeta`, emit audit events, set/clear context |
| `src/agent/root.zig` | Emit `context_compacted` at 3 compaction sites |
| `src/channel_loop.zig` | Wire `AuditObserver` into `MultiObserver`, update `processMessage` calls |
| `src/daemon.zig` | Use `processMessageWithMeta` with channel metadata |
| `src/main.zig` | Wire `AuditObserver` in Signal/Telegram standalone paths |
| `config.example.json` | Add new audit fields |

## Test plan

- [x] `zig build test` — all existing + 8 new tests pass (AuditObserver name, setContext/clearContext, truncatePreview with UTF-8, jsonEscape with control chars, all event types, error messages, Observer interface, ObserverEvent variants)
- [x] `zig build` — clean compilation, no warnings
- [x] Live-tested with `openrouter/upstage/solar-pro-3:free` — agent sends request, gets response, returns to user
- [x] Verified audit JSONL file creation and content validity — all 9 event types produce parseable JSON with correct fields
- [x] Verified content preview truncation (default 200 chars)
- [x] Verified JSON escaping handles quotes, backslashes, newlines, and control characters (0x00-0x1F)
- [x] Verified UTF-8 truncation doesn't split multi-byte codepoints
- [x] Verified backwards compatibility — existing configs without new fields work unchanged
- [ ] Manual: configure `log_requests: true` on a channel (Telegram/Signal/daemon), send messages, verify `audit.log` contains full flow entries
- [ ] Manual: test `log_full_content: true` logs untruncated content
- [ ] Manual: test log rotation still works with audit entries