### PR TITLE
Fix tool call response ASCII codes and Windows GBK encoding issues

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -1851,7 +1851,7 @@ pub const Agent = struct {
             const preview = llmLogPreview(msg.content);
             const parts_count: usize = if (msg.content_parts) |parts| parts.len else 0;
             log.info(
-                "llm request msg session=0x{x} iter={d} attempt={d} index={d} role={s} bytes={d} parts={d} content={f}{s}",
+                "llm request msg session=0x{x} iter={d} attempt={d} index={d} role={s} bytes={d} parts={d} content={s}{s}",
                 .{
                     session_hash,
                     iteration,
@@ -1860,7 +1860,7 @@ pub const Agent = struct {
                     msg.role.toSlice(),
                     msg.content.len,
                     parts_count,
-                    std.json.fmt(preview.slice, .{}),
+                    preview.slice,
                     if (preview.truncated) " [log preview truncated]" else "",
                 },
             );
@@ -1873,7 +1873,7 @@ pub const Agent = struct {
         const content = response.contentOrEmpty();
         const preview = llmLogPreview(content);
         log.info(
-            "llm response session=0x{x} iter={d} attempt={d} provider={s} model={s} bytes={d} tool_calls={d} usage={f} content={f}{s}",
+            "llm response session=0x{x} iter={d} attempt={d} provider={s} model={s} bytes={d} tool_calls={d} usage={f} content={s}{s}",
             .{
                 session_hash,
                 iteration,
@@ -1883,7 +1883,7 @@ pub const Agent = struct {
                 content.len,
                 response.tool_calls.len,
                 std.json.fmt(response.usage, .{}),
-                std.json.fmt(preview.slice, .{}),
+                preview.slice,
                 if (preview.truncated) " [log preview truncated]" else "",
             },
         );
@@ -1891,13 +1891,13 @@ pub const Agent = struct {
         if (response.reasoning_content) |reasoning| {
             const r_preview = llmLogPreview(reasoning);
             log.info(
-                "llm response reasoning session=0x{x} iter={d} attempt={d} bytes={d} content={f}{s}",
+                "llm response reasoning session=0x{x} iter={d} attempt={d} bytes={d} content={s}{s}",
                 .{
                     session_hash,
                     iteration,
                     attempt,
                     reasoning.len,
-                    std.json.fmt(r_preview.slice, .{}),
+                    r_preview.slice,
                     if (r_preview.truncated) " [log preview truncated]" else "",
                 },
             );
@@ -1906,7 +1906,7 @@ pub const Agent = struct {
         for (response.tool_calls, 0..) |tc, idx| {
             const args_preview = llmLogPreview(tc.arguments);
             log.info(
-                "llm response tool-call session=0x{x} iter={d} attempt={d} index={d} id={s} name={s} args={f}{s}",
+                "llm response tool-call session=0x{x} iter={d} attempt={d} index={d} id={s} name={s} args={s}{s}",
                 .{
                     session_hash,
                     iteration,
@@ -1914,7 +1914,7 @@ pub const Agent = struct {
                     idx + 1,
                     if (tc.id.len > 0) tc.id else "-",
                     tc.name,
-                    std.json.fmt(args_preview.slice, .{}),
+                    args_preview.slice,
                     if (args_preview.truncated) " [log preview truncated]" else "",
                 },
             );

--- a/src/tools/shell.zig
+++ b/src/tools/shell.zig
@@ -120,9 +120,23 @@ pub const ShellTool = struct {
             }
         }
 
+        // On Windows, force UTF-8 output encoding to prevent GBK garbled text
+        if (comptime @import("builtin").os.tag == .windows) {
+            try env.put("PYTHONUTF8", "1");
+            try env.put("PYTHONIOENCODING", "utf-8");
+        }
+
         // Execute via platform shell
         const proc = @import("process_util.zig");
-        const result = try proc.run(allocator, &.{ platform.getShell(), platform.getShellFlag(), command }, .{
+
+        // On Windows, prepend 'chcp 65001 >nul && ' to force UTF-8 codepage for cmd.exe output
+        const final_command = if (comptime @import("builtin").os.tag == .windows) blk: {
+            const utf8_prefix = "chcp 65001 >nul 2>&1 && ";
+            break :blk try std.fmt.allocPrint(allocator, "{s}{s}", .{ utf8_prefix, command });
+        } else command;
+        defer if (comptime @import("builtin").os.tag == .windows) allocator.free(final_command);
+
+        const result = try proc.run(allocator, &.{ platform.getShell(), platform.getShellFlag(), final_command }, .{
             .cwd = effective_cwd,
             .env_map = &env,
             .max_output_bytes = self.max_output_bytes,


### PR DESCRIPTION
1. Fixed tool call response content showing ASCII codes instead of strings by removing std.json.fmt from log statements
2. Fixed Windows GBK encoding garbled text issue in shell tool by:
   - Forcing UTF-8 codepage with 'chcp 65001' for cmd.exe
   - Setting Python UTF-8 environment variables (PYTHONUTF8, PYTHONIOENCODING)

This ensures proper UTF-8 output for shell commands on Windows Chinese systems.