### PR TITLE
fix(service): use stable Homebrew path for macOS launchd

### DIFF
--- a/src/service.zig
+++ b/src/service.zig
@@ -285,7 +285,8 @@ fn preferredHomebrewShimPath(allocator: std.mem.Allocator, exe_path: []const u8)
         return null;
     }
 
-    const candidate = try std.fs.path.join(allocator, &.{ exe_path[0..cellar_index], "bin", "nullclaw" });
+    // selfExePath uses POSIX separators for Homebrew installs even when tests run on Windows.
+    const candidate = try std.fmt.allocPrint(allocator, "{s}/bin/nullclaw", .{exe_path[0..cellar_index]});
     return candidate;
 }
 


### PR DESCRIPTION
## Summary
- use the stable Homebrew shim path for launchd plists on macOS
- avoid writing versioned Cellar paths into the LaunchAgent
- add tests for Apple Silicon and Intel Homebrew installs

## Why
`nullclaw service install` could write a versioned Cellar binary path into the plist. After `brew upgrade`, that path disappears and the service silently stops working.

## Validation
- `zig test src/service.zig`
