### PR TITLE
feat: add Telnyx as AI provider + voice transcription

### DIFF
--- a/src/providers/factory.zig
+++ b/src/providers/factory.zig
@@ -604,6 +604,11 @@ test "ProviderHolder.fromConfig routes to correct variant" {
     var h6 = ProviderHolder.fromConfig(alloc, "groq", "gsk_test", null, true);
     defer h6.deinit();
     try std.testing.expect(h6 == .compatible);
+    // compatible (telnyx from built-in table URL)
+    var h6b = ProviderHolder.fromConfig(alloc, "telnyx", "test-key", null, true);
+    defer h6b.deinit();
+    try std.testing.expect(h6b == .compatible);
+    try std.testing.expectEqualStrings("https://api.telnyx.com/v2/ai", h6b.compatible.base_url);
     // openai-codex
     var h7 = ProviderHolder.fromConfig(alloc, "openai-codex", null, null, true);
     defer h7.deinit();


### PR DESCRIPTION
## Summary

This PR adds Telnyx as an OpenAI-compatible AI provider and implements voice transcription support via Telnyx's Whisper-compatible STT API.

## Changes

### 1. Telnyx as OpenAI-compatible provider (`factory.zig`)
- Added Telnyx to the `compat_providers` array in the "Major Cloud Providers" section
- URL: `https://api.telnyx.com/v2/ai`
- Display name: "Telnyx"

### 2. Telnyx voice transcription (`voice.zig`)
- Added `TelnyxTranscriber` struct implementing the `Transcriber` vtable
- Endpoint: `https://api.telnyx.com/v2/ai/audio/transcriptions`
- Uses Bearer token authentication (TELNYX_API_KEY)
- Model: "whisper-1" (Telnyx default)
- Updated `resolveTranscriptionEndpoint` to handle "telnyx" provider

### 3. Tests
- `classifyProvider("telnyx")` returns `.compatible_provider`
- `compatibleProviderUrl("telnyx")` returns correct URL
- `compatibleProviderDisplayName("telnyx")` returns "Telnyx"
- `TelnyxTranscriber` vtable wiring test
- `resolveTranscriptionEndpoint("telnyx", null)` returns correct endpoint

## Why Telnyx?

Telnyx provides OpenAI-compatible APIs for:
- **LLM inference** - Run various AI models via their AI API
- **Speech-to-Text (STT)** - Whisper-compatible transcription
- **Text-to-Speech (TTS)** - Voice synthesis

Telnyx is particularly relevant for **voice AI agents** since it combines **telephony + AI inference** in a single platform. This makes it a natural choice for building voice-based AI assistants that need to handle phone calls, transcribe audio, and generate responses.

## Relevant Links

- [Telnyx AI Documentation](https://developers.telnyx.com/docs/ai/overview)
- [ClawdTalk - Voice AI with Telnyx](https://clawdtalk.com)

## Testing

All tests pass:
```
zig build test --summary all
Build Summary: 9/9 steps succeeded; 4582/4583 tests passed; 1 skipped
```

The build compiles cleanly with Zig 0.15.2.