### PR TITLE
fix(update): curl error.StdoutStreamTooLong in self-update

### DIFF
--- a/src/update.zig
+++ b/src/update.zig
@@ -198,7 +198,7 @@ pub fn getLatestRelease(allocator: std.mem.Allocator) !ReleaseInfo {
     const result = std.process.Child.run(.{
         .allocator = allocator,
         .argv = &.{ "curl", "-sf", "--max-time", "30", url },
-        .max_output_bytes = 1024 * 1024,
+        .max_output_bytes = 10 * 1024 * 1024,
     }) catch |err| {
         log.err("curl failed: {}", .{err});
         return error.CurlFailed;


### PR DESCRIPTION
Current hardcoded `max_output_bytes` in Child.run  is 50KB, which is too little for downloading self-update binary. Let's explicitly set it at 10MB at the moment.

It fixes self-update issue 
```
nullclaw update
Current version: 2026.2.25
Latest version:  v2026.2.26
...
Download and install v2026.2.26? [y/N] y
Downloading nullclaw-linux-aarch64.bin...
error(update): curl failed: error.StdoutStreamTooLong
error(update): Download failed: error.CurlFailed
```