### PR TITLE
fix: use HTTP PUT for Matrix send and typing endpoints

### DIFF
--- a/src/channels/matrix.zig
+++ b/src/channels/matrix.zig
@@ -8,7 +8,8 @@ const log = std.log.scoped(.matrix);
 /// Matrix channel via Client-Server API.
 ///
 /// - Inbound: long-poll /_matrix/client/v3/sync
-/// - Outbound: POST /_matrix/client/v3/rooms/{roomId}/send/m.room.message/{txnId}
+/// - Outbound: PUT /_matrix/client/v3/rooms/{roomId}/send/m.room.message/{txnId}
+/// - Typing: PUT /_matrix/client/v3/rooms/{roomId}/typing/{userId}
 pub const MatrixChannel = struct {
     allocator: std.mem.Allocator,
     account_id: []const u8 = "default",

--- a/src/http_util.zig
+++ b/src/http_util.zig
@@ -306,6 +306,10 @@ test "curlPost builds correct argv structure" {
     try std.testing.expect(true);
 }
 
+test "curlPut compiles and is callable" {
+    try std.testing.expect(true);
+}
+
 test "curlGet compiles and is callable" {
     try std.testing.expect(true);
 }


### PR DESCRIPTION
## Summary
- Matrix Client-Server API requires PUT for `/send/{txnId}` and `/typing/{userId}` endpoints, but we were using POST, causing `MatrixSendFailed` errors
- Extracted `curlRequestWithProxy` helper from `curlPostWithProxy` to support parameterized HTTP methods, added `curlPut` wrapper
- Changed both `curlPost` calls in `matrix.zig` (message send + typing indicator) to `curlPut`

## Test plan
- [x] `zig build` compiles cleanly
- [ ] Send a message via Matrix channel and confirm no `MatrixSendFailed` error
- [ ] Verify typing indicator works without errors