### PR TITLE
Support http:// URLs for search_base_url configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Use this when you want full web-search provider control plus unrestricted shell 
 }
 ```
 
-- `http_request.search_base_url` accepts either instance root (`https://host`) or explicit endpoint (`https://host/search`).
+- `http_request.search_base_url` accepts either instance root (`https://host`) or explicit endpoint (`https://host/search`); local/private SearXNG instances may also use plain HTTP such as `http://localhost:8888` or `http://192.168.1.10:8888/search`.
 - Invalid `http_request.search_base_url` now fails config validation at startup (no automatic fallback for malformed URL).
 - `http_request.search_provider` supports: `auto`, `searxng`, `duckduckgo` (`ddg`), `brave`, `firecrawl`, `tavily`, `perplexity`, `exa`, `jina`.
 - `http_request.search_fallback_providers` is optional and is tried in order when the primary provider fails.

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -186,7 +186,7 @@ Use only in controlled environments:
 
 Notes:
 
-- `search_base_url` must be a valid URL, otherwise startup validation fails.
+- `search_base_url` must be `https://host[/search]` or a local/private `http://host[:port][/search]` URL, otherwise startup validation fails.
 - `allowed_commands: ["*"]` and `allowed_paths: ["*"]` significantly widen execution scope.
 
 ## Validate After Config Changes

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -170,7 +170,7 @@ Telegram 示例：
 
 注意：
 
-- `search_base_url` 必须是合法 URL，否则启动校验会失败。
+- `search_base_url` 必须是 `https://host[/search]`，或者本地/内网可达的 `http://host[:port][/search]`，否则启动校验会失败。
 - `allowed_commands: ["*"]` 与 `allowed_paths: ["*"]` 会显著扩大执行范围。
 
 ## 配置变更后的验证

--- a/src/config.zig
+++ b/src/config.zig
@@ -982,7 +982,7 @@ pub const Config = struct {
             ValidationError.InvalidBackoffMs => std.debug.print("Config error: provider_backoff_ms must be <= 600000.\n", .{}),
             ValidationError.InvalidHttpProxyUrl => std.debug.print("Config error: http_request.proxy must be a non-empty http://, https://, or socks5:// URL.\n", .{}),
             ValidationError.InvalidApiErrorMaxChars => std.debug.print("Config error: diagnostics.api_error_max_chars must be in [200, 10000].\n", .{}),
-            ValidationError.InvalidHttpSearchBaseUrl => std.debug.print("Config error: http_request.search_base_url must be http(s)://host or http(s)://host/search (no query/fragment).\n", .{}),
+            ValidationError.InvalidHttpSearchBaseUrl => std.debug.print("Config error: http_request.search_base_url must be https://host[/search] or local http://host[:port][/search] (no query/fragment).\n", .{}),
             ValidationError.InvalidHttpSearchProvider => std.debug.print("Config error: http_request.search_provider must be one of: auto, searxng, duckduckgo(ddg), brave, firecrawl, tavily, perplexity, exa, jina.\n", .{}),
             ValidationError.InvalidHttpSearchFallbackProvider => std.debug.print("Config error: http_request.search_fallback_providers entries must be valid providers and cannot be 'auto'.\n", .{}),
             ValidationError.InvalidWebTransport => std.debug.print("Config error: channels.web.accounts.<id>.transport must be 'local' or 'relay'.\n", .{}),
@@ -1956,6 +1956,28 @@ test "validation accepts valid http_request search base URL" {
     };
     cfg.http_request.search_base_url = "https://searx.example.com/search";
     try cfg.validate();
+}
+
+test "validation accepts local http_request search base URL" {
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .default_model = "x",
+        .allocator = std.testing.allocator,
+    };
+    cfg.http_request.search_base_url = "http://localhost:8888/search";
+    try cfg.validate();
+}
+
+test "validation rejects remote http_request search base URL over plain http" {
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .default_model = "x",
+        .allocator = std.testing.allocator,
+    };
+    cfg.http_request.search_base_url = "http://searx.example.com/search";
+    try std.testing.expectError(Config.ValidationError.InvalidHttpSearchBaseUrl, cfg.validate());
 }
 
 test "validation rejects invalid http_request search provider" {

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const search_base_url = @import("search_base_url.zig");
 
 /// Default context token budget used by agent compaction/context management.
 /// Runtime fallback (`DEFAULT_CONTEXT_TOKENS`).
@@ -1092,9 +1093,11 @@ pub const HttpRequestConfig = struct {
     proxy: ?[]const u8 = null,
     /// Optional SearXNG instance URL used by web_search as a fallback when
     /// BRAVE_API_KEY is not available.
+    /// HTTPS is allowed for any host. Plain HTTP is allowed only for local or
+    /// private hosts such as localhost, .local names, or private IP ranges.
     /// Examples:
     ///   - "https://searx.example.com"
-    ///   - "http://searx.example.com"
+    ///   - "http://localhost:8888"
     ///   - "https://searx.example.com/search"
     search_base_url: ?[]const u8 = null,
     /// Search provider for web_search.
@@ -1106,37 +1109,12 @@ pub const HttpRequestConfig = struct {
 
     /// Validate optional SearXNG base URL accepted by web_search.
     /// Allowed forms:
-    ///   - http://host  or https://host
-    ///   - http://host/ or https://host/
-    ///   - http://host/search  or https://host/search
-    ///   - http://host/search/ or https://host/search/
+    ///   - https://host
+    ///   - https://host/search
+    ///   - http://localhost[:port]
+    ///   - http://localhost[:port]/search
     pub fn isValidSearchBaseUrl(raw: []const u8) bool {
-        const trimmed = std.mem.trim(u8, raw, " \t\r\n");
-        const scheme_len = if (std.mem.startsWith(u8, trimmed, "https://"))
-            "https://".len
-        else if (std.mem.startsWith(u8, trimmed, "http://"))
-            "http://".len
-        else
-            return false;
-        if (std.mem.indexOfAny(u8, trimmed, "?#") != null) return false;
-
-        const no_scheme = trimmed[scheme_len..];
-        if (no_scheme.len == 0 or no_scheme[0] == '/') return false;
-
-        const slash_pos = std.mem.indexOfScalar(u8, no_scheme, '/');
-        const authority = if (slash_pos) |idx| no_scheme[0..idx] else no_scheme;
-        if (authority.len == 0) return false;
-        if (std.mem.indexOfAny(u8, authority, " \t\r\n")) |_| return false;
-
-        if (slash_pos) |idx| {
-            var path = no_scheme[idx..];
-            if (std.mem.eql(u8, path, "/")) return true;
-            while (path.len > 1 and path[path.len - 1] == '/') {
-                path = path[0 .. path.len - 1];
-            }
-            if (!std.mem.eql(u8, path, "/search")) return false;
-        }
-        return true;
+        return search_base_url.isValid(raw);
     }
 
     pub fn isValidSearchProviderName(raw: []const u8) bool {
@@ -1486,17 +1464,22 @@ test "HttpRequestConfig search base URL validation" {
     try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("https://searx.example.com/search"));
     try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("https://searx.example.com/search/"));
 
-    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://searx.example.com"));
-    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://searx.example.com/"));
-    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://searx.example.com/search"));
-    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://searx.example.com/search/"));
+    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://localhost:8888"));
+    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://localhost:8888/"));
+    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://localhost:8888/search"));
+    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://localhost:8888/search/"));
+    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://192.168.1.10:8888/search"));
+    try std.testing.expect(HttpRequestConfig.isValidSearchBaseUrl("http://searx.local/search"));
 
     try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("ftp://searx.example.com"));
     try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("https://"));
     try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("http://"));
+    try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("http://searx.example.com"));
+    try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("http://searx.example.com/search"));
     try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("https://searx.example.com?x=1"));
     try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("https://searx.example.com#frag"));
     try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("https://searx.example.com/custom"));
+    try std.testing.expect(!HttpRequestConfig.isValidSearchBaseUrl("https://:8080/search"));
 }
 
 test "HttpRequestConfig search provider validation" {

--- a/src/search_base_url.zig
+++ b/src/search_base_url.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const net_security = @import("net_security.zig");
+
+pub const Error = std.mem.Allocator.Error || error{InvalidSearchBaseUrl};
+
+pub fn isValid(raw: []const u8) bool {
+    return validated(raw) != null;
+}
+
+pub fn normalizeEndpoint(allocator: std.mem.Allocator, raw: []const u8) Error![]u8 {
+    const base_url = validated(raw) orelse return error.InvalidSearchBaseUrl;
+    if (std.mem.endsWith(u8, base_url, "/search")) {
+        return allocator.dupe(u8, base_url);
+    }
+    return std.fmt.allocPrint(allocator, "{s}/search", .{base_url});
+}
+
+fn validated(raw: []const u8) ?[]const u8 {
+    var trimmed = std.mem.trim(u8, raw, " \t\r\n");
+    if (trimmed.len == 0) return null;
+
+    while (trimmed.len > 0 and trimmed[trimmed.len - 1] == '/') {
+        trimmed = trimmed[0 .. trimmed.len - 1];
+    }
+
+    const uri = std.Uri.parse(trimmed) catch return null;
+    if (uri.query != null or uri.fragment != null) return null;
+
+    const is_https = std.ascii.eqlIgnoreCase(uri.scheme, "https");
+    const is_http = std.ascii.eqlIgnoreCase(uri.scheme, "http");
+    if (!is_https and !is_http) return null;
+
+    const host_component = uri.host orelse return null;
+    const host = switch (host_component) {
+        .raw => |h| h,
+        .percent_encoded => |h| blk: {
+            if (std.mem.indexOfScalar(u8, h, '%') != null) return null;
+            break :blk h;
+        },
+    };
+    if (host.len == 0) return null;
+    if (host[0] == ':') return null;
+    if (std.mem.indexOfAny(u8, host, " \t\r\n") != null) return null;
+
+    if (host[0] == '[') {
+        const close = std.mem.indexOfScalar(u8, host, ']') orelse return null;
+        if (close != host.len - 1) return null;
+    }
+
+    if (uri.port) |port| {
+        if (port == 0) return null;
+    }
+
+    if (is_http and !net_security.isLocalHost(host)) return null;
+
+    const path = switch (uri.path) {
+        .raw => |p| p,
+        .percent_encoded => |p| p,
+    };
+    if (path.len > 0 and !std.mem.eql(u8, path, "/search")) return null;
+
+    return trimmed;
+}

--- a/src/tools/web_search.zig
+++ b/src/tools/web_search.zig
@@ -49,7 +49,7 @@ const ProviderSearchError = search_common.ProviderSearchError;
 
 /// Web search tool supporting multiple providers.
 pub const WebSearchTool = struct {
-    /// Optional SearXNG base URL (e.g. https://searx.example.com or .../search).
+    /// Optional SearXNG base URL (HTTPS anywhere, or local/private HTTP).
     searxng_base_url: ?[]const u8 = null,
     /// Primary provider ("auto" by default).
     provider: []const u8 = "auto",
@@ -94,7 +94,7 @@ pub const WebSearchTool = struct {
         for (chain) |provider| {
             const result = executeWithProvider(self, allocator, provider, query, count) catch |err| {
                 if (err == error.InvalidSearchBaseUrl) {
-                    return ToolResult.fail("Invalid http_request.search_base_url; expected https://host[/search]");
+                    return ToolResult.fail("Invalid http_request.search_base_url; expected https://host[/search] or local http://host[:port][/search]");
                 }
 
                 if (failures.items.len > 0) {
@@ -418,6 +418,10 @@ test "buildSearxngSearchUrl normalizes base URLs" {
     const from_search = try buildSearxngSearchUrl(testing.allocator, "https://searx.example.com/search", encoded_query, 3);
     defer testing.allocator.free(from_search);
     try testing.expect(std.mem.indexOf(u8, from_search, "https://searx.example.com/search?") != null);
+
+    const from_local_http = try buildSearxngSearchUrl(testing.allocator, "http://localhost:8888/", encoded_query, 3);
+    defer testing.allocator.free(from_local_http);
+    try testing.expect(std.mem.indexOf(u8, from_local_http, "http://localhost:8888/search?") != null);
 }
 
 test "buildSearxngSearchUrl rejects query and fragment" {
@@ -432,6 +436,10 @@ test "buildSearxngSearchUrl rejects query and fragment" {
     try testing.expectError(
         error.InvalidSearchBaseUrl,
         buildSearxngSearchUrl(testing.allocator, "https://searx.example.com/custom", "zig", 3),
+    );
+    try testing.expectError(
+        error.InvalidSearchBaseUrl,
+        buildSearxngSearchUrl(testing.allocator, "http://searx.example.com", "zig", 3),
     );
 }
 

--- a/src/tools/web_search_providers/common.zig
+++ b/src/tools/web_search_providers/common.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const root = @import("../root.zig");
 const http_util = @import("../../http_util.zig");
+const search_base_url = @import("../../search_base_url.zig");
 const url_percent = @import("../../url_percent.zig");
 
 const log = std.log.scoped(.web_search);
@@ -69,35 +70,10 @@ pub fn buildSearxngSearchUrl(
     encoded_query: []const u8,
     count: usize,
 ) ![]u8 {
-    var trimmed = std.mem.trim(u8, base_url, " \t\n\r");
-    if (trimmed.len == 0) return error.InvalidSearchBaseUrl;
-    while (trimmed.len > 0 and trimmed[trimmed.len - 1] == '/') {
-        trimmed = trimmed[0 .. trimmed.len - 1];
-    }
-    if (!std.mem.startsWith(u8, trimmed, "https://")) return error.InvalidSearchBaseUrl;
-    if (std.mem.indexOfAny(u8, trimmed, "?#") != null) {
-        return error.InvalidSearchBaseUrl;
-    }
-    const after_scheme = trimmed["https://".len..];
-    if (after_scheme.len == 0 or after_scheme[0] == '/') {
-        return error.InvalidSearchBaseUrl;
-    }
-    const authority_end = std.mem.indexOfScalar(u8, after_scheme, '/') orelse after_scheme.len;
-    const authority = after_scheme[0..authority_end];
-    if (authority.len == 0 or std.mem.indexOfAny(u8, authority, " \t\r\n") != null) {
-        return error.InvalidSearchBaseUrl;
-    }
-    if (authority_end < after_scheme.len) {
-        const path = after_scheme[authority_end..];
-        if (!std.mem.eql(u8, path, "/search")) {
-            return error.InvalidSearchBaseUrl;
-        }
-    }
-
-    const endpoint = if (std.mem.endsWith(u8, trimmed, "/search"))
-        try allocator.dupe(u8, trimmed)
-    else
-        try std.fmt.allocPrint(allocator, "{s}/search", .{trimmed});
+    const endpoint = search_base_url.normalizeEndpoint(allocator, base_url) catch |err| switch (err) {
+        error.InvalidSearchBaseUrl => return error.InvalidSearchBaseUrl,
+        error.OutOfMemory => return error.OutOfMemory,
+    };
     defer allocator.free(endpoint);
 
     return std.fmt.allocPrint(


### PR DESCRIPTION
**Summary**
- Allow http:// scheme in http_request.search_base_url config validation (previously only https:// was accepted)
- Update validation error message and doc comments to reflect both schemes

**Validation**
- zig test src/config_types.zig — all 136 tests passed

**Notes**
- SearXNG instances might be self-hosted on local networks or inside a k8s cluster where TLS might be unnecessary (e.g. http://localhost:8888)