### PR TITLE
fix(security): scope git -C handling and support Signal Note to Self

### DIFF
--- a/src/channels/signal.zig
+++ b/src/channels/signal.zig
@@ -73,6 +73,11 @@ const SIGNAL_RPC_ENDPOINT = "/api/v1/rpc";
 /// SSE endpoint for receiving messages.
 const SIGNAL_SSE_ENDPOINT = "/api/v1/events";
 
+/// Signal reserves device id 1 for the primary device. Linked devices use
+/// other ids; we use this to accept Note-to-Self only from the primary device
+/// and fail closed for sync echoes originating from linked devices.
+const SIGNAL_PRIMARY_DEVICE_ID: u64 = 1;
+
 /// REST health endpoint (signal-cli-rest-api MODE=normal).
 const SIGNAL_REST_HEALTH_ENDPOINT = "/v1/health";
 
@@ -958,14 +963,93 @@ pub const SignalChannel = struct {
         };
     }
 
+    /// Handle a syncMessage envelope for "Note to Self" support.
+    ///
+    /// Signal sync messages are sent to all linked devices when the primary
+    /// device sends a message. Most syncs are outbound echoes (messages sent
+    /// to other people) and should be ignored. However, when the destination
+    /// of the sentMessage is the account's own number, this is a "Note to Self"
+    /// message — the user is intentionally messaging themselves, and the bot
+    /// (running as a linked device) should process it as an inbound message.
+    fn parseSyncNoteToSelf(
+        self: *const SignalChannel,
+        allocator: std.mem.Allocator,
+        env_obj: std.json.ObjectMap,
+        sync: std.json.Value,
+    ) !?root.ChannelMessage {
+        if (sync != .object) return null;
+        const sent = sync.object.get("sentMessage") orelse return null;
+        if (sent != .object) return null;
+        const sent_obj = sent.object;
+
+        // Check destination: must be self-account for Note to Self.
+        const dest = jsonString(sent_obj.get("destinationNumber")) orelse
+            jsonString(sent_obj.get("destination"));
+        if (dest == null) return null;
+        if (!std.mem.eql(u8, normalizeAllowEntry(dest.?), normalizeAllowEntry(self.account))) return null;
+
+        // Only treat primary-device Note to Self as inbound user intent.
+        // Linked-device sync echoes are outbound reflections and must stay ignored.
+        const source_device = jsonU64(env_obj.get("sourceDevice")) orelse return null;
+        if (source_device != SIGNAL_PRIMARY_DEVICE_ID) return null;
+
+        // Extract message body from sentMessage.
+        const message = jsonString(sent_obj.get("message"));
+        if (message == null or message.?.len == 0) return null;
+
+        // Use the envelope source fields for sender identity.
+        const source = jsonString(env_obj.get("source"));
+        const source_number = jsonString(env_obj.get("sourceNumber"));
+        const source_name = jsonString(env_obj.get("sourceName"));
+        const envelope_timestamp = jsonU64(env_obj.get("timestamp"));
+        const dm_timestamp = jsonU64(sent_obj.get("timestamp"));
+
+        // Effective sender for reply target.
+        const sender_raw = source_number orelse source orelse return null;
+        if (sender_raw.len == 0) return null;
+
+        // Allowlist check: the sender must be in allow_from.
+        if (!(self.isSenderAllowed(sender_raw) or blk: {
+            if (source) |src| {
+                if (!std.mem.eql(u8, src, sender_raw)) break :blk self.isSenderAllowed(src);
+            }
+            break :blk false;
+        })) return null;
+
+        // Build the channel message.
+        const text = try allocator.dupe(u8, message.?);
+        errdefer allocator.free(text);
+        const reply_target_str = try allocator.dupe(u8, sender_raw);
+        errdefer allocator.free(reply_target_str);
+        const raw_timestamp: u64 = dm_timestamp orelse envelope_timestamp orelse root.nowEpochSecs();
+        const timestamp = normalizeEpochSeconds(raw_timestamp);
+
+        return root.ChannelMessage{
+            .id = try allocator.dupe(u8, sender_raw),
+            .sender = try allocator.dupe(u8, sender_raw),
+            .content = text,
+            .channel = "signal",
+            .timestamp = timestamp,
+            .reply_target = reply_target_str,
+            .first_name = if (source_name) |sn| if (sn.len > 0) try allocator.dupe(u8, sn) else null else null,
+            .is_group = false,
+            .sender_uuid = if (source) |src| if (src.len > 0 and isUuid(src)) try allocator.dupe(u8, src) else null else null,
+            .group_id = null,
+        };
+    }
+
     fn parseEnvelopeValue(self: *const SignalChannel, allocator: std.mem.Allocator, value: std.json.Value) !?root.ChannelMessage {
         if (value != .object) return null;
         const envelope = value.object.get("envelope") orelse return null;
         if (envelope != .object) return null;
         const env_obj = envelope.object;
 
-        // Skip outbound/sync envelopes to avoid handling our own sent messages.
-        if (env_obj.get("syncMessage") != null) return null;
+        // Handle syncMessage envelopes: only process "Note to Self" messages
+        // where the user sends a message to their own account. All other sync
+        // messages (outbound echoes to other recipients) are dropped.
+        if (env_obj.get("syncMessage")) |sync| {
+            return self.parseSyncNoteToSelf(allocator, env_obj, sync);
+        }
 
         const source = jsonString(env_obj.get("source"));
         const source_uuid = jsonString(env_obj.get("sourceUuid"));
@@ -3351,4 +3435,166 @@ test "stripTrailingSlashes empty string" {
 
 test "stripTrailingSlashes only slashes" {
     try std.testing.expectEqualStrings("", stripTrailingSlashes("///"));
+}
+
+test "parseSSEEnvelope processes Note to Self sync message" {
+    const users = [_][]const u8{"+1234567890"};
+    const ch = SignalChannel.init(
+        std.testing.allocator,
+        "http://127.0.0.1:8686",
+        "+1234567890",
+        &users,
+        &.{},
+        true,
+        true,
+    );
+    const raw_json =
+        \\{
+        \\  "envelope": {
+        \\    "source": "+1234567890",
+        \\    "sourceNumber": "+1234567890",
+        \\    "sourceDevice": 1,
+        \\    "sourceName": "Test User",
+        \\    "timestamp": 1700000000000,
+        \\    "syncMessage": {
+        \\      "sentMessage": {
+        \\        "destination": "+1234567890",
+        \\        "destinationNumber": "+1234567890",
+        \\        "message": "hello from note to self",
+        \\        "timestamp": 1700000001000
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    const msg_opt = try ch.parseSSEEnvelope(std.testing.allocator, raw_json);
+    try std.testing.expect(msg_opt != null);
+    const msg = msg_opt.?;
+    defer msg.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("hello from note to self", msg.content);
+    try std.testing.expectEqualStrings("+1234567890", msg.sender);
+    try std.testing.expectEqualStrings("Test User", msg.first_name.?);
+    try std.testing.expectEqual(@as(u64, 1_700_000_001), msg.timestamp);
+}
+
+test "parseSSEEnvelope ignores sync outbound to other recipient" {
+    const users = [_][]const u8{"*"};
+    const ch = SignalChannel.init(
+        std.testing.allocator,
+        "http://127.0.0.1:8686",
+        "+1234567890",
+        &users,
+        &.{},
+        true,
+        true,
+    );
+    const raw_json =
+        \\{
+        \\  "envelope": {
+        \\    "sourceNumber": "+1234567890",
+        \\    "sourceDevice": 1,
+        \\    "timestamp": 1700000000000,
+        \\    "syncMessage": {
+        \\      "sentMessage": {
+        \\        "destination": "+9999999999",
+        \\        "destinationNumber": "+9999999999",
+        \\        "message": "outbound echo should be dropped",
+        \\        "timestamp": 1700000001000
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    const msg_opt = try ch.parseSSEEnvelope(std.testing.allocator, raw_json);
+    try std.testing.expect(msg_opt == null);
+}
+
+test "parseSSEEnvelope ignores Note to Self from non-allowed sender" {
+    const users = [_][]const u8{"+9999999999"};
+    const ch = SignalChannel.init(
+        std.testing.allocator,
+        "http://127.0.0.1:8686",
+        "+1234567890",
+        &users,
+        &.{},
+        true,
+        true,
+    );
+    const raw_json =
+        \\{
+        \\  "envelope": {
+        \\    "sourceNumber": "+1234567890",
+        \\    "sourceDevice": 1,
+        \\    "timestamp": 1700000000000,
+        \\    "syncMessage": {
+        \\      "sentMessage": {
+        \\        "destinationNumber": "+1234567890",
+        \\        "message": "note to self but not allowed",
+        \\        "timestamp": 1700000001000
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    const msg_opt = try ch.parseSSEEnvelope(std.testing.allocator, raw_json);
+    try std.testing.expect(msg_opt == null);
+}
+
+test "parseSSEEnvelope ignores sync with empty sentMessage" {
+    const users = [_][]const u8{"*"};
+    const ch = SignalChannel.init(
+        std.testing.allocator,
+        "http://127.0.0.1:8686",
+        "+1234567890",
+        &users,
+        &.{},
+        true,
+        true,
+    );
+    const raw_json =
+        \\{
+        \\  "envelope": {
+        \\    "sourceNumber": "+1234567890",
+        \\    "sourceDevice": 1,
+        \\    "syncMessage": {
+        \\      "sentMessage": {
+        \\        "destinationNumber": "+1234567890"
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    const msg_opt = try ch.parseSSEEnvelope(std.testing.allocator, raw_json);
+    try std.testing.expect(msg_opt == null);
+}
+
+test "parseSSEEnvelope ignores Note to Self sync from linked device" {
+    const users = [_][]const u8{"+1234567890"};
+    const ch = SignalChannel.init(
+        std.testing.allocator,
+        "http://127.0.0.1:8686",
+        "+1234567890",
+        &users,
+        &.{},
+        true,
+        true,
+    );
+    const raw_json =
+        \\{
+        \\  "envelope": {
+        \\    "sourceNumber": "+1234567890",
+        \\    "sourceDevice": 3,
+        \\    "timestamp": 1700000000000,
+        \\    "syncMessage": {
+        \\      "sentMessage": {
+        \\        "destinationNumber": "+1234567890",
+        \\        "message": "linked device echo should be dropped",
+        \\        "timestamp": 1700000001000
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    const msg_opt = try ch.parseSSEEnvelope(std.testing.allocator, raw_json);
+    try std.testing.expect(msg_opt == null);
 }

--- a/src/security/policy.zig
+++ b/src/security/policy.zig
@@ -255,7 +255,7 @@ pub const SecurityPolicy = struct {
             if (!found) return false;
 
             // Block dangerous arguments for specific commands
-            if (!isArgsSafe(base_cmd, cmd_part)) return false;
+            if (!isArgsSafe(self, base_cmd, cmd_part)) return false;
         }
 
         return has_cmd;
@@ -550,7 +550,29 @@ fn isCargoMediumVerb(verb: []const u8) bool {
 }
 
 /// Check for dangerous arguments that allow sub-command execution.
-fn isArgsSafe(base_cmd: []const u8, full_cmd: []const u8) bool {
+fn hasParentTraversalSegment(path: []const u8) bool {
+    var iter = std.mem.tokenizeAny(u8, path, "/\\");
+    while (iter.next()) |segment| {
+        if (std.mem.eql(u8, segment, "..")) return true;
+    }
+    return false;
+}
+
+fn isSafeGitChangeDirArg(self: *const SecurityPolicy, raw_arg: []const u8) bool {
+    const trimmed = trimMatchingQuotes(std.mem.trim(u8, raw_arg, " \t"));
+
+    // Per `git -C <path>`, an empty path is a no-op on cwd.
+    if (trimmed.len == 0) return true;
+
+    if (!self.workspace_only) return true;
+
+    // Keep git `-C` scoped to the workspace when workspace_only is enabled.
+    if (std.fs.path.isAbsolute(trimmed)) return false;
+    if (hasParentTraversalSegment(trimmed)) return false;
+    return true;
+}
+
+fn isArgsSafe(self: *const SecurityPolicy, base_cmd: []const u8, full_cmd: []const u8) bool {
     const lower_base = lowerBuf(base_cmd);
     const lower_cmd = lowerBuf(full_cmd);
     const base = lower_base.slice();
@@ -568,18 +590,46 @@ fn isArgsSafe(base_cmd: []const u8, full_cmd: []const u8) bool {
     }
 
     if (std.mem.eql(u8, base, "git")) {
-        // git config, alias, and -c can set dangerous options
+        // Git keeps `-c` and `-C` case-sensitive: `-c` injects config,
+        // `-C` changes directory. We must preserve that distinction while
+        // keeping workspace_only protection intact for `-C`.
         var iter = std.mem.tokenizeScalar(u8, cmd, ' ');
-        _ = iter.next(); // skip "git" itself
+        _ = iter.next(); // skip lowercased "git" itself
+        var orig_iter = std.mem.tokenizeScalar(u8, full_cmd, ' ');
+        _ = orig_iter.next(); // skip original "git" itself
+        var expect_change_dir_arg = false;
         while (iter.next()) |arg| {
+            const orig_arg = orig_iter.next() orelse arg;
+
+            if (expect_change_dir_arg) {
+                if (!isSafeGitChangeDirArg(self, orig_arg)) return false;
+                expect_change_dir_arg = false;
+                continue;
+            }
+
             if (std.mem.eql(u8, arg, "config") or
                 std.mem.startsWith(u8, arg, "config.") or
                 std.mem.eql(u8, arg, "alias") or
                 std.mem.startsWith(u8, arg, "alias.") or
-                std.mem.eql(u8, arg, "-c"))
+                std.mem.eql(u8, orig_arg, "-c") or
+                std.mem.startsWith(u8, orig_arg, "-c") or
+                std.mem.eql(u8, arg, "--config-env") or
+                std.mem.startsWith(u8, arg, "--config-env="))
             {
                 return false;
             }
+
+            if (std.mem.eql(u8, orig_arg, "-C")) {
+                expect_change_dir_arg = true;
+                continue;
+            }
+            if (std.mem.startsWith(u8, orig_arg, "-C") and orig_arg.len > 2) {
+                if (!isSafeGitChangeDirArg(self, orig_arg[2..])) return false;
+            }
+        }
+
+        if (expect_change_dir_arg) {
+            return false;
         }
         return true;
     }
@@ -1304,6 +1354,7 @@ test "git config is blocked" {
     try std.testing.expect(!p.isCommandAllowed("git config core.editor \"rm -rf /\""));
     try std.testing.expect(!p.isCommandAllowed("git alias.st status"));
     try std.testing.expect(!p.isCommandAllowed("git -c core.editor=calc.exe commit"));
+    try std.testing.expect(!p.isCommandAllowed("git --config-env=core.editor=EVIL_EDITOR status"));
 }
 
 test "git status is allowed" {
@@ -1311,6 +1362,21 @@ test "git status is allowed" {
     try std.testing.expect(p.isCommandAllowed("git status"));
     try std.testing.expect(p.isCommandAllowed("git add ."));
     try std.testing.expect(p.isCommandAllowed("git log"));
+}
+
+test "git -C stays workspace-scoped while lowercase -c remains blocked" {
+    const p = SecurityPolicy{};
+    try std.testing.expect(p.isCommandAllowed("git -C . status"));
+    try std.testing.expect(p.isCommandAllowed("git -C ./repo log"));
+    try std.testing.expect(p.isCommandAllowed("git -Crepo status"));
+    try std.testing.expect(!p.isCommandAllowed("git -C /tmp/repo log"));
+    try std.testing.expect(!p.isCommandAllowed("git -C ../repo log"));
+    try std.testing.expect(!p.isCommandAllowed("git -c core.editor=calc.exe commit"));
+}
+
+test "git -C absolute paths are allowed when workspace_only is disabled" {
+    const p = SecurityPolicy{ .workspace_only = false };
+    try std.testing.expect(p.isCommandAllowed("git -C /tmp/repo log"));
 }
 
 test "echo hello | tee /tmp/out is blocked" {


### PR DESCRIPTION
## Summary

This PR now contains two reviewed changes:

1. Tighten `git -C` allowlist handling so uppercase `-C` is not misclassified as dangerous lowercase `-c`, while still keeping `workspace_only` protections intact.
2. Support Signal `Note to Self` sync envelopes, but only when they originate from the primary device (`sourceDevice == 1`), so linked-device sync echoes remain ignored.

## Security fix: `git -C`

The original allowlist lowercased the entire command before checking Git flags, so safe `git -C <dir>` was treated like dangerous `git -c <key>=<value>` and blocked.

The updated policy:

- preserves case-sensitive distinction between `-C` and `-c`
- keeps config injection blocked (`git -c`, `git config`, `git alias`, `--config-env`)
- keeps `workspace_only` semantics intact by allowing only workspace-scoped `-C` paths unless `workspace_only = false`

## Signal fix: `Note to Self`

Signal delivers `Note to Self` as `syncMessage.sentMessage` instead of a normal inbound `dataMessage`, so the previous blanket sync drop prevented those messages from reaching the bot.

The updated channel logic:

- accepts self-directed `syncMessage.sentMessage` envelopes
- requires the message to target the bot account itself
- requires `sourceDevice == 1` so only primary-device user intent is treated as inbound
- continues to drop linked-device sync echoes and outbound sync to other recipients

## Test plan

- [x] `zig build test --summary all`
- [x] Added policy tests for `git -C`, `git -c`, `--config-env`, and `workspace_only`
- [x] Added Signal tests for primary-device Note to Self acceptance and linked-device sync rejection
