### PR TITLE
fix(docker): use bare IPv6 address :: instead of bracketed [::]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cat > /nullclaw-data/.nullclaw/config.json << 'EOF'
   "default_temperature": 0.7,
   "gateway": {
     "port": 3000,
-    "host": "[::]",
+    "host": "::",
     "allow_public_bind": true
   }
 }
@@ -51,7 +51,7 @@ ENV NULLCLAW_GATEWAY_PORT=3000
 WORKDIR /nullclaw-data
 EXPOSE 3000
 ENTRYPOINT ["nullclaw"]
-CMD ["gateway", "--port", "3000", "--host", "[::]"]
+CMD ["gateway", "--port", "3000", "--host", "::"]
 
 # Optional autonomous mode (explicit opt-in):
 #   docker build --target release-root -t nullclaw:root .


### PR DESCRIPTION
## Summary
- Replace `[::]` with `::` in both the default config and CMD
- Zig's `std.net.Address.resolveIp` rejects bracketed IPv6 notation, causing containers to crash with `InvalidIPAddressFormat` on startup

## Test plan
- [ ] `docker compose --profile gateway up --build` starts without error
- [ ] `docker compose --profile agent up --build` starts without error
- [ ] Gateway responds on `http://localhost:8080/health`

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)