### PR TITLE
fix/claude_cli: --verbose is required when output-format=stream-json

### DIFF
--- a/src/providers/claude_cli.zig
+++ b/src/providers/claude_cli.zig
@@ -105,6 +105,7 @@ pub const ClaudeCliProvider = struct {
             "stream-json",
             "--model",
             model,
+            "--verbose",
         };
 
         var child = std.process.Child.init(&argv, allocator);


### PR DESCRIPTION
In Claude-cli 2.1.59 (and possibly as early as 2.1.37 or even earlier), `--verbose` has become required when used with `--output-format stream-json`.

Reproduce:
```
#claude --version
#2.1.59 (Claude Code)

claude -p "hi" --output-format stream-json --model claude-opus-4-6
Error: When using --print, --output-format=stream-json requires --verbose
```