### PR TITLE
fix(prompt): cap total injected bootstrap context

### DIFF
--- a/src/agent/compaction.zig
+++ b/src/agent/compaction.zig
@@ -486,7 +486,7 @@ fn readWorkspaceContextForSummary(
 ) ![]u8 {
     // Try bootstrap provider first when available.
     if (bootstrap_provider) |bp| {
-        const bp_content = bp.load(allocator, "AGENTS.md") catch null;
+        const bp_content = bp.load_excerpt(allocator, "AGENTS.md", MAX_AGENTS_FILE_BYTES) catch null;
         if (bp_content) |content| {
             defer allocator.free(content);
             const sections = try extractSections(allocator, content, &.{ "Session Startup", "Red Lines" });

--- a/src/agent/prompt.zig
+++ b/src/agent/prompt.zig
@@ -15,6 +15,9 @@ const pathStartsWith = path_prefix.pathStartsWith;
 
 /// Maximum characters to include from a single workspace identity file.
 const BOOTSTRAP_MAX_CHARS: usize = 20_000;
+/// Read one extra byte via providers so prompt rendering can distinguish
+/// "exactly at cap" from "truncated beyond cap" without loading full files.
+const BOOTSTRAP_PROVIDER_EXCERPT_BYTES: usize = BOOTSTRAP_MAX_CHARS + 1;
 /// Maximum total characters from injected bootstrap identity files.
 const BOOTSTRAP_TOTAL_MAX_CHARS: usize = 24_000;
 /// Maximum bytes allowed for guarded workspace bootstrap file reads.
@@ -613,7 +616,7 @@ fn injectWorkspaceFile(
 ) !void {
     // Try bootstrap provider first when available.
     if (bootstrap_provider) |bp| {
-        const content = bp.load(allocator, filename) catch null;
+        const content = bp.load_excerpt(allocator, filename, BOOTSTRAP_PROVIDER_EXCERPT_BYTES) catch null;
         if (content) |c| {
             defer allocator.free(c);
             try appendPromptSectionContent(
@@ -728,7 +731,7 @@ fn injectPreferredMemoryFile(
     if (bootstrap_provider) |bp| {
         const memory_files = [_][]const u8{ "MEMORY.md", "memory.md" };
         for (memory_files) |filename| {
-            const content = bp.load(allocator, filename) catch null;
+            const content = bp.load_excerpt(allocator, filename, BOOTSTRAP_PROVIDER_EXCERPT_BYTES) catch null;
             if (content) |c| {
                 defer allocator.free(c);
                 try appendPromptSectionContent(

--- a/src/bootstrap/contract_test.zig
+++ b/src/bootstrap/contract_test.zig
@@ -33,6 +33,11 @@ fn runContractTests(bp: BootstrapProvider) !void {
     defer if (loaded2) |c| allocator.free(c);
     try testing.expectEqualStrings("# Soul v2", loaded2.?);
 
+    // 3b. excerpt
+    const excerpt = try bp.load_excerpt(allocator, "SOUL.md", 3);
+    defer if (excerpt) |c| allocator.free(c);
+    try testing.expectEqualStrings("# S", excerpt.?);
+
     // 4. list contains stored files
     try bp.store("AGENTS.md", "# Agents");
     const items = try bp.list(allocator);
@@ -90,6 +95,8 @@ test "contract: NullBootstrapProvider has no-op semantics" {
     try bp.store("SOUL.md", "content");
     const loaded = try bp.load(testing.allocator, "SOUL.md");
     try testing.expect(loaded == null);
+    const excerpt = try bp.load_excerpt(testing.allocator, "SOUL.md", 3);
+    try testing.expect(excerpt == null);
     try testing.expect(!bp.exists("SOUL.md"));
 
     // list returns empty.

--- a/src/bootstrap/file_provider.zig
+++ b/src/bootstrap/file_provider.zig
@@ -32,6 +32,7 @@ pub const FileBootstrapProvider = struct {
 
     const vtable = BootstrapProvider.VTable{
         .load = load,
+        .load_excerpt = load_excerpt,
         .store = store,
         .remove = remove,
         .exists = exists,
@@ -47,13 +48,29 @@ pub const FileBootstrapProvider = struct {
         const path = try std.fs.path.join(allocator, &.{ self.workspace_dir, filename });
         defer allocator.free(path);
 
-        const file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+        var file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
             error.FileNotFound => return null,
             else => return err,
         };
         defer file.close();
 
         return try file.readToEndAlloc(allocator, 10 * 1024 * 1024);
+    }
+
+    fn load_excerpt(ptr: *anyopaque, allocator: std.mem.Allocator, filename: []const u8, max_bytes: usize) anyerror!?[]const u8 {
+        const self = castSelf(ptr);
+        if (!isBootstrapFilename(filename)) return Error.NotBootstrapFile;
+
+        const path = try std.fs.path.join(allocator, &.{ self.workspace_dir, filename });
+        defer allocator.free(path);
+
+        var file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return err,
+        };
+        defer file.close();
+
+        return try read_file_excerpt(allocator, &file, max_bytes);
     }
 
     fn store(ptr: *anyopaque, filename: []const u8, content: []const u8) anyerror!void {
@@ -148,6 +165,24 @@ pub const FileBootstrapProvider = struct {
     }
 };
 
+fn read_file_excerpt(allocator: std.mem.Allocator, file: *std.fs.File, max_bytes: usize) ![]const u8 {
+    const buf = try allocator.alloc(u8, max_bytes);
+    errdefer allocator.free(buf);
+
+    const read_len = try file.readAll(buf);
+    return shrink_alloc(allocator, buf, read_len);
+}
+
+fn shrink_alloc(allocator: std.mem.Allocator, slice: []u8, new_len: usize) ![]u8 {
+    if (new_len >= slice.len) return slice;
+    return allocator.realloc(slice, new_len) catch blk: {
+        const fresh = try allocator.alloc(u8, new_len);
+        @memcpy(fresh, slice[0..new_len]);
+        allocator.free(slice);
+        break :blk fresh;
+    };
+}
+
 // --- Tests ---
 
 const testing = std.testing;
@@ -190,6 +225,22 @@ test "load missing returns null" {
 
     const content = try bp.load(testing.allocator, "SOUL.md");
     try testing.expect(content == null);
+}
+
+test "load_excerpt returns prefix for oversized file" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var ctx = try setupTestProvider(&tmp);
+    defer testing.allocator.free(ctx.workspace);
+
+    var bp = ctx.provider.provider();
+
+    try bp.store("SOUL.md", "abcdef");
+    const excerpt = try bp.load_excerpt(testing.allocator, "SOUL.md", 3);
+    defer if (excerpt) |c| testing.allocator.free(c);
+
+    try testing.expectEqualStrings("abc", excerpt.?);
 }
 
 test "remove deletes file" {

--- a/src/bootstrap/memory_provider.zig
+++ b/src/bootstrap/memory_provider.zig
@@ -38,6 +38,7 @@ pub const MemoryBootstrapProvider = struct {
 
     const vtable = BootstrapProvider.VTable{
         .load = implLoad,
+        .load_excerpt = implLoadExcerpt,
         .store = implStore,
         .remove = implRemove,
         .exists = implExists,
@@ -84,6 +85,38 @@ pub const MemoryBootstrapProvider = struct {
         // Disk fallback for graceful migration.
         if (self.workspace_dir) |dir| {
             return diskFallback(dir, allocator, filename);
+        }
+
+        return null;
+    }
+
+    fn implLoadExcerpt(ptr: *anyopaque, allocator: std.mem.Allocator, filename: []const u8, max_bytes: usize) anyerror!?[]const u8 {
+        const self: *Self = @ptrCast(@alignCast(ptr));
+        if (!isBootstrapFilename(filename)) return Error.NotBootstrapFile;
+
+        const key = try memoryKey(allocator, filename);
+        defer allocator.free(key);
+
+        if (try self.mem.get(allocator, key)) |entry| {
+            defer allocator.free(entry.id);
+            defer allocator.free(entry.key);
+            defer allocator.free(entry.timestamp);
+            defer if (entry.session_id) |sid| allocator.free(sid);
+            defer switch (entry.category) {
+                .custom => |name| allocator.free(name),
+                else => {},
+            };
+
+            if (entry.content.len <= max_bytes) {
+                return entry.content;
+            }
+
+            defer allocator.free(entry.content);
+            return try allocator.dupe(u8, entry.content[0..max_bytes]);
+        }
+
+        if (self.workspace_dir) |dir| {
+            return diskFallbackExcerpt(dir, allocator, filename, max_bytes);
         }
 
         return null;
@@ -211,6 +244,34 @@ pub const MemoryBootstrapProvider = struct {
     }
 };
 
+fn diskFallbackExcerpt(workspace_dir: []const u8, allocator: std.mem.Allocator, filename: []const u8, max_bytes: usize) ?[]const u8 {
+    const path = std.fs.path.join(allocator, &.{ workspace_dir, filename }) catch return null;
+    defer allocator.free(path);
+
+    const file = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer file.close();
+
+    const buf = allocator.alloc(u8, max_bytes) catch return null;
+    const read_len = file.readAll(buf) catch {
+        allocator.free(buf);
+        return null;
+    };
+    return shrink_alloc(allocator, buf, read_len) catch {
+        allocator.free(buf);
+        return null;
+    };
+}
+
+fn shrink_alloc(allocator: std.mem.Allocator, slice: []u8, new_len: usize) ![]u8 {
+    if (new_len >= slice.len) return slice;
+    return allocator.realloc(slice, new_len) catch blk: {
+        const fresh = try allocator.alloc(u8, new_len);
+        @memcpy(fresh, slice[0..new_len]);
+        allocator.free(slice);
+        break :blk fresh;
+    };
+}
+
 // ── Tests ──────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -251,6 +312,20 @@ test "load missing returns null" {
     try testing.expect(content == null);
 }
 
+test "load_excerpt returns prefix for stored memory bootstrap" {
+    var lru = InMemoryLruMemory.init(testing.allocator, 100);
+    defer lru.deinit();
+
+    var ctx = initTestProvider(&lru, null);
+    var bp = ctx.provider.provider();
+
+    try bp.store("AGENTS.md", "abcdef");
+    const excerpt = try bp.load_excerpt(testing.allocator, "AGENTS.md", 4);
+    defer if (excerpt) |c| testing.allocator.free(c);
+
+    try testing.expectEqualStrings("abcd", excerpt.?);
+}
+
 test "fallback reads from workspace dir when not in DB" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -271,6 +346,27 @@ test "fallback reads from workspace dir when not in DB" {
     defer if (content) |c| testing.allocator.free(c);
 
     try testing.expectEqualStrings("disk identity", content.?);
+}
+
+test "load_excerpt uses disk fallback prefix when not in DB" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    tmp.dir.writeFile(.{ .sub_path = "IDENTITY.md", .data = "disk identity" }) catch unreachable;
+
+    const workspace = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(workspace);
+
+    var lru = InMemoryLruMemory.init(testing.allocator, 100);
+    defer lru.deinit();
+
+    var ctx = initTestProvider(&lru, workspace);
+    var bp = ctx.provider.provider();
+
+    const excerpt = try bp.load_excerpt(testing.allocator, "IDENTITY.md", 4);
+    defer if (excerpt) |c| testing.allocator.free(c);
+
+    try testing.expectEqualStrings("disk", excerpt.?);
 }
 
 test "DB takes priority over disk fallback" {

--- a/src/bootstrap/null_provider.zig
+++ b/src/bootstrap/null_provider.zig
@@ -27,6 +27,10 @@ pub const NullBootstrapProvider = struct {
         return null;
     }
 
+    fn implLoadExcerpt(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: usize) anyerror!?[]const u8 {
+        return null;
+    }
+
     fn implStore(_: *anyopaque, _: []const u8, _: []const u8) anyerror!void {}
 
     fn implRemove(_: *anyopaque, _: []const u8) anyerror!bool {
@@ -54,6 +58,7 @@ pub const NullBootstrapProvider = struct {
 
     const vtable = BootstrapProvider.VTable{
         .load = &implLoad,
+        .load_excerpt = &implLoadExcerpt,
         .store = &implStore,
         .remove = &implRemove,
         .exists = &implExists,
@@ -67,6 +72,13 @@ test "load returns null" {
     var np = NullBootstrapProvider.init();
     const bp = np.provider();
     const result = try bp.load(std.testing.allocator, "AGENTS.md");
+    try std.testing.expect(result == null);
+}
+
+test "load_excerpt returns null" {
+    var np = NullBootstrapProvider.init();
+    const bp = np.provider();
+    const result = try bp.load_excerpt(std.testing.allocator, "AGENTS.md", 4);
     try std.testing.expect(result == null);
 }
 

--- a/src/bootstrap/provider.zig
+++ b/src/bootstrap/provider.zig
@@ -9,6 +9,7 @@ pub const BootstrapProvider = struct {
 
     pub const VTable = struct {
         load: *const fn (ptr: *anyopaque, allocator: std.mem.Allocator, filename: []const u8) anyerror!?[]const u8,
+        load_excerpt: *const fn (ptr: *anyopaque, allocator: std.mem.Allocator, filename: []const u8, max_bytes: usize) anyerror!?[]const u8,
         store: *const fn (ptr: *anyopaque, filename: []const u8, content: []const u8) anyerror!void,
         remove: *const fn (ptr: *anyopaque, filename: []const u8) anyerror!bool,
         exists: *const fn (ptr: *anyopaque, filename: []const u8) bool,
@@ -19,6 +20,10 @@ pub const BootstrapProvider = struct {
 
     pub fn load(self: BootstrapProvider, allocator: std.mem.Allocator, filename: []const u8) !?[]const u8 {
         return self.vtable.load(self.ptr, allocator, filename);
+    }
+
+    pub fn load_excerpt(self: BootstrapProvider, allocator: std.mem.Allocator, filename: []const u8, max_bytes: usize) !?[]const u8 {
+        return self.vtable.load_excerpt(self.ptr, allocator, filename, max_bytes);
     }
 
     pub fn store(self: BootstrapProvider, filename: []const u8, content: []const u8) !void {

--- a/src/heartbeat.zig
+++ b/src/heartbeat.zig
@@ -3,6 +3,8 @@ const observability = @import("observability.zig");
 const bootstrap_mod = @import("bootstrap/root.zig");
 const BootstrapProvider = bootstrap_mod.BootstrapProvider;
 
+const MAX_HEARTBEAT_FILE_BYTES: usize = 64 * 1024;
+
 pub const TickOutcome = enum {
     processed,
     skipped_empty_file,
@@ -57,7 +59,7 @@ pub const HeartbeatEngine = struct {
     pub fn collectTasks(self: *const HeartbeatEngine, allocator: std.mem.Allocator) ![][]const u8 {
         // Try bootstrap provider first when available.
         if (self.bootstrap_provider) |bp| {
-            const bp_content = bp.load(allocator, "HEARTBEAT.md") catch null;
+            const bp_content = bp.load_excerpt(allocator, "HEARTBEAT.md", MAX_HEARTBEAT_FILE_BYTES) catch null;
             if (bp_content) |content| {
                 defer allocator.free(content);
                 if (isContentEffectivelyEmpty(content)) return &.{};
@@ -76,7 +78,7 @@ pub const HeartbeatEngine = struct {
         };
         defer file.close();
 
-        const content = try file.readToEndAlloc(allocator, 1024 * 64);
+        const content = try file.readToEndAlloc(allocator, MAX_HEARTBEAT_FILE_BYTES);
         defer allocator.free(content);
 
         if (isContentEffectivelyEmpty(content)) return &.{};
@@ -105,7 +107,7 @@ pub const HeartbeatEngine = struct {
     pub fn tick(self: *const HeartbeatEngine, allocator: std.mem.Allocator) !TickResult {
         // Try bootstrap provider first when available.
         if (self.bootstrap_provider) |bp| {
-            const bp_content = bp.load(allocator, "HEARTBEAT.md") catch null;
+            const bp_content = bp.load_excerpt(allocator, "HEARTBEAT.md", MAX_HEARTBEAT_FILE_BYTES) catch null;
             if (bp_content) |content| {
                 defer allocator.free(content);
                 if (isContentEffectivelyEmpty(content)) {
@@ -128,7 +130,7 @@ pub const HeartbeatEngine = struct {
         };
         defer file.close();
 
-        const content = try file.readToEndAlloc(allocator, 1024 * 64);
+        const content = try file.readToEndAlloc(allocator, MAX_HEARTBEAT_FILE_BYTES);
         defer allocator.free(content);
         if (isContentEffectivelyEmpty(content)) {
             return .{ .outcome = .skipped_empty_file, .task_count = 0 };


### PR DESCRIPTION
## Summary
- cap the total characters injected from workspace identity/bootstrap files during system prompt construction
- preserve the existing per-file cap while preventing prompt bloat across multiple large files
- add tests for exhausted bootstrap budget and total project-context truncation

## Validation
- `zig build`
- `zig build test --summary all` 

## Validation Note
- the full suite is currently tripping on the existing concurrent session test `session.test.concurrent processMessage different keys — no crash`
- I reproduced the same failure on `origin/main` in a clean baseline worktree, so I am not attributing that crash to this patch
