### PR TITLE
Fireworks.ai max_tokens fix. Also fixed the check.

### DIFF
--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -67,6 +67,9 @@ pub const OpenAiCompatibleProvider = struct {
     /// Whether this provider supports native OpenAI-style tool_calls.
     /// When false, the agent uses XML tool format via system prompt.
     native_tools: bool = true,
+    /// When set, cap max_tokens in non-streaming requests to this value.
+    /// Some providers (e.g. Fireworks) reject large max_tokens without streaming.
+    max_tokens_non_streaming: ?u32 = null,
     /// Optional User-Agent header for HTTP requests.
     /// When set, requests will include "User-Agent: {value}" header.
     user_agent: ?[]const u8 = null,
@@ -157,6 +160,16 @@ pub const OpenAiCompatibleProvider = struct {
             }
         }
         return model;
+    }
+
+    fn capNonStreamingMaxTokens(self: OpenAiCompatibleProvider, request: ChatRequest) ChatRequest {
+        var capped_request = request;
+        if (self.max_tokens_non_streaming) |cap| {
+            if (capped_request.max_tokens) |mt| {
+                if (mt > cap) capped_request.max_tokens = cap;
+            }
+        }
+        return capped_request;
     }
 
     /// Build a Responses API request JSON body.
@@ -575,7 +588,8 @@ pub const OpenAiCompatibleProvider = struct {
         const url = try self.chatCompletionsUrl(allocator);
         defer allocator.free(url);
 
-        const body = try buildChatRequestBody(allocator, request, effective_model, temperature, self.merge_system_into_user);
+        const capped_request = self.capNonStreamingMaxTokens(request);
+        const body = try buildChatRequestBody(allocator, capped_request, effective_model, temperature, self.merge_system_into_user);
         defer allocator.free(body);
 
         const auth = try self.authHeaderValue(allocator);
@@ -943,6 +957,36 @@ test "supportsNativeTools returns true for compatible" {
     var p = OpenAiCompatibleProvider.init(std.testing.allocator, "test", "https://example.com", "key", .bearer, null);
     const prov = p.provider();
     try std.testing.expect(prov.supportsNativeTools());
+}
+
+test "capNonStreamingMaxTokens caps request max_tokens above provider limit" {
+    const msgs = [_]root.ChatMessage{root.ChatMessage.user("hello")};
+    const req = root.ChatRequest{ .messages = &msgs, .model = "test-model", .max_tokens = 8000 };
+    var p = OpenAiCompatibleProvider.init(std.testing.allocator, "fireworks", "https://api.fireworks.ai/inference/v1", "key", .bearer, null);
+    p.max_tokens_non_streaming = 4096;
+
+    const capped = p.capNonStreamingMaxTokens(req);
+    try std.testing.expectEqual(@as(?u32, 4096), capped.max_tokens);
+    try std.testing.expectEqual(@as(?u32, 8000), req.max_tokens);
+}
+
+test "capNonStreamingMaxTokens keeps request max_tokens when already below limit" {
+    const msgs = [_]root.ChatMessage{root.ChatMessage.user("hello")};
+    const req = root.ChatRequest{ .messages = &msgs, .model = "test-model", .max_tokens = 1024 };
+    var p = OpenAiCompatibleProvider.init(std.testing.allocator, "fireworks", "https://api.fireworks.ai/inference/v1", "key", .bearer, null);
+    p.max_tokens_non_streaming = 4096;
+
+    const capped = p.capNonStreamingMaxTokens(req);
+    try std.testing.expectEqual(@as(?u32, 1024), capped.max_tokens);
+}
+
+test "capNonStreamingMaxTokens leaves request unchanged when limit is unset" {
+    const msgs = [_]root.ChatMessage{root.ChatMessage.user("hello")};
+    const req = root.ChatRequest{ .messages = &msgs, .model = "test-model", .max_tokens = 8000 };
+    const p = OpenAiCompatibleProvider.init(std.testing.allocator, "generic", "https://example.com/v1", "key", .bearer, null);
+
+    const capped = p.capNonStreamingMaxTokens(req);
+    try std.testing.expectEqual(@as(?u32, 8000), capped.max_tokens);
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/providers/factory.zig
+++ b/src/providers/factory.zig
@@ -41,6 +41,9 @@ const CompatProvider = struct {
     auth_style: compatible.AuthStyle = .bearer,
     /// Whether this provider supports native OpenAI-style tool_calls.
     native_tools: bool = true,
+    /// When set, cap max_tokens in non-streaming requests to this value.
+    /// Fireworks rejects max_tokens > 4096 when stream=false.
+    max_tokens_non_streaming: ?u32 = null,
 };
 
 const compat_providers = [_]CompatProvider{
@@ -61,8 +64,8 @@ const compat_providers = [_]CompatProvider{
     .{ .name = "vercel-ai", .url = "https://ai-gateway.vercel.sh/v1", .display = "Vercel AI Gateway" },
     .{ .name = "together", .url = "https://api.together.xyz", .display = "Together AI" },
     .{ .name = "together-ai", .url = "https://api.together.xyz", .display = "Together AI" },
-    .{ .name = "fireworks", .url = "https://api.fireworks.ai/inference/v1", .display = "Fireworks AI" },
-    .{ .name = "fireworks-ai", .url = "https://api.fireworks.ai/inference/v1", .display = "Fireworks AI" },
+    .{ .name = "fireworks", .url = "https://api.fireworks.ai/inference/v1", .display = "Fireworks AI", .max_tokens_non_streaming = 4096 },
+    .{ .name = "fireworks-ai", .url = "https://api.fireworks.ai/inference/v1", .display = "Fireworks AI", .max_tokens_non_streaming = 4096 },
     .{ .name = "huggingface", .url = "https://router.huggingface.co/v1", .display = "Hugging Face" },
     .{ .name = "aihubmix", .url = "https://aihubmix.com/v1", .display = "AIHubMix" },
     .{ .name = "siliconflow", .url = "https://api.siliconflow.cn/v1", .display = "SiliconFlow" },
@@ -308,6 +311,7 @@ pub const ProviderHolder = union(enum) {
                     if (c.no_responses_fallback) prov.supports_responses_fallback = false;
                     if (c.merge_system_into_user) prov.merge_system_into_user = true;
                     if (!c.native_tools) prov.native_tools = false;
+                    if (c.max_tokens_non_streaming) |cap| prov.max_tokens_non_streaming = cap;
                 }
 
                 // Apply config-level native_tools override (can only force to false).
@@ -501,6 +505,10 @@ test "findCompatProvider returns correct flags" {
     const minimax_cn = findCompatProvider("minimax-cn").?;
     try std.testing.expect(minimax_cn.no_responses_fallback);
     try std.testing.expect(minimax_cn.merge_system_into_user);
+
+    // Fireworks has non-streaming max_tokens cap.
+    const fireworks = findCompatProvider("fireworks").?;
+    try std.testing.expectEqual(@as(?u32, 4096), fireworks.max_tokens_non_streaming);
 }
 
 test "fromConfig applies no_responses_fallback flag" {
@@ -527,6 +535,14 @@ test "fromConfig inherits native_tools=false from table" {
     defer h.deinit();
     try std.testing.expect(h == .compatible);
     try std.testing.expect(!h.compatible.native_tools);
+}
+
+test "fromConfig applies max_tokens_non_streaming from table" {
+    const alloc = std.testing.allocator;
+    var h = ProviderHolder.fromConfig(alloc, "fireworks", "key", null, true, null);
+    defer h.deinit();
+    try std.testing.expect(h == .compatible);
+    try std.testing.expectEqual(@as(?u32, 4096), h.compatible.max_tokens_non_streaming);
 }
 
 test "detectProviderByApiKey openrouter" {


### PR DESCRIPTION
I won't pretend I created this fix alone. I asked Claude to fix, understood the fix, tested, only then I decided it was worth sending a PR.

Below are Claude's details:

# Fix: Fireworks AI non-streaming max_tokens rejection

## Problem

When using Fireworks AI as a provider, non-streaming chat requests fail with:

```
error(compatible): fireworks-ai ApiError: https://api.fireworks.ai/inference/v1/chat/completions
{"error":{"message":"Requests with max_tokens > 4096 must have stream=true","param":"max_tokens","code":"BAD_REQUEST","type":"error"}}
```

## Root Cause

Three facts combine to produce the error:

1. **Default `max_tokens` is 8192** — defined in `src/config_types.zig` as `DEFAULT_MODEL_MAX_TOKENS`.
2. **Non-streaming requests hardcode `"stream":false`** — in `compatible.zig`, `buildChatRequestBody` (line 689) always appends `"stream":false`.
3. **Fireworks rejects `max_tokens > 4096` when `stream=false`** — this is a Fireworks API-specific constraint. Streaming requests accept any `max_tokens` value.

The `max_tokens` value is set by the caller (the agent loop), not by the provider layer. So NullClaw sends `max_tokens=8192` with `stream=false`, and Fireworks rejects it.

## Why a simple max_tokens change is not enough

The constraint only applies to non-streaming requests. Streaming requests (`stream=true`) support `max_tokens` values above 4096. Globally lowering `max_tokens` would unnecessarily cap streaming output tokens. The fix must target the intersection of: Fireworks provider + non-streaming code path + large `max_tokens`.

## Fix

Added a per-provider `max_tokens_non_streaming` cap, following the existing per-provider flag pattern (`no_responses_fallback`, `merge_system_into_user`, `native_tools`).

### Changes

**`src/providers/factory.zig`**

- Added `max_tokens_non_streaming: ?u32 = null` field to `CompatProvider` struct.
- Set `max_tokens_non_streaming = 4096` on both `fireworks` and `fireworks-ai` entries.
- Wired the flag through in `fromConfig` alongside the other compat flags.

**`src/providers/compatible.zig`**

- Added `max_tokens_non_streaming: ?u32 = null` field to `OpenAiCompatibleProvider` struct.
- In `chatImpl`, caps the request's `max_tokens` to the provider limit before building the non-streaming request body.

### Behavior

| Request type   | max_tokens | Before fix     | After fix          |
|----------------|------------|----------------|--------------------|
| Non-streaming  | 8192       | API error      | Capped to 4096     |
| Non-streaming  | 2048       | Works          | Works (below cap)  |
| Streaming      | 8192       | Works          | Works (unaffected) |

All 4657 existing tests pass with 0 leaks. No formatting regressions in modified files.
