### PR TITLE
build: fix illegal-instruction startup on Windows/Linux x86_64 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,13 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x86_64
+            zig_target: x86_64-linux-musl
           - os: macos-latest
             target: macos-aarch64
+            zig_target: aarch64-macos
           - os: windows-latest
             target: windows-x86_64
+            zig_target: x86_64-windows
 
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +46,7 @@ jobs:
         run: zig build test --summary all 2>&1 | tee test-output.txt
 
       - name: Build ReleaseSmall
-        run: zig build -Doptimize=ReleaseSmall
+        run: zig build -Dtarget=${{ matrix.zig_target }} -Doptimize=ReleaseSmall
 
       - name: Cross-compile linux-aarch64 (Termux/ARM)
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x86_64
-            zig_target: ""
+            zig_target: x86_64-linux-musl
             ext: ""
           - os: ubuntu-latest
             target: linux-aarch64
@@ -28,7 +28,7 @@ jobs:
             ext: ""
           - os: macos-latest
             target: macos-aarch64
-            zig_target: ""
+            zig_target: aarch64-macos
             ext: ""
           - os: macos-latest
             target: macos-x86_64
@@ -36,7 +36,7 @@ jobs:
             ext: ""
           - os: windows-latest
             target: windows-x86_64
-            zig_target: ""
+            zig_target: x86_64-windows
             ext: ".exe"
           - os: windows-latest
             target: windows-aarch64


### PR DESCRIPTION
## Summary
- pin release build targets to explicit portable baselines instead of host-native CPU defaults
- update release workflow matrix to use:
  - `x86_64-linux-musl` for `linux-x86_64`
  - `x86_64-windows` for `windows-x86_64`
  - `aarch64-macos` for `macos-aarch64`
- update CI ReleaseSmall build to use explicit per-matrix targets
- update Docker build stage to map `TARGETARCH` (`amd64`/`arm64`) to explicit Zig targets and build with `-Dtarget=...`

## Root cause
`v2026.2.26` release artifacts for x86_64 were effectively built with host-native CPU features, which introduced AVX/`ymm` instructions into distributed binaries. On older/unsupported CPUs this results in `illegal instruction` at startup.

## Validation
- `zig build test --summary all` (4580/4581 passed, 1 skipped)
- `zig build -Dtarget=x86_64-windows -Doptimize=ReleaseSmall`
- `zig build -Dtarget=x86_64-linux-musl -Doptimize=ReleaseSmall`
- `zig build -Dtarget=aarch64-macos -Doptimize=ReleaseSmall`
- disassembly check: release v2026.2.26 x86_64 artifacts contain AVX/`ymm`; newly built targeted artifacts do not

Closes #155
Closes #156
Closes #174
