### PR TITLE
fix: wire diagnostics.backend config to observer instantiation

### DIFF
--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -60,9 +60,11 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         }
     }
 
-    // Create a noop observer
-    var noop = observability.NoopObserver{};
-    const obs = noop.observer();
+    // Create observer from diagnostics config (falls back to noop)
+    var fallback_noop = observability.NoopObserver{};
+    const obs_handle = observability.createFromConfig(allocator, cfg.diagnostics);
+    defer if (obs_handle) |h| h.deinit();
+    const obs = if (obs_handle) |h| h.observer() else fallback_noop.observer();
 
     // Record agent start
     const start_event = ObserverEvent{ .agent_start = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -815,9 +815,11 @@ fn runChannelStart(allocator: std.mem.Allocator, args: []const []const u8) !void
         } else |_| {}
     }
 
-    // Create noop observer
-    var noop_obs = yc.observability.NoopObserver{};
-    const obs = noop_obs.observer();
+    // Observer from diagnostics config (falls back to noop)
+    var fallback_noop = yc.observability.NoopObserver{};
+    const obs_handle = yc.observability.createFromConfig(allocator, config.diagnostics);
+    defer if (obs_handle) |h| h.deinit();
+    const obs = if (obs_handle) |h| h.observer() else fallback_noop.observer();
 
     // Create provider vtable — concrete struct must stay alive for the loop.
     var holder = yc.providers.ProviderHolder.fromConfig(allocator, config.default_provider, resolved_api_key);


### PR DESCRIPTION
## Summary

The `diagnostics.backend` config key is parsed and stored in `DiagnosticsConfig`, but every runtime entry point (`agent`, `daemon`, `gateway`, `channel start`) hardcodes `NoopObserver`, making the setting a no-op. Setting `"diagnostics": {"backend": "log"}` in `config.json` currently produces no diagnostic output.

This PR:

- **Adds `createFromConfig()` factory** in `observability.zig` that returns an `ObserverHandle` owning the concrete observer, dispatching on the backend string (`"log"`, `"verbose"`, `"otel"`/`"otlp"`, or noop fallback)
- **Replaces all 4 hardcoded `NoopObserver` sites** (`agent/cli.zig`, `channel_loop.zig`, `gateway.zig`, `main.zig`) with config-driven observer creation
- **Rewrites `LogObserver` to use direct stderr writes** instead of `std.log.info`, which is compiled out in `ReleaseSmall` builds (the optimization level used by the Docker/GHCR image)
- **Adds `ObserverHandle`** for uniform lifetime management across zero-size (`noop`/`log`/`verbose`) and heap-owning (`otel`) backends

### Before
```
# config.json has "diagnostics": {"backend": "log"}
# journalctl shows NO diagnostic output — only startup messages
```

### After
```
# LogObserver emits to stderr (captured by journald):
obs: agent.start provider=openrouter model=openrouter/free
obs: llm.request provider=openrouter model=openrouter/free messages=3
obs: llm.response provider=openrouter model=openrouter/free duration_ms=1200 success=true
obs: tool.call tool=shell duration_ms=50 success=true
obs: turn.complete
obs: channel.message channel=telegram direction=outbound
```

## Files changed

| File | Change |
|------|--------|
| `src/observability.zig` | Rewrite `LogObserver` (stderr), add `ObserverHandle`, add `createFromConfig()` factory, add tests |
| `src/agent/cli.zig` | Replace hardcoded `NoopObserver` with `createFromConfig(cfg.diagnostics)` |
| `src/channel_loop.zig` | Replace hardcoded `NoopObserver`, update `ChannelRuntime` field type |
| `src/gateway.zig` | Replace hardcoded `NoopObserver`, hoist handle for lifetime |
| `src/main.zig` | Replace hardcoded `NoopObserver` in `runChannelStart` |

## Test plan

- [ ] Existing `observability.zig` tests pass (NoopObserver, LogObserver, VerboseObserver, OtelObserver, MultiObserver, FileObserver)
- [ ] New `createFromConfig` tests pass for all backend values
- [ ] `zig build test` passes
- [ ] Deploy with `"diagnostics": {"backend": "log"}` and verify `obs:` lines appear in journald output
- [ ] Deploy with `"diagnostics": {"backend": "none"}` and verify no diagnostic output (regression check)