### PR TITLE
fix(providers): respect base_url and add native_tools toggle for custom providers

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -153,6 +153,15 @@ pub const Config = struct {
         return null;
     }
 
+    /// Look up whether a provider supports native tool calls.
+    /// Returns true (default) if provider is not in the list.
+    pub fn getProviderNativeTools(self: *const Config, name: []const u8) bool {
+        for (self.providers) |e| {
+            if (std.mem.eql(u8, e.name, name)) return e.native_tools;
+        }
+        return true;
+    }
+
     /// Sync flat convenience fields from the nested sub-configs.
     pub fn syncFlatFields(self: *Config) void {
         self.temperature = self.default_temperature;

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -1084,6 +1084,9 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                                 if (au == .string) pe.base_url = try self.allocator.dupe(u8, au.string);
                             }
                         }
+                        if (val.object.get("native_tools")) |nt| {
+                            if (nt == .bool) pe.native_tools = nt.bool;
+                        }
                         try prov_list.append(self.allocator, pe);
                     }
                     self.providers = try prov_list.toOwnedSlice(self.allocator);

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -31,6 +31,9 @@ pub const ProviderEntry = struct {
     name: []const u8,
     api_key: ?[]const u8 = null,
     base_url: ?[]const u8 = null,
+    /// Whether this provider supports native OpenAI-style tool_calls.
+    /// Set to false to use XML tool format via system prompt instead.
+    native_tools: bool = true,
 };
 
 // ── Audio media config (tools.media.audio) ─────────────────────

--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -48,6 +48,9 @@ pub const OpenAiCompatibleProvider = struct {
     /// user message as "[System: …]\n\n…", then skip system-role messages.
     /// Required by providers like MiniMax that reject the system role.
     merge_system_into_user: bool = false,
+    /// Whether this provider supports native OpenAI-style tool_calls.
+    /// When false, the agent uses XML tool format via system prompt.
+    native_tools: bool = true,
     allocator: std.mem.Allocator,
 
     pub fn init(
@@ -536,8 +539,9 @@ pub const OpenAiCompatibleProvider = struct {
         return parseNativeResponse(allocator, resp_body);
     }
 
-    fn supportsNativeToolsImpl(_: *anyopaque) bool {
-        return true;
+    fn supportsNativeToolsImpl(ptr: *anyopaque) bool {
+        const self: *OpenAiCompatibleProvider = @ptrCast(@alignCast(ptr));
+        return self.native_tools;
     }
 
     fn supportsVisionImpl(_: *anyopaque) bool {

--- a/src/providers/factory.zig
+++ b/src/providers/factory.zig
@@ -264,6 +264,7 @@ pub const ProviderHolder = union(enum) {
         provider_name: []const u8,
         api_key: ?[]const u8,
         base_url: ?[]const u8,
+        native_tools: bool,
     ) ProviderHolder {
         const kind = classifyProvider(provider_name);
         return switch (kind) {
@@ -303,6 +304,9 @@ pub const ProviderHolder = union(enum) {
                     if (c.merge_system_into_user) prov.merge_system_into_user = true;
                 }
 
+                // Apply config-level native_tools override.
+                prov.native_tools = native_tools;
+
                 break :blk .{ .compatible = prov };
             },
             .claude_cli_provider => if (claude_cli.ClaudeCliProvider.init(allocator, null)) |p|
@@ -316,16 +320,17 @@ pub const ProviderHolder = union(enum) {
             .openai_codex_provider => .{ .openai_codex = openai_codex.OpenAiCodexProvider.init(allocator, null) },
             // Unknown provider: if base_url is configured, treat as OpenAI-compatible;
             // otherwise fall back to OpenRouter.
-            .unknown => if (base_url) |url|
-                .{ .compatible = compatible.OpenAiCompatibleProvider.init(
+            .unknown => if (base_url) |url| blk: {
+                var prov = compatible.OpenAiCompatibleProvider.init(
                     allocator,
                     provider_name,
                     url,
                     api_key,
                     .bearer,
-                ) }
-            else
-                .{ .openrouter = openrouter.OpenRouterProvider.init(allocator, api_key) },
+                );
+                prov.native_tools = native_tools;
+                break :blk .{ .compatible = prov };
+            } else .{ .openrouter = openrouter.OpenRouterProvider.init(allocator, api_key) },
         };
     }
 };
@@ -490,7 +495,7 @@ test "findCompatProvider returns correct flags" {
 
 test "fromConfig applies no_responses_fallback flag" {
     const alloc = std.testing.allocator;
-    var h = ProviderHolder.fromConfig(alloc, "glm", "key", null);
+    var h = ProviderHolder.fromConfig(alloc, "glm", "key", null, true);
     defer h.deinit();
     try std.testing.expect(h == .compatible);
     try std.testing.expect(!h.compatible.supports_responses_fallback);
@@ -498,7 +503,7 @@ test "fromConfig applies no_responses_fallback flag" {
 
 test "fromConfig applies merge_system_into_user flag" {
     const alloc = std.testing.allocator;
-    var h = ProviderHolder.fromConfig(alloc, "minimax", "key", null);
+    var h = ProviderHolder.fromConfig(alloc, "minimax", "key", null, true);
     defer h.deinit();
     try std.testing.expect(h == .compatible);
     try std.testing.expect(h.compatible.merge_system_into_user);
@@ -560,39 +565,39 @@ test "ProviderHolder tagged union has all expected fields" {
 test "ProviderHolder.fromConfig routes to correct variant" {
     const alloc = std.testing.allocator;
     // anthropic
-    var h1 = ProviderHolder.fromConfig(alloc, "anthropic", "sk-test", null);
+    var h1 = ProviderHolder.fromConfig(alloc, "anthropic", "sk-test", null, true);
     defer h1.deinit();
     try std.testing.expect(h1 == .anthropic);
     // openai
-    var h2 = ProviderHolder.fromConfig(alloc, "openai", "sk-test", null);
+    var h2 = ProviderHolder.fromConfig(alloc, "openai", "sk-test", null, true);
     defer h2.deinit();
     try std.testing.expect(h2 == .openai);
     // gemini
-    var h3 = ProviderHolder.fromConfig(alloc, "gemini", "key", null);
+    var h3 = ProviderHolder.fromConfig(alloc, "gemini", "key", null, true);
     defer h3.deinit();
     try std.testing.expect(h3 == .gemini);
     // ollama
-    var h4 = ProviderHolder.fromConfig(alloc, "ollama", null, null);
+    var h4 = ProviderHolder.fromConfig(alloc, "ollama", null, null, true);
     defer h4.deinit();
     try std.testing.expect(h4 == .ollama);
     // openrouter
-    var h5 = ProviderHolder.fromConfig(alloc, "openrouter", "sk-or-test", null);
+    var h5 = ProviderHolder.fromConfig(alloc, "openrouter", "sk-or-test", null, true);
     defer h5.deinit();
     try std.testing.expect(h5 == .openrouter);
     // compatible (groq)
-    var h6 = ProviderHolder.fromConfig(alloc, "groq", "gsk_test", null);
+    var h6 = ProviderHolder.fromConfig(alloc, "groq", "gsk_test", null, true);
     defer h6.deinit();
     try std.testing.expect(h6 == .compatible);
     // openai-codex
-    var h7 = ProviderHolder.fromConfig(alloc, "openai-codex", null, null);
+    var h7 = ProviderHolder.fromConfig(alloc, "openai-codex", null, null, true);
     defer h7.deinit();
     try std.testing.expect(h7 == .openai_codex);
     // unknown falls back to openrouter
-    var h8 = ProviderHolder.fromConfig(alloc, "nonexistent", "key", null);
+    var h8 = ProviderHolder.fromConfig(alloc, "nonexistent", "key", null, true);
     defer h8.deinit();
     try std.testing.expect(h8 == .openrouter);
     // anthropic-custom prefix
-    var h9 = ProviderHolder.fromConfig(alloc, "anthropic-custom:https://my-api.example.com", "sk-test", null);
+    var h9 = ProviderHolder.fromConfig(alloc, "anthropic-custom:https://my-api.example.com", "sk-test", null, true);
     defer h9.deinit();
     try std.testing.expect(h9 == .anthropic);
 }

--- a/src/providers/runtime_bundle.zig
+++ b/src/providers/runtime_bundle.zig
@@ -43,6 +43,7 @@ pub const RuntimeProviderBundle = struct {
             cfg.default_provider,
             bundle.primary_key,
             cfg.getProviderBaseUrl(cfg.default_provider),
+            cfg.getProviderNativeTools(cfg.default_provider),
         );
 
         const allows_key_rotation = factory.classifyProvider(cfg.default_provider) != .openai_codex_provider;
@@ -86,6 +87,7 @@ pub const RuntimeProviderBundle = struct {
                     provider_name,
                     fb_key,
                     cfg.getProviderBaseUrl(provider_name),
+                    cfg.getProviderNativeTools(provider_name),
                 );
                 bundle.extra_holders_initialized = extra_i + 1;
                 bundle.reliable_entries.?[extra_i] = .{
@@ -110,6 +112,7 @@ pub const RuntimeProviderBundle = struct {
                         cfg.default_provider,
                         key_copy,
                         cfg.getProviderBaseUrl(cfg.default_provider),
+                        cfg.getProviderNativeTools(cfg.default_provider),
                     );
                     bundle.extra_holders_initialized = extra_i + 1;
                     bundle.reliable_entries.?[extra_i] = .{


### PR DESCRIPTION
**Problem**

1. Unknown providers ignore base_url: Providers not in the built-in list (e.g. "local") silently fall back to OpenRouter, discarding the configured base_url.

2. Native tool calls break local proxies: The compatible provider always advertises native OpenAI tool_calls support, but nullclaw stores tool history as XML. This mismatch causes AllProvidersFailed errors when the proxy enforces strict OpenAI tool protocol.

**Changes**

1. factory.fromConfig: Unknown providers with base_url now create an OpenAiCompatibleProvider instead of falling back to OpenRouter. Config base_url also overrides built-in URL table for known compatible providers.

2. native_tools config flag: New per-provider boolean (default true). When false, the agent uses XML tool format via system prompt instead of structured tool_calls in the API request.

**Config example**
```
"local": {
    "base_url": "http://127.0.0.1:8045/v1",
    "api_key": "...",
    "native_tools": false
}
```