### PR TITLE
fix(web): vendor websocket and use recv on Windows / 修复(web): 同步 websocket 库并为 Windows 适配 recv

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,8 +8,7 @@
             .path = "vendor/sqlite3",
         },
         .websocket = .{
-            .url = "git+https://github.com/karlseguin/websocket.zig#97fefafa59cc78ce177cff540b8685cd7f699276",
-            .hash = "websocket-0.1.0-ZPISdRlzAwBB_Bz2UMMqxYqF6YEVTIBoFsbzwPUJTHIc",
+            .path = "vendor/websocket",
         },
     },
     .paths = .{

--- a/vendor/websocket/build.zig
+++ b/vendor/websocket/build.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const websocket_module = b.addModule("websocket", .{
+        .target = target,
+        .optimize = optimize,
+        .root_source_file = b.path("src/websocket.zig"),
+    });
+
+    {
+        const options = b.addOptions();
+        options.addOption(bool, "websocket_blocking", false);
+        websocket_module.addOptions("build", options);
+    }
+
+    {
+        // run tests
+        const tests = b.addTest(.{
+            .root_module = websocket_module,
+            .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
+        });
+        tests.linkLibC();
+        const force_blocking = b.option(bool, "force_blocking", "Force blocking mode") orelse false;
+        const options = b.addOptions();
+        options.addOption(bool, "websocket_blocking", force_blocking);
+        tests.root_module.addOptions("build", options);
+
+        const run_test = b.addRunArtifact(tests);
+
+        const test_step = b.step("test", "Run tests");
+        test_step.dependOn(&run_test.step);
+    }
+}

--- a/vendor/websocket/build.zig.zon
+++ b/vendor/websocket/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+	.name = .websocket,
+	.version = "0.1.0",
+	.dependencies = .{},
+	.fingerprint = 0x42ce80b97512f264,
+	.paths = .{
+		"readme.md",
+		"build.zig",
+		"build.zig.zon",
+		"src",
+	},
+}

--- a/vendor/websocket/readme.md
+++ b/vendor/websocket/readme.md
@@ -1,0 +1,655 @@
+# A zig websocket server.
+The master branch targets the latest stable of Zig (0.15.1). The dev branch targets the latest version of Zig. If you're looking for an older version, look for an zig-X.YZ branches.
+
+Skip to the [client section](#client).
+
+If you're upgrading from a previous version, check out the [Server Migration](https://github.com/karlseguin/websocket.zig/wiki/Server-Migration) and [Client Migration](https://github.com/karlseguin/websocket.zig/wiki/Client-Migration) wikis.
+
+# Server
+```zig
+const std = @import("std");
+const ws = @import("websocket");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    var server = try ws.Server(Handler).init(allocator, .{
+        .port = 9224,
+        .address = "127.0.0.1",
+        .handshake = .{
+            .timeout = 3,
+            .max_size = 1024,
+            // since we aren't using hanshake.headers
+            // we can set this to 0 to save a few bytes.
+            .max_headers = 0,
+        },
+    });
+
+    // Arbitrary (application-specific) data to pass into each handler
+    // Pass void ({}) into listen if you have none
+    var app = App{};
+
+    // this blocks
+    try server.listen(&app);
+}
+
+// This is your application-specific wrapper around a websocket connection
+const Handler = struct {
+    app: *App,
+    conn: *ws.Conn,
+
+    // You must define a public init function which takes
+    pub fn init(h: *ws.Handshake, conn: *ws.Conn, app: *App) !Handler {
+        // `h` contains the initial websocket "handshake" request
+        // It can be used to apply application-specific logic to verify / allow
+        // the connection (e.g. valid url, query string parameters, or headers)
+
+        _ = h; // we're not using this in our simple case
+
+        return .{
+            .app = app,
+            .conn = conn,
+        };
+    }
+
+    // You must defined a public clientMessage method
+    pub fn clientMessage(self: *Handler, data: []const u8) !void {
+        try self.conn.write(data); // echo the message back
+    }
+};
+
+// This is application-specific you want passed into your Handler's
+// init function.
+const App = struct {
+  // maybe a db pool
+  // maybe a list of rooms
+};
+```
+
+## Handler
+When you create a `websocket.Server(Handler)`, the specified `Handler` is your structure which will receive messages. It must have a public `init` function and `clientMessage` method. Other methods, such as `close` can optionally be defined.
+
+### init
+The `init` method is called with a `*websocket.Handshake`, a `*websocket.Conn` and whatever app-specific value was passed into `Server(H).init`. 
+
+When `init` is called, the handshake response has not yet been sent to the client (this allows your `init` method to return an error which will cause websocket.zig to send an error response and close the connection). As such, you should not use/write to the `*websocket.Conn` at this point. Instead, use the `afterInit` method, described next.
+
+The websocket specification requires the initial "handshake" to contain certain headers and values. The library validates these headers. However applications may have additional requirements before allowing the connection to be "upgraded" to a websocket connection. For example, a one-time-use token could be required in the querystring. Applications should use the provided `websocket.Handshake` to apply any application-specific verification and optionally return an error to terminate the connection.
+
+The `*websocket.Handshake` exposes the following fields:
+
+* `url: []const u8` - URL of the request in its original casing
+* `method: []const u8` - Method of the request in its original casing
+* `raw_headers: []const u8` - The raw "key1: value1\r\nkey2: value2\r\n" headers. Keys are lowercase.
+
+If you set the `max_headers` configuration value to > 0, then you can use `req.headers.get("HEADER_NAME")` to extract a header value from the given name:
+
+If you set the `max_res_headers` configuration value to > 0, then you can set headers to be sent in the handshake response:
+
+```zig
+pub fn init(h: *ws.Handshake, conn: *ws.Conn, app: *App) !Handler {
+    h.res_headers.add("set-cookie", "delicious")
+    //...
+}
+```
+
+Note that, currently, the total length of the headers added to `res_headers` should not exceed 1024 characters, else you will exeperience an out of bounds segfault.
+
+```zig
+// the last parameter, an *App in this case, is an application-specific
+// value that you passed into server.listen()
+pub fn init(h: *websocket.Handshake, conn: websocket.Conn, app: *App) !Handler {
+    // get returns a ?[]const u8
+    // the name is lowercase
+    // the value is in its original case
+    const token = handshake.headers.get("authorization") orelse {
+        return error.NotAuthorized;
+    }
+
+    return .{
+        .app = app,
+        .conn = conn,
+    };
+}
+
+```
+
+You can iterate through all the headers:
+```zig
+var it = handshake.headers.iterator();
+while (it.next) |kv| {
+    std.debug.print("{s} = {s}\n", .{kv.key, kv.value});
+}
+```
+
+Memory referenced by the `websocket.Handshake`, including headers from `handshake.headers` will be freed after the call to `init` completes. Application that need these values to exist beyond the call to `init` must make a copy.
+
+### afterInit
+If your handler defines a `afterInit(handler: *Handler) !void` method, the method is called after the handshake response has been sent. This is the first time the connection can safely be used.
+
+`afterInit` supports two overloads:
+
+```zig
+pub fn afterInit(handler: *Handler) !void
+pub fn afterInit(handler: *Handler, ctx: anytype) !void
+```
+
+The `ctx` is the same `ctx` passed into `init`. It is passed here for cases where the value is only needed once when the connection is established.
+
+### clientMessage
+The `clientMessage` method is called whenever a text or binary message is received.
+
+The `clientMessage` method can take one of four shapes. The simplest, shown in the first example, is:
+
+```zig
+// simple clientMessage
+clientMessage(h: *Handler, data: []u8) !void
+```
+
+The Websocket specific has a distinct message type for text and binary. Text messages must be valid UTF-8. Websocket.zig does not do this validation (it's expensive and most apps don't care). However, if you do care about the distinction, your `clientMessage` can take another parameter:
+
+```zig
+// clientMessage that accepts a tpe to differentiate between messages
+// sent as `text` vs those sent as `binary`. Either way, Websocket.zig
+// does not validate that text data is valid UTF-8.
+clientMessage(h: *Handler, data: []u8, tpe: ws.MessageTextType) !void
+```
+
+Finally, `clientMessage` can take an optional `std.mem.Allocator`. If you need to dynamically allocate memory within `clientMessage`, consider using this allocator. It is a fast thread-local buffer that fallsback to an arena allocator. Allocations made with this allocator are freed after `clientMessage` returns:
+
+```zig
+// clientMessage that takes an allocator
+clientMessage(h: *Handler, allocator: Allocator, data: []u8) !void
+
+// cilentMessage that takes an allocator AND a MessageTextType
+clientMessage(h: *Handler, allocator: Allocator, data: []u8, tpe: ws.MessageTextType) !void`
+```
+
+If `clientMessage` returns an error, the connection is closed. You can also call `conn.close()` within the method.
+
+### close
+If your handler defines a `close(handler: *Handler) void` method, the method is called whenever the connection is being closed. Guaranteed to be called exactly once, so it is safe to deinitialize the `handler` at this point. This is called no matter the reason for the closure (on shutdown, if the client closed the connection, if your code close the connection, ...)
+
+The socket may or may not still be alive.
+
+### clientClose
+If your handler defines a `clientClose(handler: *Handler, data: []u8) !void` method, the function will be called whenever a `close` message is received from the client. 
+
+You almost certainly *do not* want to define this method and instead want to use `close()`. When not defined, websocket.zig follows the websocket specific and replies with its own matching close message.
+
+### clientPong
+If your handler defines a `clientPong(handler: *Handler, data: []u8) !void` method, the function will be called whenever a `pong` message is received from the client. When not defined, no action is taken.
+
+### clientPing
+If your handler defines a `clientPing(handler: *Handler, data: []u8) !void` method, the function will be called whenever `ping` message is received from the client. When not defined, websocket.zig will write a corresponding `pong` reply.
+
+## websocket.Conn
+The call to `init` includes a `*websocket.Conn`. It is expected that handlers will keep a reference to it. The main purpose of the `*Conn` is to write data via `conn.write([]const u8)` and `conn.writeBin([]const u8)`. The websocket protocol differentiates between a "text" and "binary" message, with the only difference that "text" must be valid UTF-8. This library does not enforce this. Which you use really depends on what your client expects. For browsers, text messages appear as strings, and binary messages appear as a Blob or ArrayBuffer (depending on how the client is configured).
+
+`conn.close(.{})` can also be called to close the connection. Calling `conn.close()` **will** result in the handler's `close` callback being called. 
+
+`close` takes an optional value where you can specify the `code` and/or `reason`: `conn.close(.{.code = 4000, .reason = "bye bye"})` Refer to [RFC6455](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1) for valid codes. The `reason` must be <= 123 bytes.
+
+### Writer
+It's possible to get a `*std.Io.Writer` from a `*Conn`. Because websocket messages are framed, the writter will buffer the message in memory and requires an explicit "send". Buffering requires an allocator. 
+
+```zig
+// .text or .binary
+var wb = conn.writeBuffer(allocator, .text);
+defer wb.deinit();
+try wb.interface.print("it's over {d}!!!", .{9000});
+try wb.send();
+```
+
+Consider using the `clientMessage` overload which accepts an allocator. Not only is this allocator fast (it's a thread-local buffer than fallsback to an arena), but it also eliminates the need to call `deinit`:
+
+```zig
+pub fn clientMessage(h: *Handler, allocator: Allocator, data: []const u8) !void {
+    // Use the provided allocator.
+    // It's faster and doesn't require `deinit` to be called
+
+    var wb = conn.writeBuffer(allocator, .text);
+    try std.fmt.format(wb.writer(), "it's over {d}!!!", .{9000});
+    try wb.send();
+}
+```
+
+## Thread Safety
+Websocket.zig ensures that only 1 message per connection/handler is processed at a time. Therefore, you will never have concurrent calls to `clientMessage`, `clientPing`, `clientPong` or `clientClose`. Conversely, concurrent calls to methods of `*websocket.Conn` are allowed (i.e. `conn.write` and `conn.close`). 
+
+## Config
+The 2nd parameter to `Server(H).init` is a configuration object. 
+
+```zig
+pub const Config = struct {
+    port: u16 = 9882,
+
+    // Ignored if unix_path is set
+    address: []const u8 = "127.0.0.1",
+
+    // Not valid on windows
+    unix_path: ?[]const u8 = null,
+
+    // In nonblocking mode (Linux/Mac/BSD), sets the number of
+    // listening threads. Defaults to 1.
+    // In blocking mode, this is ignored and always set to 1.
+    worker_count: ?u8 = null,
+
+    // The maximum number of connections, per worker.
+    // default: 16_384
+    max_conn: ?usize = null,
+
+    // The maximium allows message size. 
+    // A websocket message can have up to 14 bytes of overhead/header
+    // Default: 65_536
+    max_message_size: ?usize = null,
+
+    handshake: Config.Handshake = .{},
+    thread_pool: ThreadPool = .{},
+    buffers: Config.Buffers = .{},
+
+    // compression is disabled by default
+    compression: ?Compression = null,
+
+    // In blocking mode the thread pool isn't used 
+    pub const ThreadPool = struct {
+        // Number of threads to process messages.
+        // These threads are where your `clientXYZ` method will execute.
+        // Default: 4.
+        count: ?u16 = null,
+
+        // The maximum number of pending requests that the thread pool will accept
+        // This applies back pressure to worker and ensures that, under load
+        // pending requests get precedence over processing new requests.
+        // Default: 500.
+        backlog: ?u32 = null,
+
+        // Size of the static buffer to give each thread. Memory usage will be 
+        // `count * buffer_size`.
+        // If clientMessage isn't defined with an Allocator, this defaults to 0.
+        // Else it default to 32768
+        buffer_size: ?usize = null,
+    };
+
+    const Handshake = struct {
+        // time, in seconds, to timeout the initial handshake request
+        timeout: u32 = 10,
+
+        // Max size, in bytes, allowed for the initial handshake request.
+        // If you're expected a large handshake (many headers, large cookies, etc)
+        // you'll need to set this larger.
+        // Default: 1024
+        max_size: ?u16 = null,
+
+        // Max number of headers to capture. These become available as
+        // handshake.headers.get(...).
+        // Default: 0
+        max_headers: ?u16 = null,
+
+        // Count of handshake objects to keep in a pool. More are created
+        // as needed.
+        // Default: 32
+        count: ?u16 = null,
+    };
+
+    const Buffers = struct {
+        // The number of "small" buffers to keep pooled.
+        //
+        // When `null`, the small buffer pool is disabled and each connection
+        // gets its own dedicated small buffer (of `size`). This is reasonable
+        // when you expect most clients to be sending a steady stream of data.
+        
+        // When set > 0, a pool is created (of `size` buffers) and buffers are 
+        // assigned as messages are received. This is reasonable when you expect
+        // sporadic and messages from clients.
+        //
+        // Default: `null`
+        small_pool: ?usize = null,
+
+        // The size of each "small" buffer. Depending on the value of `pool`
+        // this is either a per-connection buffer, or the size of pool buffers
+        // shared between all connections
+        // Default: 2048
+        small_size: ?usize = null,
+
+        // The number of large buffers to have in the pool.
+        // Messages larger than `buffers.small_size` but smaller than `max_message_size`
+        // will attempt to use a large buffer from the pool.
+        // If the pool is empty, a dynamic buffer is created.
+        // Default: 8
+        large_pool: ?u16 = null,
+
+        // The size of each large buffer.
+        // Default: min(2 * buffers.small_size, max_message_size)
+        large_size: ?usize = null,
+    };
+
+    // Compression is disabled by default, to enable it and accept the default
+    // values, set it to a defautl struct: .{}
+    const Compression = struct {
+        // The mimimum size of data before messages will be compressed
+        // null = message are never compressed when writing messages to the client
+        // If you want to enable compression, 512 is a reasonable default
+        write_threshold: ?usize = null,
+
+        // When compression is enable, and write_treshold != null, every connection
+        // gets an std.ArrayList(u8) to write the compressed message to. When this
+        // is true, the memory allocated to the ArrayList is kept for subsequent
+        // messages (i.e. it calls `clearRetainingCapacity`). When false, the memory
+        // is freed after each message. 
+        // true = more memory, but fewer allocations
+        retain_write_buffer: bool = true,
+    };
+}
+```
+
+## Logging
+websocket.zig uses Zig's built-in scope logging. You can control the log level by having an `std_options` decleration in your program's main file:
+
+```zig
+pub const std_options = std.Options{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .websocket, .level = .err },
+    }
+};
+```
+
+## Advanced
+
+### Pre-Framed Comptime Message
+Websocket message have their own special framing. When you use `conn.write` or `conn.writeBin` the data you provide is "framed" into a correct websocket message. Framing is fast and cheap (e.g., it DOES NOT require an O(N) loop through the data). Nonetheless, there may be be cases where pre-framing messages at compile-time is desired. The `websocket.frameText` and `websocket.frameBin` can be used for this purpose:
+
+```zig
+const UNKNOWN_COMMAND = websocket.frameText("unknown command");
+...
+
+pub fn clientMessage(self: *Handler, data: []const u8) !void {
+    if (std.mem.startsWith(u8, data, "join: ")) {
+        self.handleJoin(data)
+    } else if (std.mem.startsWith(u8, data, "leave: ")) {
+        self.handleLead(data)
+    } else {
+        try self.conn.writeFramed(UNKNOWN_COMMAND);
+    }
+}
+```
+
+### Blocking Mode
+kqueue (BSD, MacOS) or epoll (Linux) are used on supported platforms. On all other platforms (most notably Windows), a more naive thread-per-connection with blocking sockets is used.
+
+The comptime-safe, `websocket.blockingMode() bool` function can be called to determine which mode websocket is running in (when it returns `true`, then you're running the simpler blocking mode).
+
+### Per-Connection Buffers
+In non-blocking mode, the `buffers.small_pool` and `buffers.small_size` should be set for your particular use case. When `buffers.small_pool == null`, each connection gets its own buffer of `buffers.small_size` bytes. This is a good option if you expect most of your clients to be sending a steady stream of data. While it might take more memory (# of connections * buffers.small_size), its faster and minimizes multi-threading overhead.
+
+However, if you expect clients to only send messages sporadically, such as a chat application, enabling the pool can reduce memory usage at the cost of a bit of overhead.
+
+In blocking mode, these settings are ignored and each connection always gets its own buffer (though there is still a shared large buffer pool).
+
+### Stopping
+`server.stop()` can be called to stop the webserver. It is safe to call this from a different thread (i.e. a `sigaction` handler).
+
+## Testing
+The library comes with some helpers for testing.
+
+```zig
+const wt = @import("websocket").testing;
+
+test "handler: echo" {
+    var wtt = wt.init(.{});
+    defer wtt.deinit();
+
+    // create an instance of your handler (however you want)
+    // and use &tww.conn as the *ws.Conn field
+    var handler = Handler{
+        .conn = &wtt.conn,
+    };
+
+    // execute the methods of your handler
+    try handler.clientMessage("hello world");
+
+    // assert what the client should have received
+    try wtt.expectMessage(.text, "hello world");
+}
+```
+
+Besides `expectMessage` you can also call `expectClose()`.
+
+Note that this testing is heavy-handed. It opens up a pair of sockets with one side listening on `127.0.0.1` and accepting a connection from the other. `wtt.conn` is the "server" side of the connection, and assertion happens on the client side.
+
+# Client
+The `*websocket.Client` can be used in one of two ways. At its simplest, after creating a client and initiating a handshake, you simply use <code>write</code> to send messages and <code>read</code> to receive them. First, we create the client and initiate the handshake:
+
+```zig
+pub fn main() !void {
+  var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+  const allocator = gpa.allocator();
+
+  // create the client
+  var client = try websocket.Client.init(allocator, .{
+    .port = 9224,
+    .host = "localhost",
+  });
+  defer client.deinit();
+
+  // send the initial handshake request
+  const request_path = "/ws";
+  try client.handshake(request_path, .{
+    .timeout_ms = 1000,
+    // Raw headers to send, if any. 
+    // A lot of servers require a Host header.
+    // Separate multiple headers using \r\n
+    .headers = "Host: localhost:9224",
+  });
+}
+```
+
+We can then use `read` and `write`. By default, `read` blocks until a message is received (or an error occurs). We can make it return `null` by setting a timeout:
+
+```zig
+  // optional, read will return null after 1 second
+  try client.readTimeout(std.time.ms_per_s * 1);
+
+  // echo messages back to the server until the connection is closed
+  while (true) {
+    // since we didn't set a timeout, client.read() will either
+    // return a message or an error (i.e. it won't return null)
+    const message = (try client.read()) orelse {
+        // no message after our 1 second
+        std.debug.print(".", .{});
+        continue;
+    };
+
+    // must be called once you're done processing the request
+    defer client.done(message);
+
+    switch (message.type) {
+      .text, .binary => {
+        std.debug.print("received: {s}\n", .{message.data});
+        try client.write(message.data);
+      },
+      .ping => try client.writePong(message.data),
+      .pong => {},
+      .close => {
+        try client.close(.{});
+        break;
+      }
+    }
+  }
+}
+```
+
+### Config
+When creating a Client, the 2nd parameter is a configuration object:
+
+* `port` - The port to connect to. Required.
+* `host` - The host/IP address to connect to. The Host:IP value IS NOT automatically put in the header of the handshake request. Required.
+* `max_size` - Maximum incoming message size to allow. The library will dynamically allocate up to this much space per request. Default: `65536`.
+* `buffer_size` - Size of the static buffer that's available for the client to process incoming messages. While there's other overhead, the minimal memory usage of the server will be `# of active clients * buffer_size`. Default: `4096`.
+* `tls` - Whether or not to connect over TLS. Only TLS 1.3 is supported. Default: `false`.
+* `ca_bundle` - Provide a custom `std.crypto.Certificate.Bundle`. Only meaningful when `tls = true`. Default: `null`.
+
+Setting `max_size == buffer_size` is valid and will ensure that no dynamic memory allocation occurs once the connection is established.
+
+Zig only supports TLS 1.3, so this library can only connect to hosts using TLS 1.3. If no `ca_bundle` is provided, the library will create a default bundle per connection.
+
+### Handshake
+`client.handshake()` takes two parameters. The first is the request path. The second is handshake configuration value:
+
+* `timeout_ms` - Timeout, in milliseconds, for the handshake. Default: `10_000` (10 seconds).
+* `headers` - Raw headers to include in the handshake. Multiple headers should be separated by by "\r\n". Many servers require a Host header. Example: `"Host: server\r\nAuthorization: Something"`. Defaul: `null`
+
+### Custom Wrapper
+In more advanced cases, you'll likely want to wrap a `*ws.Client` in your own type and use a background read loop with "callback" methods. Like in the above example, you'll first want to create a client and initialize a handshake:
+
+```zig
+const ws = @import("websocket");
+
+const Handler = struct {
+  client: ws.Client,
+
+  fn init(allocator: std.mem.Allocator) !Handler {
+    var client = try ws.Client.init(allocator, .{
+      .port = 9224,
+      .host = "localhost",
+    });
+    defer client.deinit();
+
+     // send the initial handshake request
+    const request_path = "/ws";
+    try client.handshake(request_path, .{
+      .timeout_ms = 1000,
+      .headers = "host: localhost:9224\r\n",
+    });
+
+    return .{
+      .client = client,
+    };
+  }
+  ```
+
+You can then call `client.readLoopInNewThread()` to start a background listener. Your handler must define a `serverMessage` method:
+
+```zig
+  pub fn startLoop(self: *Handler) !void {
+    // use readLoop for a blocking version
+    const thread = try self.client.readLoopInNewThread(self);
+    thread.detach();
+  }
+
+  pub fn serverMessage(self: *Handler, data: []u8) !void {
+    // echo back to server
+    return self.client.write(data);
+  }
+}
+```
+
+Websockets have a number of different message types. `serverMessage` only receives text and binary messages. If you care about the distinction, you can use an overload:
+
+```zig
+pub fn serverMessage(self: *Handler, data: []u8, tpe: ws.MessageTextType) !void
+```
+
+where `tpe` will be either `.text` or `.binary`. Different callbacks are used for the other message types.
+
+#### Optional Callbacks
+In addition to the required `serverMessage`, you can define optional callbacks.
+
+```zig
+// Guaranteed to be called exactly once when the readLoop exits
+pub fn close(self: *Handler) void
+
+// If omitted, websocket.zig will automatically reply with a pong
+pub fn serverPing(self: *Handler, data: []u8) !void
+
+// If omitted, websocket.zig will ignore this  message
+pub fn serverPong(self: *Handler) !void
+
+// If omitted, websocket.zig will automatically reply with a close message
+pub fn serverClose(self: *Handler) !void
+```
+
+You almost certainly **do not** want to define a `serverClose` method, but instead what do define a `close` method. In your `close` callback, you should call `client.close(.{})` (and optionally pass a code and reason).
+
+## Client
+Whether you're calling `client.read()` explicitly or using `client.readLoopInNewThread()` (or `client.readLoop()`), the `client` API is the same. In both cases, the various `write` methods, as well as `close()` are thread-safe.
+
+### Writing
+It may come as a surprise, but every variation of `write` expects a `[]u8`, not a `[]const u8`. Websocket payloads sent from a client need to be masked, which the websocket.zig library handles. It is obviously more efficient to mutate the given payload versus creating a copy. By taking a `[]u8`, applications with mutable buffers benefit from avoiding the clone. Applications that have immutable buffers will need to create a mutable clone.
+
+```zig
+// write a text message
+pub fn write(self: *Client, data: []u8) !void
+
+// write a text message (same as client.write(data))
+pub fn writeText(self: *Client, data: []u8) !void
+
+// write a binary message
+pub fn writeBin(self: *Client, data: []u8) !void
+
+// write a ping message
+pub fn writePing(self: *Client, data: []u8) !void
+
+// write a pong message
+// if you don't define a handlePong message, websocket.zig
+// will automatically answer any ping with a pong
+pub fn writePong(self: *Client, data: []u8) !void
+
+// lower-level, use by all of the above
+pub fn writeFrame(self: *Client, op_code: proto.OpCode, data: []u8) !void
+```
+
+### Reading
+As seen above, most applications will either chose to call `read()` explicitly or use a `readLoop`. It is **not safe* to call `read` while the read loop is running.
+
+```zig
+// Reads 1 message. Returns null on timeout
+// Set a timeout using `client.readTimeout(ms)`
+pub fn read(self: *Client) !?ws.Message
+
+
+// Starts a readloop in the calling thread. 
+// `@TypeOf(handler)` must define the `serverMessage` callback
+// (and may define other optional callbacks)
+pub fn readLoop(self: *Client, handler: anytype) !void
+
+// Same as `readLoop` but starts the readLoop in a new thread
+pub fn readLoopInNewThread(self: *Client, h: anytype) !std.Thread
+```
+
+### Closing
+Use `try client.close(.{.code = 4000, .reason = "bye"})` to both send a close frame and close the connection. Noop if the connection is already known to be close. Thread safe.
+
+Both `code` and `reason` are optional. Refer to [RFC6455](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1) for valid codes. The `reason` must be <= 123 bytes.
+
+
+### Performance Optimization 1 - CA Bundle
+For a high number of connections, it might be beneficial to manage our own CA bundle:
+
+```zig
+// some global data
+var ca_bundle = std.crypto.Certificate.Bundle{}
+try ca_bundle.rescan(allocator);
+defer ca_bundle.deinit(allocator);
+```
+
+And then assign this `ca_bundle` into the the configuration's `ca_bundle` field. This way the library does not have to create and scan the installed CA certificates for each client connection.
+
+### Performance Optimization 2 - Buffer Provider
+For a high nummber of connections a large buffer pool can be created and provided to each client:
+
+```zig
+// Create a buffer pool of 10 buffers, each being 32K
+const buffer_provider = try websocket.bufferProvider(allocator, 10, 32768);
+defer buffer_provider.deinit();
+
+
+// create your client(s) using the above created buffer_provider
+var client = try websocket.connect(allocator, "localhost", 9001, .{
+    ...
+    .buffer_provider = buffer_provider,
+});
+```
+
+This allows each client to have a reasonable `buffer_size` that can accomodate most messages, while having an efficient fallback for the occasional large message. When `max_size` is greater than the large buffer pool size (32K in the above example) or when all pooled buffers are used, a dynamic buffer is created.

--- a/vendor/websocket/src/buffer.zig
+++ b/vendor/websocket/src/buffer.zig
@@ -1,0 +1,371 @@
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+
+pub const Buffer = struct {
+    data: []u8,
+    type: Type,
+
+    const Type = enum {
+        static,
+        pooled,
+        dynamic,
+    };
+};
+
+pub const Writer = struct {
+    buf: []u8,
+    pos: usize = 0,
+    pooled: bool,
+    provider: *Provider,
+    interface: std.Io.Writer,
+
+    pub fn init(buf: []u8, pooled: bool, provider: *Provider, dumb: []u8) Writer {
+        return .{
+            .buf = buf,
+            .pooled = pooled,
+            .provider = provider,
+            .interface = .{
+                .buffer = dumb,
+                .vtable = &.{
+                    .drain = drain,
+                },
+            },
+        };
+    }
+
+    pub fn deinit(self: *Writer) void {
+        if (self.pooled) {
+            self.provider.pool.release(self.buf);
+        } else {
+            self.provider.allocator.free(self.buf);
+        }
+    }
+
+    pub fn drain(io_w: *std.Io.Writer, data: []const []const u8, splat: usize) error{WriteFailed}!usize {
+        std.debug.print("drain: {d}\n", .{data[0].len});
+        _ = splat;
+        const self: *Writer = @alignCast(@fieldParentPtr("interface", io_w));
+        self.writeAll(data[0]) catch return error.WriteFailed;
+        return data[0].len;
+    }
+
+    pub fn writeAll(self: *Writer, data: []const u8) !void {
+        const pos = self.pos;
+        const total_len = pos + data.len;
+        if (total_len > self.provider.max_buffer_size) {
+            return error.TooLarge;
+        }
+        try self.ensureTotalCapacity(total_len);
+
+        @memcpy(self.buf[pos..total_len], data);
+        self.pos = total_len;
+    }
+
+    fn ensureTotalCapacity(self: *Writer, required_capacity: usize) !void {
+        const buf = self.buf;
+        if (required_capacity <= buf.len) {
+            return;
+        }
+
+        // from std.ArrayList
+        var new_capacity = buf.len;
+        while (true) {
+            new_capacity +|= new_capacity / 2 + 8;
+            if (new_capacity >= required_capacity) break;
+        }
+
+        const allocator = self.provider.allocator;
+        if (self.pooled or !allocator.resize(buf, new_capacity)) {
+            const new_buffer = try allocator.alloc(u8, new_capacity);
+            @memcpy(new_buffer[0..buf.len], buf);
+
+            if (self.pooled) {
+                self.provider.pool.release(buf);
+            }
+
+            self.buf = new_buffer;
+            self.pooled = false;
+        } else {
+            const new_buffer = buf.ptr[0..new_capacity];
+            self.buf = new_buffer;
+        }
+    }
+};
+
+pub const Config = struct {
+    count: u16 = 1,
+    size: usize = 65536,
+    max: usize = 65536,
+};
+
+// Manages all buffer access and types. It's where code goes to ask
+// for and release buffers.
+pub const Provider = struct {
+    pool: Pool,
+    allocator: Allocator,
+
+    max_buffer_size: usize,
+
+    // If this is 0, pool is undefined. We need this field here anyways.
+    pool_buffer_size: usize,
+
+    pub fn init(allocator: Allocator, config: Config) !Provider {
+        const size = config.size;
+        const count = config.count;
+
+        if (count == 0 or size == 0) {
+
+            // Large buffering can be disabled, in which case any large buffers will
+            // be dynamically allocated using the allocator (assuming the requested
+            // size is less than the max_message_size)
+            return .{
+                // this is safe to do, because we set size = 0, so we'll
+                // never try to access the pool
+                .pool = undefined,
+                .pool_buffer_size = 0,
+                .allocator = allocator,
+                .max_buffer_size = config.max,
+            };
+        }
+
+        return .{
+            .allocator = allocator,
+            .pool_buffer_size = size,
+            .max_buffer_size = config.max,
+            .pool = try Pool.init(allocator, count, size),
+        };
+    }
+
+    pub fn deinit(self: *Provider) void {
+        if (self.pool_buffer_size > 0) {
+            // else, pool is undefined
+            self.pool.deinit();
+        }
+    }
+
+    pub fn alloc(self: *Provider, size: usize) !Buffer {
+        if (size > self.max_buffer_size) {
+            return error.TooLarge;
+        }
+
+        // remember: if self.pool_buffer_size == 0, then self.pool is undefined.
+        if (size <= self.pool_buffer_size) {
+            if (self.pool.acquire()) |buffer| {
+                // See the Reader struct comment to see why this is necessary
+                var copy = buffer;
+                copy.len = size;
+                return .{ .type = .pooled, .data = copy };
+            }
+        }
+
+        return .{
+            .type = .dynamic,
+            .data = try self.allocator.alloc(u8, size),
+        };
+    }
+
+    pub fn grow(self: *Provider, buffer: Buffer, current_size: usize, new_size: usize) !Buffer {
+        if (new_size > self.max_buffer_size) {
+            return error.TooLarge;
+        }
+
+        if (buffer.type == .dynamic) {
+            var copy = buffer;
+            copy.data = try self.allocator.realloc(buffer.data, new_size);
+            return copy;
+        }
+
+        defer self.release(buffer);
+
+        const new_buffer = try self.alloc(new_size);
+        @memcpy(new_buffer.data[0..current_size], buffer.data[0..current_size]);
+        return new_buffer;
+    }
+
+    pub fn free(self: *Provider, buffer: Buffer) void {
+        switch (buffer.type) {
+            .pooled => {
+                // this resize is necessary because on alloc, we potentially shrink data
+                var copy = buffer.data;
+                copy.len = self.pool_buffer_size;
+                self.pool.release(copy);
+            },
+            .static => self.allocator.free(buffer.data),
+            .dynamic => self.allocator.free(buffer.data),
+        }
+    }
+
+    pub fn release(self: *Provider, buffer: Buffer) void {
+        switch (buffer.type) {
+            .static => {},
+            .pooled => {
+                // this resize is necessary because on alloc, we potentially shrink data
+                var copy = buffer.data;
+                copy.len = self.pool_buffer_size;
+                self.pool.release(copy);
+            },
+            .dynamic => self.allocator.free(buffer.data),
+        }
+    }
+};
+
+pub const Pool = struct {
+    buffer_size: usize,
+    available: usize,
+    buffers: [][]u8,
+    allocator: Allocator,
+    mutex: std.Thread.Mutex,
+
+    pub fn init(allocator: Allocator, count: usize, buffer_size: usize) !Pool {
+        const buffers = try allocator.alloc([]u8, count);
+
+        for (0..count) |i| {
+            buffers[i] = try allocator.alloc(u8, buffer_size);
+        }
+
+        return .{
+            .mutex = .{},
+            .buffers = buffers,
+            .available = count,
+            .allocator = allocator,
+            .buffer_size = buffer_size,
+        };
+    }
+
+    pub fn deinit(self: *Pool) void {
+        const allocator = self.allocator;
+        for (self.buffers) |buf| {
+            allocator.free(buf);
+        }
+        allocator.free(self.buffers);
+    }
+
+    pub fn acquire(self: *Pool) ?[]u8 {
+        const buffers = self.buffers;
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const available = self.available;
+        if (available == 0) {
+            return null;
+        }
+        const index = available - 1;
+        const buffer = buffers[index];
+        self.available = index;
+        return buffer;
+    }
+
+    pub fn acquireOrCreate(self: *Pool) ![]u8 {
+        return self.acquire() orelse self.allocator.alloc(u8, self.buffer_size);
+    }
+
+    pub fn release(self: *Pool, buffer: []u8) void {
+        var buffers = self.buffers;
+
+        self.mutex.lock();
+        const available = self.available;
+        if (available == buffers.len) {
+            self.mutex.unlock();
+            self.allocator.free(buffer);
+            return;
+        }
+        buffers[available] = buffer;
+        self.available = available + 1;
+        self.mutex.unlock();
+    }
+};
+
+const t = @import("t.zig");
+test "buffer: no pool" {
+    var p = try Provider.init(t.allocator, .{ .count = 0, .size = 0, .max = 100 });
+
+    const buffer = try p.alloc(100);
+    defer p.free(buffer);
+    try t.expectEqual(.dynamic, buffer.type);
+    try t.expectEqual(100, buffer.data.len);
+}
+
+test "buffer: pool" {
+    var p = try Provider.init(t.allocator, .{ .count = 2, .size = 10, .max = 15 });
+    defer p.deinit();
+
+    {
+        // bigger than allowed
+        try t.expectError(error.TooLarge, p.alloc(16));
+    }
+
+    {
+        // bigger than our buffers in pool
+        const buffer = try p.alloc(15);
+        defer p.free(buffer);
+        try t.expectEqual(.dynamic, buffer.type);
+        try t.expectEqual(15, buffer.data.len);
+    }
+
+    {
+        // smaller than our buffers in pool
+        const buf1 = try p.alloc(4);
+        try t.expectEqual(.pooled, buf1.type);
+        try t.expectEqual(4, buf1.data.len);
+
+        const buf2 = try p.alloc(5);
+        try t.expectEqual(.pooled, buf2.type);
+        try t.expectEqual(5, buf2.data.len);
+        try t.expectEqual(true, buf1.data.ptr != buf2.data.ptr);
+
+        // no more buffers in the pool, creats a dynamic buffer
+        const buf3 = try p.alloc(6);
+        try t.expectEqual(.dynamic, buf3.type);
+        try t.expectEqual(6, buf3.data.len);
+
+        p.release(buf1);
+
+        const buf4 = try p.alloc(7);
+        try t.expectEqual(.pooled, buf4.type);
+        try t.expectEqual(7, buf4.data.len);
+        try t.expectEqual(true, buf1.data.ptr == buf4.data.ptr);
+
+        p.release(buf2);
+        p.release(buf3);
+    }
+}
+
+test "buffer: grow" {
+    var p = try Provider.init(t.allocator, .{ .count = 1, .size = 10, .max = 30 });
+    defer p.deinit();
+
+    {
+        // grow a dynamic buffer
+        var buf1 = try p.alloc(15);
+        @memcpy(buf1.data[0..5], "hello");
+        const buf2 = try p.grow(buf1, 5, 20);
+        defer p.free(buf2);
+        try t.expectEqual(20, buf2.data.len);
+        try t.expectString("hello", buf2.data[0..5]);
+    }
+
+    {
+        // grow a static buffer
+        var buf1 = Buffer{ .type = .static, .data = try t.allocator.alloc(u8, 15) };
+        defer t.allocator.free(buf1.data);
+        @memcpy(buf1.data[0..6], "hello2");
+
+        const buf2 = try p.grow(buf1, 6, 21);
+        defer p.free(buf2);
+        try t.expectEqual(21, buf2.data.len);
+        try t.expectString("hello2", buf2.data[0..6]);
+    }
+
+    {
+        // grow a pooled buffer
+        var buf1 = try p.alloc(8);
+
+        @memcpy(buf1.data[0..7], "hello2a");
+        const buf2 = try p.grow(buf1, 7, 14);
+        defer p.free(buf2);
+        try t.expectEqual(14, buf2.data.len);
+        try t.expectString("hello2a", buf2.data[0..7]);
+        try t.expectEqual(1, p.pool.available);
+    }
+}

--- a/vendor/websocket/src/client/client.zig
+++ b/vendor/websocket/src/client/client.zig
@@ -1,0 +1,1047 @@
+const std = @import("std");
+const proto = @import("../proto.zig");
+const buffer = @import("../buffer.zig");
+
+const ascii = std.ascii;
+const net = std.net;
+const posix = std.posix;
+const tls = std.crypto.tls;
+const log = std.log.scoped(.websocket);
+
+const Reader = proto.Reader;
+const Allocator = std.mem.Allocator;
+const Bundle = std.crypto.Certificate.Bundle;
+const CompressionOpts = @import("../websocket.zig").Compression;
+const ServerHandshake = @import("../server/handshake.zig").Handshake;
+
+fn ReadLoopHandler(comptime T: type) type {
+    const info = @typeInfo(T);
+
+    switch (info) {
+        .@"struct" => |struct_info| {
+            if (struct_info.is_tuple)
+                @compileError("readLoop: handler does not support tuples.");
+
+            return T;
+        },
+        .pointer => |ptr_info| {
+            switch (ptr_info.size) {
+                .one => return ReadLoopHandler(ptr_info.child),
+                else => @compileError("readLoop: handler does not support Slice, C and Many pointers."),
+            }
+        },
+        else => @compileError("readLoop: expected handler to be a struct or pointer to a struct but found '" ++ @tagName(info) ++ "'"),
+    }
+}
+
+pub const Client = struct {
+    stream: Stream,
+    _reader: Reader,
+    _closed: bool,
+    _compression_opts: ?CompressionOpts,
+    _compression: ?Client.Compression = null,
+
+    // When creating a client, we can either be given a BufferProvider or create
+    // one ourselves. If we create it ourselves (in init), we "own" it and must
+    // free it on deinit. (The reference to the buffer provider is already in the
+    // reader, no need to hold another reference in the client).
+    _own_bp: bool,
+
+    // For advanced cases, a custom masking function can be provided. Masking
+    // is a security feature that only really makes sense in the browser. If you
+    // aren't running websockets in the browser AND you control both the client
+    // and the server, you could get a performance boost by not masking.
+    _mask_fn: *const fn () [4]u8,
+
+    pub const Config = struct {
+        port: u16,
+        host: []const u8,
+        tls: bool = false,
+        max_size: usize = 65536,
+        buffer_size: usize = 4096,
+        ca_bundle: ?Bundle = null,
+        mask_fn: *const fn () [4]u8 = generateMask,
+        buffer_provider: ?*buffer.Provider = null,
+        compression: ?CompressionOpts = null,
+    };
+
+    pub const HandshakeOpts = struct {
+        timeout_ms: u32 = 10000,
+        headers: ?[]const u8 = null,
+    };
+
+    const Compression = struct {
+        allocator: Allocator,
+        retain_writer: bool,
+        write_treshold: usize,
+        writer: std.Io.Writer.Allocating,
+    };
+
+    pub fn init(allocator: Allocator, config: Config) !Client {
+        if (config.compression != null) {
+            log.err("Compression is disabled as part of the 0.15 upgrade. I do hope to re-enable it soon.", .{});
+            return error.InvalidConfiguraion;
+        }
+
+        const net_stream = try net.tcpConnectToHost(allocator, config.host, config.port);
+
+        var tls_client: ?*TLSClient = null;
+        if (config.tls) {
+            tls_client = try TLSClient.init(allocator, net_stream, &config);
+        }
+        const stream = Stream.init(net_stream, tls_client);
+
+        var own_bp = false;
+        var buffer_provider: *buffer.Provider = undefined;
+
+        // If a buffer_provider is provided, we'll use that.
+        // If it isn't, we need to create one which also means we now "own" it
+        // and we're responsible for cleaning it up
+        if (config.buffer_provider) |shared_bp| {
+            buffer_provider = shared_bp;
+        } else {
+            own_bp = true;
+            buffer_provider = try allocator.create(buffer.Provider);
+            errdefer allocator.destroy(buffer_provider);
+            buffer_provider.* = try buffer.Provider.init(allocator, .{
+                .size = 0,
+                .count = 0,
+                .max = config.max_size,
+            });
+        }
+
+        errdefer if (own_bp) {
+            buffer_provider.deinit();
+            allocator.destroy(buffer_provider);
+        };
+
+        const reader_buf = try buffer_provider.allocator.alloc(u8, config.buffer_size);
+        errdefer buffer_provider.allocator.free(reader_buf);
+
+        return .{
+            .stream = stream,
+            ._closed = false,
+            ._own_bp = own_bp,
+            ._mask_fn = config.mask_fn,
+            ._compression_opts = null, //TODO: ZIG 0.15
+            ._reader = Reader.init(reader_buf, buffer_provider, null),
+        };
+    }
+
+    pub fn deinit(self: *Client) void {
+        self.closeStream();
+
+        const larger_buffer_provider = self._reader.large_buffer_provider;
+        const allocator = larger_buffer_provider.allocator;
+        allocator.free(self._reader.static);
+
+        self._reader.deinit();
+
+        if (self._own_bp) {
+            larger_buffer_provider.deinit();
+            allocator.destroy(larger_buffer_provider);
+        }
+    }
+
+    pub fn handshake(self: *Client, path: []const u8, opts: HandshakeOpts) !void {
+        const stream = &self.stream;
+        errdefer self.closeStream();
+
+        // we've already setup our reader, and the reader has a static buffer
+        // we might as well use it!
+        const buf = self._reader.static;
+        const key = blk: {
+            const bin_key = generateKey();
+            var encoded_key: [24]u8 = undefined;
+            break :blk std.base64.standard.Encoder.encode(&encoded_key, &bin_key);
+        };
+
+        try sendHandshake(path, key, buf, &opts, self._compression_opts != null, stream);
+
+        const res = try HandShakeReply.read(buf, key, &opts, self._compression_opts != null, stream);
+        errdefer self.close(.{ .code = 1001 }) catch unreachable;
+
+        // Set up compression with agreed-on parameters
+        if (res.compression) {
+            try self.setupCompression();
+        }
+
+        // We might have read more than handshake response. If so, readHandshakeReply
+        // has positioned the extra data at the start of the buffer, but we need
+        // to set the length.
+        self._reader.pos = res.over_read;
+    }
+
+    fn setupCompression(self: *Client) !void {
+        std.debug.assert(self._compression_opts != null);
+        self._reader.allow_compressed = true;
+
+        const allocator = self._reader.large_buffer_provider.allocator;
+        const config = self._compression_opts.?;
+        self._compression = .{
+            .allocator = allocator,
+            .write_treshold = config.write_threshold.?,
+            .retain_writer = config.retain_write_buffer,
+            .writer = std.Io.Writer.Allocating.init(allocator),
+        };
+    }
+
+    pub fn readLoop(self: *Client, handler: anytype) !void {
+        const Handler = ReadLoopHandler(@TypeOf(handler));
+        var reader = &self._reader;
+
+        defer if (comptime std.meta.hasFn(Handler, "close")) {
+            handler.close();
+        };
+
+        // block until we have data
+        try self.readTimeout(0);
+
+        while (true) {
+            const message = self.read() catch |err| switch (err) {
+                error.Closed => return,
+                else => return err,
+            } orelse unreachable;
+
+            const message_type = message.type;
+            defer reader.done(message_type);
+
+            switch (message_type) {
+                .text, .binary => {
+                    switch (comptime @typeInfo(@TypeOf(Handler.serverMessage)).@"fn".params.len) {
+                        2 => try handler.serverMessage(message.data),
+                        3 => try handler.serverMessage(message.data, if (message_type == .text) .text else .binary),
+                        else => @compileError(@typeName(Handler) ++ ".serverMessage must accept 2 or 3 parameters"),
+                    }
+                },
+                .ping => if (comptime std.meta.hasFn(Handler, "serverPing")) {
+                    try handler.serverPing(message.data);
+                } else {
+                    // @constCast is safe because we know message.data points to
+                    // reader.buffer.buf, which we own and which can be mutated
+                    try self.writeFrame(.pong, @constCast(message.data));
+                },
+                .close => {
+                    if (comptime std.meta.hasFn(Handler, "serverClose")) {
+                        try handler.serverClose(message.data);
+                    } else {
+                        self.close(.{}) catch unreachable;
+                    }
+                    return;
+                },
+                .pong => if (comptime std.meta.hasFn(Handler, "serverPong")) {
+                    try handler.serverPong(message.data);
+                },
+            }
+        }
+    }
+
+    pub fn read(self: *Client) !?proto.Message {
+        var reader = &self._reader;
+        const stream = &self.stream;
+
+        while (true) {
+            // try to read a message from our buffer first, before trying to
+            // get more data from the socket.
+            const has_more, const message = reader.read() catch |err| {
+                self.close(.{ .code = 1002 }) catch unreachable;
+                return err;
+            } orelse {
+                reader.fill(stream) catch |err| switch (err) {
+                    error.WouldBlock => return null,
+                    error.Closed, error.ConnectionResetByPeer, error.BrokenPipe, error.NotOpenForReading => {
+                        @atomicStore(bool, &self._closed, true, .monotonic);
+                        return error.Closed;
+                    },
+                    else => {
+                        self.close(.{ .code = 1002 }) catch unreachable;
+                        return err;
+                    },
+                };
+                continue;
+            };
+
+            _ = has_more;
+            return message;
+        }
+    }
+
+    pub fn done(self: *Client, message: proto.Message) void {
+        self._reader.done(message.type);
+    }
+
+    pub fn readLoopInNewThread(self: *Client, h: anytype) !std.Thread {
+        return std.Thread.spawn(.{}, readLoopOwnedThread, .{ self, h });
+    }
+
+    fn readLoopOwnedThread(self: *Client, h: anytype) void {
+        self.readLoop(h) catch {};
+    }
+
+    pub fn writeTimeout(self: *const Client, ms: u32) !void {
+        return self.stream.writeTimeout(ms);
+    }
+
+    pub fn readTimeout(self: *const Client, ms: u32) !void {
+        return self.stream.readTimeout(ms);
+    }
+
+    pub fn write(self: *Client, data: []u8) !void {
+        return self.writeFrame(.text, data);
+    }
+
+    pub fn writeText(self: *Client, data: []u8) !void {
+        return self.writeFrame(.text, data);
+    }
+
+    pub fn writeBin(self: *Client, data: []u8) !void {
+        return self.writeFrame(.binary, data);
+    }
+
+    pub fn writePing(self: *Client, data: []u8) !void {
+        return self.writeFrame(.ping, data);
+    }
+
+    pub fn writePong(self: *Client, data: []u8) !void {
+        return self.writeFrame(.pong, data);
+    }
+
+    const CloseOpts = struct {
+        code: ?u16 = null,
+        reason: []const u8 = "",
+    };
+
+    pub fn close(self: *Client, opts: CloseOpts) !void {
+        if (@atomicRmw(bool, &self._closed, .Xchg, true, .monotonic) == true) {
+            // already closed
+            return;
+        }
+
+        defer self.stream.close();
+
+        const code = opts.code orelse {
+            self.writeFrame(.close, "") catch {};
+            return;
+        };
+
+        const reason = opts.reason;
+        if (reason.len > 123) {
+            return error.ReasonTooLong;
+        }
+
+        var buf: [125]u8 = undefined;
+        buf[0] = @intCast((code >> 8) & 0xFF);
+        buf[1] = @intCast(code & 0xFF);
+
+        const end = 2 + reason.len;
+        @memcpy(buf[2..end], reason);
+        self.writeFrame(.close, buf[0..end]) catch {};
+    }
+
+    pub fn writeFrame(self: *Client, op_code: proto.OpCode, data: []u8) !void {
+        const payload = data;
+        const compressed = false;
+        // if (self._compression) |c| {
+        //     if (data.len >= c.write_treshold and (op_code == .binary or op_code == .text)) {
+        //         compressed = true;
+
+        //         var writer = &c.writer;
+        //         var compressor = &c.compressor;
+        //         var fbs = std.io.fixedBufferStream(data);
+        //         _ = try compressor.compress(fbs.reader());
+        //         try compressor.flush();
+        //         payload = writer.items[0 .. writer.items.len - 4];
+
+        //         if (c.reset) {
+        //             c.compressor = try Compression.Type.init(writer.writer(), .{});
+        //         }
+        //     }
+        // }
+        // defer if (compressed) {
+        //     const c = self._compression.?;
+        //     if (c.retain_writer) {
+        //         c.compressor.wrt.context.clearRetainingCapacity();
+        //     } else {
+        //         c.compressor.wrt.context.clearAndFree();
+        //     }
+        // };
+
+        // maximum possible prefix length. op_code + length_type + 8byte length + 4 byte mask
+        var buf: [14]u8 = undefined;
+        const header = proto.writeFrameHeader(&buf, op_code, payload.len, compressed);
+
+        const header_len = header.len;
+        const header_end = header.len + 4; // for the mask
+
+        buf[1] |= 128; // indicate that the payload is masked
+
+        const mask = self._mask_fn();
+        @memcpy(buf[header_len..header_end], &mask);
+        try self.stream.writeAll(buf[0..header_end]);
+
+        if (payload.len > 0) {
+            proto.mask(&mask, payload);
+            try self.stream.writeAll(payload);
+        }
+    }
+
+    fn closeStream(self: *Client) void {
+        if (@atomicRmw(bool, &self._closed, .Xchg, true, .monotonic) == false) {
+            self.stream.close();
+        }
+    }
+};
+
+// wraps a net.Stream and optional a tls.Client
+pub const Stream = struct {
+    stream: net.Stream,
+    tls_client: ?*TLSClient = null,
+
+    pub fn init(stream: net.Stream, tls_client: ?*TLSClient) Stream {
+        return .{
+            .stream = stream,
+            .tls_client = tls_client,
+        };
+    }
+
+    pub fn close(self: *Stream) void {
+        const fd = self.stream.handle;
+        const builtin = @import("builtin");
+        const native_os = builtin.os.tag;
+
+        if (self.tls_client) |tls_client| {
+            // Shutdown the socket first, so readLoop() can exit, before tls_client's buffers are freed
+            if (native_os == .windows) {
+                _ = std.os.windows.ws2_32.shutdown(fd, std.os.windows.ws2_32.SD_BOTH);
+            } else if (native_os == .wasi and !builtin.link_libc) {
+                _ = std.os.wasi.sock_shutdown(fd, .{ .WR = true, .RD = true });
+            } else {
+                std.posix.shutdown(fd, .both) catch {};
+            }
+            tls_client.deinit();
+        }
+
+        // std.posix.close panics on EBADF
+        // This is a general issue in Zig:
+        // https://github.com/ziglang/zig/issues/6389
+        //
+        // we don't want to crash on double close
+
+        if (native_os == .windows) {
+            return std.os.windows.CloseHandle(fd);
+        }
+        if (native_os == .wasi and !builtin.link_libc) {
+            _ = std.os.wasi.fd_close(fd);
+            return;
+        }
+        _ = std.posix.system.close(fd);
+    }
+
+    pub fn read(self: *Stream, buf: []u8) !usize {
+        if (self.tls_client) |tls_client| {
+            var w: std.Io.Writer = .fixed(buf);
+            while (true) {
+                const n = try tls_client.client.reader.stream(&w, .limited(buf.len));
+                if (n != 0) {
+                    return n;
+                }
+            }
+        }
+        return self.stream.read(buf);
+    }
+
+    pub fn writeAll(self: *Stream, data: []const u8) !void {
+        if (self.tls_client) |tls_client| {
+            try tls_client.client.writer.writeAll(data);
+            // I know this looks silly, but as far as I can tell, this is what
+            // we need to do.
+            try tls_client.client.writer.flush();
+            try tls_client.stream_writer.interface.flush();
+            return;
+        }
+        return self.stream.writeAll(data);
+    }
+
+    const zero_timeout = std.mem.toBytes(posix.timeval{ .sec = 0, .usec = 0 });
+    pub fn writeTimeout(self: *const Stream, ms: u32) !void {
+        return self.setTimeout(posix.SO.SNDTIMEO, ms);
+    }
+
+    pub fn readTimeout(self: *const Stream, ms: u32) !void {
+        return self.setTimeout(posix.SO.RCVTIMEO, ms);
+    }
+
+    fn setTimeout(self: *const Stream, opt_name: u32, ms: u32) !void {
+        if (ms == 0) {
+            return self.setsockopt(opt_name, &zero_timeout);
+        }
+
+        const timeout = std.mem.toBytes(posix.timeval{
+            .sec = @intCast(@divTrunc(ms, 1000)),
+            .usec = @intCast(@mod(ms, 1000) * 1000),
+        });
+        return self.setsockopt(opt_name, &timeout);
+    }
+
+    pub fn setsockopt(self: *const Stream, opt_name: u32, value: []const u8) !void {
+        return posix.setsockopt(self.stream.handle, posix.SOL.SOCKET, opt_name, value);
+    }
+};
+
+const TLSClient = struct {
+    client: tls.Client,
+    stream: net.Stream,
+    stream_writer: net.Stream.Writer,
+    stream_reader: net.Stream.Reader,
+    arena: std.heap.ArenaAllocator,
+
+    fn init(allocator: Allocator, stream: net.Stream, config: *const Client.Config) !*TLSClient {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const aa = arena.allocator();
+
+        const bundle = config.ca_bundle orelse blk: {
+            var b = Bundle{};
+            try b.rescan(aa);
+            break :blk b;
+        };
+
+        // The TLS input and output have to be max_ciphertext_record_len each.
+        // It isn't clear to me how big the un-encrypted reader and writer
+        // need to be. I would think 0, but that will fail an assertion. I
+        // don't think that it's right that we need 4 buffers, but apparently
+        // we do. Until i figure this out, using 4 x max_ciphertext_record_len
+        // seems like the only safe choice.
+        const buf_len = std.crypto.tls.max_ciphertext_record_len;
+        var buf = try aa.alloc(u8, buf_len * 4);
+
+        const self = try aa.create(TLSClient);
+        self.* = .{
+            .stream = stream,
+            .arena = arena,
+            .client = undefined,
+            .stream_writer = stream.writer(buf.ptr[0..buf_len][0..buf_len]),
+            .stream_reader = stream.reader(buf.ptr[buf_len .. 2 * buf_len][0..buf_len]),
+        };
+
+        self.client = try tls.Client.init(
+            self.stream_reader.interface(),
+            &self.stream_writer.interface,
+            .{
+                .ca = .{ .bundle = bundle },
+                .host = .{ .explicit = config.host },
+                .read_buffer = buf.ptr[2 * buf_len .. 3 * buf_len][0..buf_len],
+                .write_buffer = buf.ptr[3 * buf_len .. 4 * buf_len][0..buf_len],
+            },
+        );
+
+        return self;
+    }
+
+    fn deinit(self: *TLSClient) void {
+        _ = self.client.end() catch {};
+        self.arena.deinit();
+    }
+};
+
+fn generateKey() [16]u8 {
+    if (comptime @import("builtin").is_test) {
+        return [16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    }
+    var key: [16]u8 = undefined;
+    std.crypto.random.bytes(&key);
+    return key;
+}
+
+fn generateMask() [4]u8 {
+    var m: [4]u8 = undefined;
+    std.crypto.random.bytes(&m);
+    return m;
+}
+
+fn sendHandshake(path: []const u8, key: []const u8, buf: []u8, opts: *const Client.HandshakeOpts, compression: bool, stream: anytype) !void {
+    @memcpy(buf[0..4], "GET ");
+    var pos: usize = 4;
+    var end = pos + path.len;
+
+    {
+        @memcpy(buf[pos..end], path);
+        pos = end;
+    }
+
+    {
+        const headers = " HTTP/1.1\r\ncontent-length: 0\r\nupgrade: websocket\r\nsec-websocket-version: 13\r\nconnection: upgrade\r\nsec-websocket-key: ";
+        end = pos + headers.len;
+        @memcpy(buf[pos..end], headers);
+
+        pos = end;
+        end = pos + key.len;
+        @memcpy(buf[pos..end], key);
+    }
+
+    if (compression) {
+        // NOTE: client_max_window_bits is unsupported
+        const permessage_deflate = "\r\nSec-WebSocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover";
+        pos = end;
+        end = pos + permessage_deflate.len;
+        @memcpy(buf[pos..end], permessage_deflate);
+    }
+
+    {
+        pos = end;
+        end = pos + 2;
+        @memcpy(buf[pos..end], "\r\n");
+        pos = end;
+    }
+
+    if (opts.headers) |extra_headers| {
+        end = pos + extra_headers.len;
+        @memcpy(buf[pos..end], extra_headers);
+        pos = end;
+        if (!std.mem.endsWith(u8, extra_headers, "\r\n")) {
+            buf[pos] = '\r';
+            buf[pos + 1] = '\n';
+            pos += 2;
+        }
+    }
+    buf[pos] = '\r';
+    buf[pos + 1] = '\n';
+
+    try stream.writeTimeout(opts.timeout_ms);
+    try stream.writeAll(buf[0 .. pos + 2]);
+    try stream.writeTimeout(0);
+}
+
+const HandShakeReply = struct {
+    compression: bool,
+    over_read: usize,
+
+    fn read(buf: []u8, key: []const u8, opts: *const Client.HandshakeOpts, compression: bool, stream: anytype) !HandShakeReply {
+        const timeout_ms = opts.timeout_ms;
+        const deadline = std.time.milliTimestamp() + timeout_ms;
+        try stream.readTimeout(timeout_ms);
+
+        var pos: usize = 0;
+        var line_start: usize = 0;
+        var complete_response: u8 = 0;
+        var server_compression: bool = false;
+
+        while (true) {
+            const n = stream.read(buf[pos..]) catch |err| switch (err) {
+                error.WouldBlock => return error.Timeout,
+                else => return err,
+            };
+            if (n == 0) {
+                return error.ConnectionClosed;
+            }
+
+            pos += n;
+            while (std.mem.indexOfScalar(u8, buf[line_start..pos], '\r')) |relative_end| {
+                if (relative_end == 0) {
+                    if (complete_response != 15) {
+                        return error.InvalidHandshakeResponse;
+                    }
+                    const over_read = pos - (line_start + 2);
+                    std.mem.copyForwards(u8, buf[0..over_read], buf[line_start + 2 .. pos]);
+                    try stream.readTimeout(0);
+                    return .{
+                        .over_read = over_read,
+                        .compression = server_compression,
+                    };
+                }
+
+                const line_end = line_start + relative_end;
+                const line = buf[line_start..line_end];
+
+                // the next line starts where this line ends, skip over the \r\n
+                line_start = line_end + 2;
+
+                if (complete_response == 0) {
+                    if (!ascii.startsWithIgnoreCase(line, "HTTP/1.1 101 ")) {
+                        return error.InvalidHandshakeResponse;
+                    }
+                    complete_response |= 1;
+                    continue;
+                }
+
+                for (line, 0..) |b, i| {
+                    // find the colon and lowercase the header while we're iterating
+                    if ('A' <= b and b <= 'Z') {
+                        line[i] = b + 32;
+                        continue;
+                    }
+
+                    if (b != ':') {
+                        continue;
+                    }
+
+                    switch (i) {
+                        7 => if (std.mem.eql(u8, line[0..i], "upgrade")) {
+                            if (!ascii.eqlIgnoreCase(std.mem.trim(u8, line[i + 1 ..], &ascii.whitespace), "websocket")) {
+                                return error.InvalidUpgradeHeader;
+                            }
+                            complete_response |= 2;
+                        },
+                        10 => if (std.mem.eql(u8, line[0..i], "connection")) {
+                            if (!ascii.eqlIgnoreCase(std.mem.trim(u8, line[i + 1 ..], &ascii.whitespace), "upgrade")) {
+                                return error.InvalidConnectionHeader;
+                            }
+                            complete_response |= 4;
+                        },
+                        20 => if (std.mem.eql(u8, line[0..i], "sec-websocket-accept")) {
+                            var h: [20]u8 = undefined;
+                            {
+                                var hasher = std.crypto.hash.Sha1.init(.{});
+                                hasher.update(key);
+                                hasher.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+                                hasher.final(&h);
+                            }
+
+                            var encoded_buf: [28]u8 = undefined;
+                            const sec_hash = std.base64.standard.Encoder.encode(&encoded_buf, &h);
+                            const header_value = std.mem.trim(u8, line[i + 1 ..], &ascii.whitespace);
+
+                            if (!std.mem.eql(u8, header_value, sec_hash)) {
+                                return error.InvalidWebsocketAcceptHeader;
+                            }
+                            complete_response |= 8;
+                        },
+                        24 => if (std.mem.eql(u8, line[0..i], "sec-websocket-extensions")) {
+                            if (try parseExtension(line[i + 1 ..])) |sc| {
+                                if (!compression) {
+                                    // server is saying compression, but we didn't ask for it.
+                                    return error.InvalidExtensionHeader;
+                                }
+                                if (!sc.client_no_context_takeover or !sc.server_no_context_takeover) {
+                                    // as of Zig 0.15, we no longer support context takeover
+                                    // We told the server this, it should have respected it.
+                                    return error.InvalidExtensionHeader;
+                                }
+
+                                server_compression = true;
+                            }
+                        },
+                        else => {}, // some other header we don't care about
+                    }
+                }
+            }
+
+            if (std.time.milliTimestamp() > deadline) {
+                return error.Timeout;
+            }
+
+            if (pos == buf.len) {
+                return error.ResponseTooLarge;
+            }
+        }
+    }
+
+    pub fn parseExtension(value: []const u8) !?ServerHandshake.Compression {
+        var deflate = false;
+        var client_max_bits: u8 = 15;
+        var client_no_context_takeover = false;
+        var server_no_context_takeover = false;
+
+        var it = std.mem.splitScalar(u8, value, ';');
+        while (it.next()) |param_| {
+            const param = std.mem.trim(u8, param_, &ascii.whitespace);
+            if (std.mem.eql(u8, param, "permessage-deflate")) {
+                deflate = true;
+                continue;
+            }
+            if (std.mem.eql(u8, param, "client_no_context_takeover")) {
+                client_no_context_takeover = true;
+                continue;
+            }
+            if (std.mem.eql(u8, param, "server_no_context_takeover")) {
+                server_no_context_takeover = true;
+                continue;
+            }
+            const client_max_window_bits = "client_max_window_bits=";
+            if (std.mem.startsWith(u8, param, client_max_window_bits)) {
+                client_max_bits = std.fmt.parseInt(u8, param[client_max_window_bits.len..], 10) catch {
+                    return error.InvalidCompressionServerMaxBits;
+                };
+            }
+        }
+        if (deflate == false) {
+            return null;
+        }
+
+        if (client_max_bits != 15) {
+            // We don't offer client window, so if the server asks for one, that's an error
+            return error.InvalidExtensionHeader;
+        }
+
+        return .{
+            .client_no_context_takeover = client_no_context_takeover,
+            .server_no_context_takeover = server_no_context_takeover,
+        };
+    }
+};
+
+const t = @import("../t.zig");
+test "Client: handshake" {
+    {
+        // empty response
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try t.expectError(error.InvalidHandshakeResponse, client.handshake("/", .{}));
+    }
+
+    {
+        // invalid websocket response
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 200 OK\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try t.expectError(error.InvalidHandshakeResponse, client.handshake("/", .{}));
+    }
+
+    {
+        // missing upgrade header
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 101 Switching Protocol\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try t.expectError(error.InvalidHandshakeResponse, client.handshake("/", .{}));
+    }
+
+    {
+        // wrong upgrade header
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 101 Switching Protocol\r\nUpgrade: nope\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try t.expectError(error.InvalidUpgradeHeader, client.handshake("/", .{}));
+    }
+
+    {
+        // missing connection header
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 101 Switching Protocol\r\nUpgrade: websocket\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try t.expectError(error.InvalidHandshakeResponse, client.handshake("/", .{}));
+    }
+
+    {
+        // wrong connection header
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 101 Switching Protocol\r\nupgrade: WebSocket\r\nConnection: something\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try t.expectError(error.InvalidConnectionHeader, client.handshake("/", .{}));
+    }
+
+    {
+        // missing Sec-Websocket-Accept header
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 101 Switching Protocol\r\nUpgrade: websocket\r\nConnection: upgrade\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try t.expectError(error.InvalidHandshakeResponse, client.handshake("/", .{}));
+    }
+
+    {
+        // wrong Sec-Websocket-Accept header
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 101 Switching Protocol\r\nupgrade: WebSocket\r\nConnection: UPGRADE\r\nSec-Websocket-Accept: hack\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try t.expectError(error.InvalidWebsocketAcceptHeader, client.handshake("/", .{}));
+    }
+
+    {
+        // ok for successful
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 101 Switching Protocol\r\nupgrade: WebSocket\r\nConnection: UPGRADE\r\nSec-Websocket-Accept: C/0nmHhBztSRGR1CwL6Tf4ZjwpY=\r\n\r\n");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try client.handshake("/", .{});
+        try t.expectEqual(0, client._reader.pos);
+    }
+
+    {
+        // ok for successful, with overread
+        var pair = t.SocketPair.init(.{});
+        defer pair.deinit();
+        try pair.client.writeAll("HTTP/1.1 101 Switching Protocol\r\nupgrade: WebSocket\r\nConnection: UPGRADE\r\nSec-Websocket-Accept: C/0nmHhBztSRGR1CwL6Tf4ZjwpY=\r\n\r\nSome Random Data Which is Part Of the Next Message");
+
+        var client = testClient(pair.server);
+        defer client.deinit();
+        try client.handshake("/", .{});
+        try t.expectEqual(50, client._reader.pos);
+    }
+}
+
+test "Client: write/read" {
+    var client = try Client.init(t.allocator, .{
+        .port = 9292,
+        .host = "127.0.0.1",
+    });
+    defer client.deinit();
+
+    try client.handshake("/", .{
+        .timeout_ms = 1000,
+    });
+
+    var buf = [_]u8{ 'o', 'v', 'e', 'r' };
+    try client.write(&buf);
+    try client.readTimeout(1000);
+
+    const message = (try client.read()) orelse unreachable;
+    try t.expectEqual(.text, message.type);
+    try t.expectString("9000", message.data);
+
+    client.close(.{}) catch unreachable;
+}
+
+test "Client: close with code" {
+    var client = try Client.init(t.allocator, .{
+        .port = 9292,
+        .host = "127.0.0.1",
+    });
+    defer client.deinit();
+
+    try client.handshake("/", .{
+        .timeout_ms = 1000,
+    });
+
+    client.close(.{ .code = 4002 }) catch unreachable;
+}
+
+test "Client: with code and reason" {
+    var client = try Client.init(t.allocator, .{
+        .port = 9292,
+        .host = "127.0.0.1",
+    });
+    defer client.deinit();
+
+    try client.handshake("/", .{
+        .timeout_ms = 1000,
+    });
+
+    client.close(.{ .code = 4002, .reason = "goodbye" }) catch unreachable;
+}
+
+test "Client: Handler" {
+    var h = try ClientHandler.init(t.allocator);
+    defer h.deinit();
+
+    var buf: [6]u8 = undefined;
+    {
+        @memcpy(buf[0..3], "dyn");
+        try h.client.write(buf[0..3]);
+    }
+
+    {
+        @memcpy(buf[0..4], "ping");
+        try h.client.write(buf[0..4]);
+    }
+
+    {
+        @memcpy(buf[0..4], "pong");
+        try h.client.write(buf[0..4]);
+    }
+
+    {
+        @memcpy(buf[0..6], "close1");
+        try h.client.write(buf[0..6]);
+    }
+
+    try h.client.readLoop(&h);
+
+    // if pong is true then ping and message have to be true
+    // because each asserts the previous
+    try t.expectEqual(true, h.pong);
+    try t.expectEqual(true, h.closed);
+}
+
+fn testClient(stream: net.Stream) Client {
+    const bp = t.allocator.create(buffer.Provider) catch unreachable;
+    bp.* = buffer.Provider.init(t.allocator, .{ .count = 0, .size = 0, .max = 4096 }) catch unreachable;
+
+    const reader_buf = bp.allocator.alloc(u8, 1024) catch unreachable;
+
+    return .{
+        ._closed = false,
+        ._own_bp = true,
+        ._mask_fn = generateMask,
+        ._compression_opts = null,
+        .stream = .{ .stream = stream },
+        ._reader = Reader.init(reader_buf, bp, null),
+    };
+}
+
+const ClientHandler = struct {
+    ping: bool = false,
+    pong: bool = false,
+    closed: bool = false,
+    message: bool = false,
+    client: Client,
+
+    fn init(allocator: Allocator) !ClientHandler {
+        var client = try Client.init(allocator, .{
+            .port = 9292,
+            .host = "127.0.0.1",
+        });
+        errdefer client.deinit();
+
+        try client.handshake("/", .{
+            .timeout_ms = 1000,
+        });
+
+        return .{
+            .client = client,
+        };
+    }
+
+    fn deinit(self: *ClientHandler) void {
+        self.client.deinit();
+    }
+
+    pub fn serverMessage(self: *ClientHandler, data: []u8, tpe: proto.Message.TextType) !void {
+        try t.expectEqual(.text, tpe);
+        try t.expectString("over 9000!", data);
+        self.message = true;
+    }
+
+    pub fn serverPing(self: *ClientHandler, data: []u8) !void {
+        try t.expectEqual(true, self.message);
+        try t.expectString("a-ping", data);
+        self.ping = true;
+    }
+
+    pub fn serverPong(self: *ClientHandler, data: []u8) !void {
+        try t.expectEqual(true, self.ping);
+        try t.expectString("a-pong", data);
+        self.pong = true;
+    }
+
+    pub fn close(self: *ClientHandler) void {
+        self.client.close(.{}) catch unreachable;
+        self.closed = true;
+    }
+};

--- a/vendor/websocket/src/proto.zig
+++ b/vendor/websocket/src/proto.zig
@@ -1,0 +1,836 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const buffer = @import("buffer.zig");
+const Compression = @import("websocket.zig").Compression;
+
+const backend_supports_vectors = switch (builtin.zig_backend) {
+    .stage2_llvm, .stage2_c => true,
+    else => false,
+};
+
+pub const Message = struct {
+    type: Type,
+    data: []u8,
+
+    pub const Type = enum {
+        text,
+        binary,
+        close,
+        ping,
+        pong,
+    };
+
+    pub const TextType = enum {
+        text,
+        binary,
+    };
+};
+
+pub const OpCode = enum(u8) {
+    text = 128 | 1,
+    binary = 128 | 2,
+    close = 128 | 8,
+    ping = 128 | 9,
+    pong = 128 | 10,
+};
+
+// The reader has a static buffer. But it can go to the BufferProvider to ask
+// for a larger buffer. Depending on how it's configured, the BufferProvider could
+// reject the request, return a buffer from a pool or return a dynamically allocated
+// buffer.
+//
+// Also, when we read data from the stream, we read up to the entire buffer length
+// This can result in an "over-read", meaning we might read more than a single message.
+//
+// Ove-reads make managing buffers complicated. In a simple case,
+// we could copy any over-read back into our static buffer, but our over-read
+// could be larger than our static buffer, requiring the dynamic/pooled buffer
+// to be pinned for a potentially long time.
+//
+// The way we solve this is that when we ask the buffer provider for a larger
+// buffer, we ask it for exactly the size of the message. (Even if the buffer
+// comes from a pool, the buffer provider will shrink its length).
+//
+// In other words, when we're reading into our static buffer (which, ideally is
+// most of the time), we'll over-read. But when we're reading into a dynamic buffer
+// we'll only ever read 1 message, with no chance of an overread. The buffer
+// management in Reader depends on this fact.
+//
+// TOOD: we could optimize the above. Specifically, when we get a buffer from
+// the pool, we could ask for + static.data.len. This would allow us to over-read
+// into a pooled buffer, yet make sure any over-read fits back into our static buffer.
+
+pub const Reader = struct {
+    // The current buffer that we're reading into. This could be our initial static buffer.
+    // If the current message is larger than the static buffer (but staticer than
+    // our max-allowed message), this could point to a pooled buffer from the large
+    // buffer pool, or a dynamic buffer.
+    buf: buffer.Buffer,
+
+    static: []u8,
+
+    large_buffer_provider: *buffer.Provider,
+
+    // Position within buf that we've read into. We might read more than one
+    // message in a single read, so this could span beyond 1 message.
+    pos: usize,
+
+    // Position in buf where the current message starts
+    start: usize,
+
+    // Length of the current message.
+    // This is set to 0 if we don't know yet
+    message_len: usize,
+
+    // If we're dealing with a fragmented message (websocket fragment, not tcp
+    // fragment), the state of the fragmented message is maintained here.)
+    fragment: ?Fragmented,
+
+    allow_compressed: bool,
+
+    // if we returned a decompressed message, it's stored here so that we can
+    // cleanup when the user is done with the message
+    decompress_writer: ?buffer.Writer,
+
+    const DecompressorType = std.compress.flate.Decompress;
+
+    pub fn init(static: []u8, large_buffer_provider: *buffer.Provider, compression: ?Compression) Reader {
+        return .{
+            .pos = 0,
+            .start = 0,
+            .buf = .{ .type = .static, .data = static },
+            .static = static,
+            .message_len = 0,
+            .fragment = null,
+            .decompress_writer = null,
+            .allow_compressed = compression != null,
+            .large_buffer_provider = large_buffer_provider,
+        };
+    }
+
+    pub fn deinit(self: *Reader) void {
+        if (self.fragment) |*f| {
+            f.deinit();
+        }
+        if (self.decompress_writer) |*dw| {
+            dw.deinit();
+        }
+
+        // not our job to manage the static buffer, its buf was given to us an init and we
+        // can't know where it came from.
+        if (self.usingLargeBuffer()) {
+            self.large_buffer_provider.release(self.buf);
+        }
+    }
+
+    pub fn fill(self: *Reader, stream: anytype) !void {
+        const pos = self.pos;
+        std.debug.assert(self.buf.data.len > pos);
+        const n = try stream.read(self.buf.data[pos..]);
+        if (n == 0) {
+            return error.Closed;
+        }
+        self.pos = pos + n;
+    }
+
+    pub fn read(self: *Reader) !?struct { bool, Message } {
+        // read can return null if self.buf doesn't contain a full message.
+        // But, because control messages can come between normal messages, we might
+        // have to process more than one message per call.
+        // For example, say we get a text message but it's fragmented. We can't return
+        // it until we get the remaining fragments. If there's no other data in buf,
+        // then we return null to signal that we need more data, as normal.
+        // But if there IS more data, we need to process it then and there.
+
+        loop: while (true) {
+            const pos = self.pos;
+            const start = self.start;
+            var buf = self.buf.data[start..pos];
+
+            if (buf.len < 2) {
+                // not enough data yet
+                return null;
+            }
+
+            const byte1 = buf[0];
+            const byte2 = buf[1];
+            const data_len = pos - start;
+
+            var masked = false;
+            var length_of_len: usize = 0;
+            var message_len = self.message_len;
+
+            if (message_len == 0) {
+                masked, length_of_len = payloadMeta(byte2);
+
+                // + 2 for the first 2 bytes
+                if (buf.len < length_of_len + 2) {
+                    // at this point, we don't have enough bytes to know the length of
+                    // the message. We need more data
+                    return null;
+                }
+
+                // At this point, we're sure that we have at least enough bytes to know
+                // the total length of the message.
+                var ml = switch (length_of_len) {
+                    2 => @as(u16, @intCast(buf[3])) | @as(u16, @intCast(buf[2])) << 8,
+                    8 => @as(u64, @intCast(buf[9])) | @as(u64, @intCast(buf[8])) << 8 | @as(u64, @intCast(buf[7])) << 16 | @as(u64, @intCast(buf[6])) << 24 | @as(u64, @intCast(buf[5])) << 32 | @as(u64, @intCast(buf[4])) << 40 | @as(u64, @intCast(buf[3])) << 48 | @as(u64, @intCast(buf[2])) << 56,
+                    else => buf[1] & 127,
+                } + length_of_len + 2; // + 2 for the 2 byte prefix
+
+                masked = byte2 & 128 == 128;
+                if (masked) {
+                    // message is masked
+                    ml += 4;
+                }
+
+                if (comptime builtin.target.ptrBitWidth() < 64) {
+                    if (ml > std.math.maxInt(usize)) {
+                        return error.TooLarge;
+                    }
+                }
+
+                message_len = @intCast(ml);
+                self.message_len = message_len;
+
+                if (self.buf.data.len < message_len) {
+                    // We don't have enough space in our buffer.
+
+                    const current_buf = self.buf;
+                    defer self.large_buffer_provider.release(current_buf);
+
+                    const new_buffer = try self.large_buffer_provider.alloc(message_len);
+                    @memcpy(new_buffer.data[0..data_len], current_buf.data[start..pos]);
+
+                    self.buf = new_buffer;
+                    self.start = 0;
+                    self.pos = data_len;
+                    buf = new_buffer.data[0..data_len];
+                } else if (start > 0) {
+                    // Our buffer is big enough to hold the message, but it might need to
+                    // be compacted to do so.
+
+                    const available_space = self.buf.data.len - start;
+                    if (available_space < message_len) {
+                        std.mem.copyForwards(u8, self.buf.data[0..data_len], self.buf.data[start..pos]);
+                        self.start = 0;
+                        self.pos = data_len;
+                        buf = self.buf.data[0..data_len];
+                    }
+                }
+            }
+
+            if (data_len < message_len) {
+                // we don't have enough data for the full message
+                return null;
+            }
+
+            // At this point, we have a full message in buf (we might even have more than
+            // 1 message, but we'll worry about that later);
+
+            // Since we're sure we're going to process the current message, we set
+            // self.message_len back to 0, so that wherever we return (or continue
+            // to loop because of fragmentation), we'll start a new message from scratch.
+            self.message_len = 0;
+
+            if (length_of_len == 0) {
+                masked, length_of_len = payloadMeta(byte2);
+            }
+
+            var is_continuation = false;
+            var message_type: Message.Type = undefined;
+            switch (byte1 & 15) {
+                0 => is_continuation = true,
+                1 => message_type = .text,
+                2 => message_type = .binary,
+                8 => message_type = .close,
+                9 => message_type = .ping,
+                10 => message_type = .pong,
+                else => return error.InvalidMessageType,
+            }
+
+            // FIN, RSV1, RSV2, RSV3, OP,OP,OP,OP
+            // RSV2 and RSV3 should never be set, and RSV1 should not be set
+            // when compression is disabled
+            const rsv_bits: u8 = if (self.allow_compressed == false or is_continuation) 112 else 48;
+            if (byte1 & rsv_bits != 0) {
+                return error.ReservedFlags;
+            }
+
+            const compressed = byte1 & 64 == 64;
+            if (compressed) {
+                if (self.allow_compressed == false) {
+                    return error.CompressionDisabled;
+                }
+            }
+
+            if (!is_continuation and length_of_len != 0 and (message_type == .ping or message_type == .close or message_type == .pong)) {
+                return error.LargeControl;
+            }
+
+            const header_length = 2 + length_of_len + @as(usize, if (masked) 4 else 0);
+
+            const fin = byte1 & 128 == 128;
+            const payload = buf[header_length..message_len];
+
+            if (masked) {
+                const mask_bytes = buf[header_length - 4 .. header_length];
+                mask(mask_bytes, payload);
+            }
+
+            var more = false;
+            const next = self.start + header_length + payload.len;
+            if (next == self.pos) {
+                // Best case. We didn't read part (of a whole) 2nd message, we can just
+                // reset our pos & start to 0.
+                // This should always be true if we're into a dynamic buffer, since the
+                // dynamic buffer would have been sized exactly for the message, with no
+                // spare room for more data.
+                self.pos = 0;
+                self.start = 0;
+            } else {
+                more = true;
+                std.debug.assert(next < self.pos);
+
+                // We've read some of the next message. This can get complicated.
+                // Our buf might be dynamic. Our buf could be static, but there might
+                // not be enough room for another message, or maybe we can't tell.
+                // Whatever the case, we can't handle it here because the message
+                // we're going to return references buf.
+                self.start = next;
+            }
+
+            if (fin) {
+                if (is_continuation) {
+                    if (self.fragment) |*f| {
+                        if (f.compressed) {
+                            return .{ more, .{ .data = try self.decompress(try f.last(payload)), .type = f.type } };
+                        }
+                        return .{ more, .{ .type = f.type, .data = try f.last(payload) } };
+                    }
+
+                    return error.UnfragmentedContinuation;
+                }
+
+                if (self.fragment != null and (message_type == .text or message_type == .binary)) {
+                    return error.NestedFragment;
+                }
+
+                if (compressed) {
+                    return .{ more, .{ .data = try self.decompress(payload), .type = message_type } };
+                }
+
+                // just a normal single-fragment message (most common case)
+                return .{ more, .{ .data = payload, .type = message_type } };
+            }
+
+            if (is_continuation) {
+                if (self.fragment) |*f| {
+                    try f.add(payload);
+                    self.restoreStatic();
+
+                    if (more) {
+                        continue :loop;
+                    }
+                    return null;
+                }
+                return error.UnfragmentedContinuation;
+            } else if (message_type != .text and message_type != .binary) {
+                return error.FragmentedControl;
+            }
+
+            if (self.fragment != null) {
+                return error.NestedFragment;
+            }
+
+            self.fragment = try Fragmented.init(self.large_buffer_provider, compressed, message_type, payload);
+            self.restoreStatic();
+
+            if (more) {
+                continue :loop;
+            }
+            return null;
+        }
+    }
+
+    // There's some cleanup in read that we can't do until after the client has
+    // had the chance to read the message. We don't want to wait for the next
+    // call to "read" to do this, because we don't know when that'll be.
+    pub fn done(self: *Reader, message_type: Message.Type) void {
+        if (message_type == .text or message_type == .binary) {
+            if (self.fragment) |*f| {
+                f.deinit();
+                self.fragment = null;
+            }
+            if (self.decompress_writer) |*dw| {
+                dw.deinit();
+                self.decompress_writer = null;
+            }
+        }
+
+        self.restoreStatic();
+    }
+
+    pub fn isEmpty(self: *Reader) bool {
+        return self.pos == 0 and self.fragment == null and self.usingLargeBuffer() == false;
+    }
+
+    fn restoreStatic(self: *Reader) void {
+        if (self.usingLargeBuffer()) {
+            std.debug.assert(self.pos == 0);
+            std.debug.assert(self.start == 0);
+            self.large_buffer_provider.release(self.buf);
+            self.buf = .{ .type = .static, .data = self.static };
+            return;
+        }
+
+        const start = self.start;
+        if (start > self.static.len / 2) {
+            // only copy the data back to the start of our static buffer If
+            // we've used up half the buffer.
+
+            // TODO: this could be further optimized by seeing if we know the length
+            // of the next message and using that to decide if we need to compact
+            // the static buffer or not.
+            const pos = self.pos;
+            const data_len = pos - start;
+            std.mem.copyForwards(u8, self.static[0..data_len], self.static[start..pos]);
+            self.pos = data_len;
+            self.start = 0;
+        }
+    }
+
+    fn decompress(self: *Reader, compressed: []const u8) ![]u8 {
+        const provider = self.large_buffer_provider;
+
+        var dumb: [32]u8 = undefined;
+        var writer: buffer.Writer = undefined;
+        if (compressed.len < provider.pool_buffer_size) {
+            const buf = try provider.pool.acquireOrCreate();
+            writer = .init(buf, true, provider, &dumb);
+        } else {
+            const buf = try provider.allocator.alloc(u8, @intFromFloat(@as(f64, @floatFromInt(compressed.len)) * 1.25));
+            writer = .init(buf, false, provider, &dumb);
+        }
+
+        errdefer writer.deinit();
+
+        var reader = std.Io.Reader.fixed(compressed);
+        var decompressor = std.compress.flate.Decompress.init(&reader, .raw, &.{});
+        const n = decompressor.reader.streamRemaining(&writer.interface) catch {
+            return error.CompressionError;
+        };
+
+        self.decompress_writer = writer;
+        return writer.buf[0..n];
+    }
+
+    inline fn usingLargeBuffer(self: *const Reader) bool {
+        return self.buf.type != .static;
+    }
+};
+
+fn payloadMeta(byte2: u8) struct { bool, usize } {
+    const masked = byte2 & 128 == 128;
+    const length_of_length: usize = switch (byte2 & 127) {
+        126 => 2,
+        127 => 8,
+        else => 0,
+    };
+    return .{ masked, length_of_length };
+}
+
+const Fragmented = struct {
+    max: usize,
+    compressed: bool,
+    type: Message.Type,
+    buf: std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+
+    pub fn init(bp: *buffer.Provider, compressed: bool, message_type: Message.Type, value: []const u8) !Fragmented {
+        var buf: std.ArrayList(u8) = .empty;
+        try buf.ensureTotalCapacity(bp.allocator, value.len * 2);
+        buf.appendSliceAssumeCapacity(value);
+
+        return .{
+            .buf = buf,
+            .type = message_type,
+            .compressed = compressed,
+            .max = bp.max_buffer_size,
+            .allocator = bp.allocator,
+        };
+    }
+
+    pub fn deinit(self: *Fragmented) void {
+        self.buf.deinit(self.allocator);
+    }
+
+    pub fn add(self: *Fragmented, value: []const u8) !void {
+        if (self.buf.items.len + value.len > self.max) {
+            return error.TooLarge;
+        }
+        try self.buf.appendSlice(self.allocator, value);
+    }
+
+    // Optimization so that we don't over-allocate on our last frame.
+    pub fn last(self: *Fragmented, value: []const u8) ![]u8 {
+        const total_len = self.buf.items.len + value.len;
+        if (total_len > self.max) {
+            return error.TooLarge;
+        }
+        try self.buf.ensureTotalCapacityPrecise(self.allocator, total_len);
+        self.buf.appendSliceAssumeCapacity(value);
+        return self.buf.items;
+    }
+};
+
+pub fn mask(m: []const u8, payload: []u8) void {
+    var data = payload;
+
+    if (!comptime backend_supports_vectors) return simpleMask(m, data);
+
+    const vector_size = std.simd.suggestVectorLength(u8) orelse @sizeOf(usize);
+    if (data.len >= vector_size) {
+        const mask_vector = std.simd.repeat(vector_size, @as(@Vector(4, u8), m[0..4].*));
+        while (data.len >= vector_size) {
+            const slice = data[0..vector_size];
+            const masked_data_slice: @Vector(vector_size, u8) = slice.*;
+            slice.* = masked_data_slice ^ mask_vector;
+            data = data[vector_size..];
+        }
+    }
+    simpleMask(m, data);
+}
+
+fn simpleMask(m: []const u8, payload: []u8) void {
+    @setRuntimeSafety(false);
+    for (payload, 0..) |b, i| {
+        payload[i] = b ^ m[i & 3];
+    }
+}
+
+pub fn frame(op_code: OpCode, comptime msg: []const u8) [calculateFrameLen(msg)]u8 {
+    var framed: [calculateFrameLen(msg)]u8 = undefined;
+    const header = writeFrameHeader(&framed, op_code, msg.len, false);
+    @memcpy(framed[header.len..], msg);
+    return framed;
+}
+
+pub fn writeFrameHeader(buf: []u8, op_code: OpCode, l: usize, compressed: bool) []u8 {
+    buf[0] = @intFromEnum(op_code);
+    if (compressed) {
+        buf[0] |= 64;
+    }
+
+    if (l <= 125) {
+        buf[1] = @intCast(l);
+        return buf[0..2];
+    }
+    if (l < 65536) {
+        buf[1] = 126;
+        buf[2] = @intCast((l >> 8) & 0xFF);
+        buf[3] = @intCast(l & 0xFF);
+        return buf[0..4];
+    }
+
+    buf[1] = 127;
+    if (comptime builtin.target.ptrBitWidth() >= 64) {
+        buf[2] = @intCast((l >> 56) & 0xFF);
+        buf[3] = @intCast((l >> 48) & 0xFF);
+        buf[4] = @intCast((l >> 40) & 0xFF);
+        buf[5] = @intCast((l >> 32) & 0xFF);
+    } else {
+        buf[2] = 0;
+        buf[3] = 0;
+        buf[4] = 0;
+        buf[5] = 0;
+    }
+    buf[6] = @intCast((l >> 24) & 0xFF);
+    buf[7] = @intCast((l >> 16) & 0xFF);
+    buf[8] = @intCast((l >> 8) & 0xFF);
+    buf[9] = @intCast(l & 0xFF);
+    return buf[0..10];
+}
+
+pub fn calculateFrameLen(comptime msg: []const u8) usize {
+    if (msg.len <= 125) return msg.len + 2;
+    if (msg.len < 65536) return msg.len + 4;
+    return msg.len + 10;
+}
+
+const t = @import("t.zig");
+test "mask" {
+    var r = t.getRandom();
+    const random = r.random();
+    const m = [4]u8{ 10, 20, 55, 200 };
+
+    var original = try t.allocator.alloc(u8, 10000);
+    var payload = try t.allocator.alloc(u8, 10000);
+
+    var size: usize = 0;
+    while (size < 1000) {
+        const slice = original[0..size];
+        random.bytes(slice);
+        @memcpy(payload[0..size], slice);
+        mask(m[0..], payload[0..size]);
+
+        for (slice, 0..) |b, i| {
+            try t.expectEqual(b ^ m[i & 3], payload[i]);
+        }
+
+        size += 1;
+    }
+    t.allocator.free(original);
+    t.allocator.free(payload);
+}
+
+test "Reader: read too large" {
+    defer t.reset();
+
+    var pair = t.SocketPair.init(.{});
+    defer pair.deinit();
+    pair.textFrame(true, "hello world");
+    pair.sendBuf();
+
+    var reader = testReader(.{ .max = 16, .static = 16 });
+    defer reader.deinit();
+    try t.expectError(error.TooLarge, testRead(&reader, pair));
+}
+
+test "Reader: read too large over multiple fragments" {
+    defer t.reset();
+
+    var pair = t.SocketPair.init(.{});
+    defer pair.deinit();
+    pair.textFrame(false, "hello world");
+    pair.cont(false, " !!!_!!! ");
+    pair.cont(true, "how are you doing?");
+    pair.sendBuf();
+
+    var reader = testReader(.{ .max = 32, .static = 32 });
+    defer reader.deinit();
+    try t.expectError(error.TooLarge, testRead(&reader, pair));
+}
+
+test "Reader: exact read into static with no overflow" {
+    defer t.reset();
+
+    var pair = t.SocketPair.init(.{});
+    defer pair.deinit();
+    pair.textFrame(true, "hello!");
+    pair.sendBuf();
+
+    var reader = testReader(.{ .max = 12, .static = 12 });
+    defer reader.deinit();
+    try t.expectString("hello!", (try testRead(&reader, pair)).data);
+}
+
+test "Reader: fuzz" {
+    defer t.reset();
+    var r = t.getRandom();
+    const random = r.random();
+
+    for (0..250) |_| {
+        defer _ = t.arena.reset(.{ .retain_capacity = {} });
+        const arena = t.arena.allocator();
+
+        const MAX_FRAGMENTS = random.intRangeAtMost(u32, 1, 4);
+        const MESSAGE_TO_SEND = random.intRangeAtMost(u32, 1, 500);
+        const MAX_PAYLOAD_SIZE = random.intRangeAtMost(u32, 200, 1000);
+        const MAX_MESSAGE_SIZE = MAX_PAYLOAD_SIZE + 14;
+        var scrap = try arena.alloc(u8, MAX_PAYLOAD_SIZE);
+
+        var writer = t.Writer.init();
+        defer writer.deinit();
+
+        var expected = try arena.alloc(Message, MESSAGE_TO_SEND);
+
+        var is_fragmented = false;
+        var fragment_count: usize = 0;
+        var fragment: std.ArrayList(u8) = .empty;
+
+        var i: usize = 0;
+        while (i < MESSAGE_TO_SEND) {
+            if (is_fragmented == false) {
+                // this is rare
+                is_fragmented = random.intRangeAtMost(u8, 0, 8) == 0;
+                fragment_count = 0;
+            }
+
+            // a non-fragmented message is always "fin"
+            // and we'll force a "fin" after ~ 4 messages.
+            const is_fin = is_fragmented == false or random.intRangeAtMost(u8, 0, 3) == 0 or fragment_count == MAX_FRAGMENTS;
+            switch (random.intRangeAtMost(u16, 0, 11)) {
+                0...8 => { // we mostly expect text or binary messages
+                    const buf = scrap[0..random.intRangeAtMost(u32, 0, MAX_PAYLOAD_SIZE)];
+                    random.bytes(buf);
+                    if (is_fragmented == false) {
+                        writer.textFrame(true, buf);
+                        expected[i] = .{ .type = .text, .data = try arena.dupe(u8, buf) };
+                        i += 1;
+                    } else {
+                        if (fragment_count == 0) {
+                            // the first part of our fragmented message
+                            writer.textFrame(is_fin, buf);
+                        } else {
+                            writer.cont(is_fin, buf);
+                        }
+                        fragment_count += 1;
+
+                        try fragment.appendSlice(arena, try arena.dupe(u8, buf));
+
+                        if (is_fin) {
+                            // this was the last message in our fragment
+                            expected[i] = .{ .type = .text, .data = try arena.dupe(u8, fragment.items) };
+
+                            i += 1;
+                            is_fragmented = false;
+                            fragment.clearRetainingCapacity();
+                        }
+                    }
+                },
+                9 => {
+                    // empty ping
+                    writer.ping();
+                    expected[i] = .{ .type = .ping, .data = "" };
+                    i += 1;
+                },
+                10 => {
+                    // ping with data
+                    const buf = scrap[0..random.intRangeAtMost(u32, 1, 125)];
+                    random.bytes(buf);
+                    writer.pingPayload(buf);
+                    expected[i] = .{ .type = .ping, .data = try arena.dupe(u8, buf) };
+                    i += 1;
+                },
+                11 => {
+                    writer.pong();
+                    expected[i] = .{ .type = .pong, .data = "" };
+                    i += 1;
+                },
+                else => unreachable,
+            }
+        }
+
+        // test with various buffer sizes, and large buffer pools enabled/disabled
+        const static_size = random.intRangeAtMost(u32, 20, MAX_MESSAGE_SIZE + 200);
+        const large_buffer_count = random.intRangeAtMost(u16, 0, 1);
+        const large_buffer_size = random.intRangeAtMost(u32, static_size, MAX_MESSAGE_SIZE * 2);
+
+        // fragmentation could make messages very large
+        var reader = testReader(.{ .max = MAX_MESSAGE_SIZE * (MAX_FRAGMENTS + 1), .static = static_size, .count = large_buffer_count, .size = large_buffer_size });
+        defer reader.large_buffer_provider.deinit();
+        defer reader.deinit();
+
+        i = 0;
+        while (true) {
+            reader.fill(&writer) catch |err| switch (err) {
+                error.Closed => {
+                    try t.expectEqual(@as(u32, @intCast(i)), MESSAGE_TO_SEND);
+                    break;
+                },
+                else => return err,
+            };
+
+            while (true) {
+                const has_more, const message = (try reader.read()) orelse break;
+                try t.expectEqual(expected[i].type, message.type);
+                try t.expectString(expected[i].data, message.data);
+                reader.done(message.type);
+
+                i += 1;
+                if (has_more == false) {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+test "Fragmented" {
+    {
+        var bp = try buffer.Provider.init(t.allocator, .{ .count = 0, .size = 0, .max = 500 });
+        var f = try Fragmented.init(&bp, false, .text, "hello");
+        defer f.deinit();
+
+        try t.expectString("hello", f.buf.items);
+
+        try f.add(" ");
+        try t.expectString("hello ", f.buf.items);
+
+        try f.add("world");
+        try t.expectString("hello world", f.buf.items);
+    }
+
+    {
+        var bp = try buffer.Provider.init(t.allocator, .{ .count = 0, .size = 0, .max = 10 });
+        var f = try Fragmented.init(&bp, false, .text, "hello");
+        defer f.deinit();
+        try f.add(" ");
+        try t.expectError(error.TooLarge, f.add("world"));
+    }
+
+    {
+        var bp = try buffer.Provider.init(t.allocator, .{ .count = 0, .size = 0, .max = 5000 });
+
+        var r = std.Random.DefaultPrng.init(0);
+        var random = r.random();
+
+        var count: usize = 0;
+        var buf: [100]u8 = undefined;
+        while (count < 1000) : (count += 1) {
+            var payload = buf[0 .. random.uintAtMost(usize, 99) + 1];
+            random.bytes(payload);
+
+            var f = try Fragmented.init(&bp, false, .binary, payload);
+            defer f.deinit();
+
+            var expected: std.ArrayList(u8) = .empty;
+            defer expected.deinit(t.allocator);
+            try expected.appendSlice(t.allocator, payload);
+
+            const number_of_adds = random.uintAtMost(usize, 30);
+            for (0..number_of_adds) |_| {
+                payload = buf[0 .. random.uintAtMost(usize, 99) + 1];
+                random.bytes(payload);
+                try f.add(payload);
+                try expected.appendSlice(t.allocator, payload);
+            }
+            payload = buf[0 .. random.uintAtMost(usize, 99) + 1];
+            random.bytes(payload);
+            try expected.appendSlice(t.allocator, payload);
+
+            try t.expectString(expected.items, try f.last(payload));
+        }
+    }
+}
+
+fn testReader(opts: anytype) Reader {
+    const T = @TypeOf(opts);
+
+    const aa = t.arena.allocator();
+
+    const bp = aa.create(buffer.Provider) catch unreachable;
+    bp.* = buffer.Provider.init(t.allocator, .{
+        .max = if (@hasField(T, "max")) opts.max else 20,
+        .size = if (@hasField(T, "size")) opts.size else 0,
+        .count = if (@hasField(T, "count")) opts.count else 0,
+    }) catch unreachable;
+
+    const static_size = if (@hasField(T, "static")) opts.static else 16;
+    const reader_buf = aa.alloc(u8, static_size) catch unreachable;
+    return Reader.init(reader_buf, bp, null);
+}
+
+fn testRead(reader: *Reader, pair: t.SocketPair) !Message {
+    var i: usize = 0;
+    while (i < 100) : (i += 1) {
+        try reader.fill(pair.server);
+        if (try reader.read()) |result| {
+            return result.@"1";
+        }
+    } else {
+        return error.LoopReadOverflow;
+    }
+}

--- a/vendor/websocket/src/server/fallback_allocator.zig
+++ b/vendor/websocket/src/server/fallback_allocator.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+const FixedBufferAllocator = std.heap.FixedBufferAllocator;
+
+// std.heap.StackFallbackAllocator is very specific. It's really _stack_ as it
+// requires a comptime size. Also, it uses non-public calls from the FixedBufferAllocator.
+// There should be a more generic FallbackAllocator that just takes 2 allocators...
+// which is what this is.
+pub const FallbackAllocator = struct {
+    fixed: Allocator,
+    fallback: Allocator,
+    fba: *FixedBufferAllocator,
+
+    pub fn allocator(self: *FallbackAllocator) Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .alloc = alloc,
+                .resize = resize,
+                .free = free,
+                .remap = remap,
+            },
+        };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *FallbackAllocator = @ptrCast(@alignCast(ctx));
+        return self.fixed.rawAlloc(len, alignment, ra) orelse self.fallback.rawAlloc(len, alignment, ra);
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *FallbackAllocator = @ptrCast(@alignCast(ctx));
+        if (self.fba.ownsPtr(buf.ptr)) {
+            if (self.fixed.rawResize(buf, alignment, new_len, ra)) {
+                return true;
+            }
+        }
+        return self.fallback.rawResize(buf, alignment, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        _ = ctx;
+        _ = buf;
+        _ = alignment;
+        _ = ra;
+        // hack.
+        // Always noop since, in our specific usage, we know fallback is an arena.
+    }
+
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        if (resize(ctx, memory, alignment, new_len, ret_addr)) {
+            return memory.ptr;
+        }
+        return null;
+    }
+};

--- a/vendor/websocket/src/server/handshake.zig
+++ b/vendor/websocket/src/server/handshake.zig
@@ -1,0 +1,673 @@
+const std = @import("std");
+
+const posix = std.posix;
+const ascii = std.ascii;
+const Allocator = std.mem.Allocator;
+const websocket = @import("../websocket.zig");
+
+const M = @This();
+
+const SpecialHeader = enum {
+    none,
+    upgrade,
+    connection,
+    @"sec-websocket-key",
+    @"sec-websocket-version",
+    @"sec-websocket-extensions",
+};
+
+pub const Handshake = struct {
+    url: []const u8,
+    key: []const u8,
+    method: []const u8,
+    headers: *KeyValue,
+    res_headers: *KeyValue,
+    raw_header: []const u8,
+    compression: ?Compression,
+
+    pub const Pool = M.Pool;
+
+    pub const Compression = struct {
+        client_no_context_takeover: bool,
+        server_no_context_takeover: bool,
+    };
+
+    // returns null if the request isn't full
+    pub fn parse(state: *State) !?Handshake {
+        const request = state.buf[0..state.len];
+
+        var buf = request;
+        if (std.mem.endsWith(u8, buf, "\r\n\r\n") == false) {
+            return null;
+        }
+
+        const request_line_end = std.mem.indexOfScalar(u8, buf, '\r') orelse unreachable;
+        var request_line = buf[0..request_line_end];
+
+        if (!ascii.endsWithIgnoreCase(request_line, "http/1.1")) {
+            return error.InvalidProtocol;
+        }
+
+        var headers = &state.req_headers;
+
+        var key: []const u8 = "";
+        var required_headers: u8 = 0;
+
+        var compression: ?Handshake.Compression = null;
+
+        var request_length = request_line_end;
+
+        buf = buf[request_line_end + 2 ..];
+
+        while (buf.len > 4) {
+            const index = std.mem.indexOfScalar(u8, buf, '\r') orelse unreachable;
+            const separator = std.mem.indexOfScalar(u8, buf[0..index], ':') orelse return error.InvalidHeader;
+
+            const name = std.mem.trim(u8, toLower(buf[0..separator]), &ascii.whitespace);
+            const value = std.mem.trim(u8, buf[(separator + 1)..index], &ascii.whitespace);
+
+            headers.add(name, value);
+            switch (std.meta.stringToEnum(SpecialHeader, name) orelse .none) {
+                .upgrade => {
+                    if (!ascii.eqlIgnoreCase("websocket", value)) {
+                        return error.InvalidUpgrade;
+                    }
+                    required_headers |= 1;
+                },
+                .connection => {
+                    // find if connection header has upgrade in it, example header:
+                    // Connection: keep-alive, Upgrade
+                    if (std.ascii.indexOfIgnoreCase(value, "upgrade") == null) {
+                        return error.InvalidConnection;
+                    }
+                    required_headers |= 4;
+                },
+                .@"sec-websocket-key" => {
+                    key = value;
+                    required_headers |= 8;
+                },
+                .@"sec-websocket-version" => {
+                    if (value.len != 2 or value[0] != '1' or value[1] != '3') {
+                        return error.InvalidVersion;
+                    }
+                    required_headers |= 2;
+                },
+                .@"sec-websocket-extensions" => compression = try parseExtension(value),
+                .none => {},
+            }
+
+            const next = index + 2;
+            request_length += next;
+            buf = buf[next..];
+        }
+
+        if (required_headers != 15) {
+            return error.MissingHeaders;
+        }
+
+        // we already established that request_line ends with http/1.1, so this buys
+        // us some leeway into parsing it
+        const separator = std.mem.indexOfScalar(u8, request_line, ' ') orelse return error.InvalidRequestLine;
+        const method = request_line[0..separator];
+        const url = std.mem.trim(u8, request_line[separator + 1 .. request_line.len - 9], &ascii.whitespace);
+
+        return .{
+            .key = key,
+            .url = url,
+            .method = method,
+            .headers = headers,
+            .compression = compression,
+            .res_headers = &state.res_headers,
+            .raw_header = request[request_line_end + 2 .. request_length + 2],
+        };
+    }
+
+    pub fn createReply(key: []const u8, headers_: ?*KeyValue, compression: bool, buf: []u8) ![]const u8 {
+        const HEADER =
+            "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\n" ++
+            "Connection: upgrade\r\n" ++
+            "Sec-Websocket-Accept: ";
+
+        @memcpy(buf[0..HEADER.len], HEADER);
+        var pos = HEADER.len;
+
+        {
+            var h: [20]u8 = undefined;
+            var hasher = std.crypto.hash.Sha1.init(.{});
+            hasher.update(key);
+            // websocket spec always used this value
+            hasher.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+            hasher.final(&h);
+
+            const end = pos + 28;
+            _ = std.base64.standard.Encoder.encode(buf[pos..end], h[0..]);
+            pos = end;
+        }
+
+        if (compression) {
+            const permessage_deflate =
+                "\r\nSec-WebSocket-Extensions: permessage-deflate" ++
+                "; server_no_context_takeover" ++
+                "; client_no_context_takeover";
+
+            const end = pos + permessage_deflate.len;
+            @memcpy(buf[pos..end], permessage_deflate);
+            pos = end;
+        }
+
+        if (headers_) |headers| {
+            for (headers.keys[0..headers.len], headers.values[0..headers.len]) |k, v| {
+                pos += (try std.fmt.bufPrint(buf[pos..], "\r\n{s}: {s}", .{ k, v })).len;
+            }
+        }
+
+        const end = pos + 4;
+        @memcpy(buf[pos..end], "\r\n\r\n");
+        return buf[0..end];
+    }
+
+    pub fn parseExtension(value: []const u8) !?Handshake.Compression {
+        var deflate = false;
+        var server_max_bits: u8 = 15;
+        var client_no_context_takeover = false;
+        var server_no_context_takeover = false;
+
+        var it = std.mem.splitScalar(u8, value, ';');
+        while (it.next()) |param_| {
+            const param = std.mem.trim(u8, param_, &ascii.whitespace);
+            if (std.mem.eql(u8, param, "permessage-deflate")) {
+                deflate = true;
+                continue;
+            }
+            if (std.mem.eql(u8, param, "client_no_context_takeover")) {
+                client_no_context_takeover = true;
+                continue;
+            }
+            if (std.mem.eql(u8, param, "server_no_context_takeover")) {
+                server_no_context_takeover = true;
+                continue;
+            }
+            const server_max_window_bits = "server_max_window_bits=";
+            if (std.mem.startsWith(u8, param, server_max_window_bits)) {
+                server_max_bits = std.fmt.parseInt(u8, param[server_max_window_bits.len..], 10) catch {
+                    return error.InvalidCompressionServerMaxBits;
+                };
+            }
+        }
+        if (deflate == false) {
+            return null;
+        }
+
+        if (server_max_bits != 15) {
+            // Zig doesn't support a sliding deflate window. If the client asks
+            // for a sliding window < 15, we can't accomodate it. This logic
+            // should be pushed into the worker, but putting it here makes it
+            // easier for any integration to also use this (i..e httz)
+            return null;
+        }
+
+        return .{
+            .client_no_context_takeover = client_no_context_takeover,
+            .server_no_context_takeover = server_no_context_takeover,
+        };
+    }
+
+    // This is what we're pooling
+    pub const State = struct {
+        // length of data we have in buf
+        len: usize = 0,
+
+        // a buffer to read data into
+        buf: []u8,
+
+        // Headers from the request
+        req_headers: KeyValue,
+
+        // Headers that we want to send in the response
+        res_headers: KeyValue,
+
+        pool: *M.Pool,
+
+        fn init(pool: *M.Pool) !State {
+            const allocator = pool.allocator;
+            const buf = try allocator.alloc(u8, pool.buffer_size);
+            errdefer allocator.free(buf);
+
+            const req_headers = try Handshake.KeyValue.init(allocator, pool.max_req_headers);
+            errdefer req_headers.deinit(allocator);
+
+            const res_headers = try Handshake.KeyValue.init(allocator, pool.max_res_headers);
+            errdefer res_headers.deinit(allocator);
+
+            return .{
+                .buf = buf,
+                .pool = pool,
+                .req_headers = req_headers,
+                .res_headers = res_headers,
+            };
+        }
+
+        fn deinit(self: *State) void {
+            const allocator = self.pool.allocator;
+            allocator.free(self.buf);
+            self.req_headers.deinit(allocator);
+            self.res_headers.deinit(allocator);
+        }
+
+        pub fn release(self: *State) void {
+            self.len = 0;
+            self.req_headers.len = 0;
+            self.res_headers.len = 0;
+            self.pool.release(self);
+        }
+    };
+
+    pub const KeyValue = struct {
+        len: usize,
+        keys: [][]const u8,
+        values: [][]const u8,
+
+        fn init(allocator: Allocator, max: usize) !KeyValue {
+            const keys = try allocator.alloc([]const u8, max);
+            errdefer allocator.free(keys);
+
+            const values = try allocator.alloc([]const u8, max);
+            errdefer allocator.free(values);
+
+            return .{
+                .len = 0,
+                .keys = keys,
+                .values = values,
+            };
+        }
+
+        fn deinit(self: *const KeyValue, allocator: Allocator) void {
+            allocator.free(self.keys);
+            allocator.free(self.values);
+        }
+
+        pub fn add(self: *KeyValue, key: []const u8, value: []const u8) void {
+            const len = self.len;
+            var keys = self.keys;
+            if (len == keys.len) {
+                return;
+            }
+
+            keys[len] = key;
+            self.values[len] = value;
+            self.len = len + 1;
+        }
+
+        pub fn get(self: *const KeyValue, needle: []const u8) ?[]const u8 {
+            const keys = self.keys[0..self.len];
+            loop: for (keys, 0..) |key, i| {
+                // This is largely a reminder to myself that std.mem.eql isn't
+                // particularly fast. Here we at least avoid the 1 extra ptr
+                // equality check that std.mem.eql does, but we could do better
+                // TODO: monitor https://github.com/ziglang/zig/issues/8689
+                if (needle.len != key.len) {
+                    continue;
+                }
+                for (needle, key) |n, k| {
+                    if (n != k) {
+                        continue :loop;
+                    }
+                }
+                return self.values[i];
+            }
+
+            return null;
+        }
+
+        pub fn iterator(self: *const KeyValue) Iterator {
+            const len = self.len;
+            return .{
+                .pos = 0,
+                .keys = self.keys[0..len],
+                .values = self.values[0..len],
+            };
+        }
+
+        pub const Iterator = struct {
+            pos: usize,
+            keys: [][]const u8,
+            values: [][]const u8,
+
+            const KV = struct {
+                key: []const u8,
+                value: []const u8,
+            };
+
+            pub fn next(self: *Iterator) ?KV {
+                const pos = self.pos;
+                if (pos == self.keys.len) {
+                    return null;
+                }
+
+                self.pos = pos + 1;
+                return .{
+                    .key = self.keys[pos],
+                    .value = self.values[pos],
+                };
+            }
+        };
+    };
+};
+
+pub const Pool = struct {
+    mutex: std.Thread.Mutex,
+    available: usize,
+    allocator: Allocator,
+    buffer_size: usize,
+    max_req_headers: usize,
+    max_res_headers: usize,
+    states: []*Handshake.State,
+
+    pub fn init(allocator: Allocator, count: usize, buffer_size: usize, max_req_headers: usize, max_res_headers: usize) !*Pool {
+        const states = try allocator.alloc(*Handshake.State, count);
+        errdefer allocator.free(states);
+
+        const pool = try allocator.create(Pool);
+        errdefer allocator.destroy(pool);
+
+        pool.* = .{
+            .mutex = .{},
+            .states = states,
+            .allocator = allocator,
+            .available = count,
+            .buffer_size = buffer_size,
+            .max_req_headers = max_req_headers,
+            .max_res_headers = max_res_headers,
+        };
+
+        for (0..count) |i| {
+            const state = try allocator.create(Handshake.State);
+            errdefer allocator.destroy(state);
+
+            state.* = try Handshake.State.init(pool);
+            states[i] = state;
+        }
+
+        return pool;
+    }
+
+    pub fn deinit(self: *Pool) void {
+        const allocator = self.allocator;
+        for (self.states) |s| {
+            s.deinit();
+            allocator.destroy(s);
+        }
+        allocator.free(self.states);
+        allocator.destroy(self);
+    }
+
+    pub fn acquire(self: *Pool) !*Handshake.State {
+        const states = self.states;
+
+        self.mutex.lock();
+        const available = self.available;
+        if (available == 0) {
+            // dont hold the lock over factory
+            self.mutex.unlock();
+
+            const allocator = self.allocator;
+            const state = try allocator.create(Handshake.State);
+            errdefer allocator.destroy(state);
+            state.* = try Handshake.State.init(self);
+            return state;
+        }
+        const index = available - 1;
+        const state = states[index];
+        self.available = index;
+        self.mutex.unlock();
+        return state;
+    }
+
+    fn release(self: *Pool, state: *Handshake.State) void {
+        var states = self.states;
+
+        self.mutex.lock();
+        const available = self.available;
+        if (available == states.len) {
+            self.mutex.unlock();
+            state.deinit();
+            self.allocator.destroy(state);
+            return;
+        }
+        states[available] = state;
+        self.available = available + 1;
+        self.mutex.unlock();
+    }
+};
+
+fn toLower(str: []u8) []u8 {
+    for (str, 0..) |c, i| {
+        str[i] = ascii.toLower(c);
+    }
+    return str;
+}
+
+const t = @import("../t.zig");
+test "handshake: parse" {
+    var pool = try Pool.init(t.allocator, 1, 512, 10, 1);
+    defer pool.deinit();
+
+    {
+        var state = try pool.acquire();
+        defer state.release();
+
+        try t.expectEqual(null, try testHandshake("", state));
+        try t.expectEqual(null, try testHandshake("GET", state));
+        try t.expectEqual(null, try testHandshake("GET 1 HTTP/1.0\r", state));
+        try t.expectEqual(null, try testHandshake("GET 1 HTTP/1.0\r\n", state));
+
+        try t.expectError(error.InvalidProtocol, testHandshake("GET / HTTP/1.0\r\n\r\n", state));
+        try t.expectError(error.MissingHeaders, testHandshake("GET / HTTP/1.1\r\n\r\n", state));
+        try t.expectError(error.MissingHeaders, testHandshake("GET / HTTP/1.1\r\nConnection:  upgrade\r\n\r\n", state));
+        try t.expectError(error.MissingHeaders, testHandshake("GET / HTTP/1.1\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n", state));
+        try t.expectError(error.MissingHeaders, testHandshake("GET / HTTP/1.1\r\nConnection: upgrade\r\nUpgrade: websocket\r\nsec-websocket-version:13\r\n\r\n", state));
+    }
+
+    {
+        var state = try pool.acquire();
+        defer state.release();
+
+        const h = (try testHandshake("GET /test?a=1   HTTP/1.1\r\nConnection: upgrade\r\nUpgrade: websocket\r\nsec-websocket-version:13\r\nsec-websocket-key: 9000!\r\nCustom:  Header-Value\r\n\r\n", state)).?;
+        try t.expectString("9000!", h.key);
+        try t.expectString("GET", h.method);
+        try t.expectString("/test?a=1", h.url);
+        try t.expectString("connection: upgrade\r\nupgrade: websocket\r\nsec-websocket-version:13\r\nsec-websocket-key: 9000!\r\ncustom:  Header-Value\r\n", h.raw_header);
+        try t.expectString("Header-Value", h.headers.get("custom").?);
+
+        var it = h.headers.iterator();
+        {
+            const kv = it.next().?;
+            try t.expectString("connection", kv.key);
+            try t.expectString("upgrade", kv.value);
+        }
+
+        {
+            const kv = it.next().?;
+            try t.expectString("upgrade", kv.key);
+            try t.expectString("websocket", kv.value);
+        }
+
+        {
+            const kv = it.next().?;
+            try t.expectString("sec-websocket-version", kv.key);
+            try t.expectString("13", kv.value);
+        }
+
+        {
+            const kv = it.next().?;
+            try t.expectString("sec-websocket-key", kv.key);
+            try t.expectString("9000!", kv.value);
+        }
+
+        {
+            const kv = it.next().?;
+            try t.expectString("custom", kv.key);
+            try t.expectString("Header-Value", kv.value);
+        }
+
+        try t.expectEqual(null, it.next());
+    }
+}
+
+test "handshake: reply" {
+    var buf: [512]u8 = undefined;
+
+    {
+        // no compression
+        const expected =
+            "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\n" ++
+            "Connection: upgrade\r\n" ++
+            "Sec-Websocket-Accept: flzHu2DevQ2dSCSVqKSii5e9C2o=\r\n\r\n";
+        try t.expectString(expected, try Handshake.createReply("this is my key", null, false, &buf));
+    }
+
+    {
+        // compression
+        const expected =
+            "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\n" ++
+            "Connection: upgrade\r\n" ++
+            "Sec-Websocket-Accept: flzHu2DevQ2dSCSVqKSii5e9C2o=\r\n" ++
+            "Sec-WebSocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover\r\n\r\n";
+        try t.expectString(expected, try Handshake.createReply("this is my key", null, true, &buf));
+    }
+
+    // With custom headers
+    var res_headers = try Handshake.KeyValue.init(t.allocator, 2);
+    defer res_headers.deinit(t.allocator);
+    res_headers.add("Set-Cookie", "Yummy!");
+
+    {
+        // no compression
+        const expected =
+            "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\n" ++
+            "Connection: upgrade\r\n" ++
+            "Sec-Websocket-Accept: flzHu2DevQ2dSCSVqKSii5e9C2o=\r\n" ++
+            "Set-Cookie: Yummy!\r\n\r\n";
+        try t.expectString(expected, try Handshake.createReply("this is my key", &res_headers, false, &buf));
+    }
+
+    {
+        // compression
+        const expected =
+            "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\n" ++
+            "Connection: upgrade\r\n" ++
+            "Sec-Websocket-Accept: flzHu2DevQ2dSCSVqKSii5e9C2o=\r\n" ++
+            "Sec-WebSocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover\r\n" ++
+            "Set-Cookie: Yummy!\r\n\r\n";
+        try t.expectString(expected, try Handshake.createReply("this is my key", &res_headers, true, &buf));
+    }
+}
+
+test "KeyValue: get" {
+    const allocator = t.allocator;
+    var kv = try Handshake.KeyValue.init(allocator, 2);
+    defer kv.deinit(t.allocator);
+
+    var key = "content-type".*;
+    kv.add(&key, "application/json");
+
+    try t.expectString("application/json", kv.get("content-type").?);
+
+    kv.len = 0;
+    try t.expectEqual(null, kv.get("content-type"));
+    kv.add(&key, "application/json2");
+    try t.expectString("application/json2", kv.get("content-type").?);
+}
+
+test "KeyValue: ignores beyond max" {
+    var kv = try Handshake.KeyValue.init(t.allocator, 2);
+    defer kv.deinit(t.allocator);
+
+    var n1 = "content-length".*;
+    kv.add(&n1, "cl");
+
+    var n2 = "host".*;
+    kv.add(&n2, "www");
+
+    var n3 = "authorization".*;
+    kv.add(&n3, "hack");
+
+    try t.expectString("cl", kv.get("content-length").?);
+    try t.expectString("www", kv.get("host").?);
+    try t.expectEqual(null, kv.get("authorization"));
+}
+
+test "pool: acquire and release" {
+    // not 100% sure this is testing exactly what I want, but it's ....something ?
+    var p = try Pool.init(t.allocator, 2, 10, 3, 1);
+    defer p.deinit();
+
+    var hs1a = p.acquire() catch unreachable;
+    var hs2a = p.acquire() catch unreachable;
+    var hs3a = p.acquire() catch unreachable; // this should be dynamically generated
+
+    try t.expectEqual(false, &hs1a.buf[0] == &hs2a.buf[0]);
+    try t.expectEqual(false, &hs2a.buf[0] == &hs3a.buf[0]);
+    try t.expectEqual(10, hs1a.buf.len);
+    try t.expectEqual(10, hs2a.buf.len);
+    try t.expectEqual(10, hs3a.buf.len);
+    try t.expectEqual(0, hs1a.req_headers.len);
+    try t.expectEqual(0, hs2a.req_headers.len);
+    try t.expectEqual(0, hs3a.req_headers.len);
+    try t.expectEqual(3, hs1a.req_headers.keys.len);
+    try t.expectEqual(3, hs2a.req_headers.keys.len);
+    try t.expectEqual(3, hs3a.req_headers.keys.len);
+
+    p.release(hs1a);
+
+    var hs1b = p.acquire() catch unreachable;
+    try t.expectEqual(true, &hs1a.buf[0] == &hs1b.buf[0]);
+
+    p.release(hs3a);
+    p.release(hs2a);
+    p.release(hs1b);
+}
+
+test "Handshake.Pool: threadsafety" {
+    var p = try Pool.init(t.allocator, 4, 10, 2, 2);
+    defer p.deinit();
+
+    for (p.states) |hs| {
+        hs.buf[0] = 0;
+    }
+
+    const t1 = try std.Thread.spawn(.{}, testPool, .{p});
+    const t2 = try std.Thread.spawn(.{}, testPool, .{p});
+    const t3 = try std.Thread.spawn(.{}, testPool, .{p});
+    const t4 = try std.Thread.spawn(.{}, testPool, .{p});
+
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
+}
+
+fn testPool(p: *Pool) void {
+    var r = t.getRandom();
+    const random = r.random();
+
+    for (0..5000) |_| {
+        var hs = p.acquire() catch unreachable;
+        std.debug.assert(hs.buf[0] == 0);
+        hs.buf[0] = 255;
+        std.Thread.sleep(random.uintAtMost(u32, 100000));
+        hs.buf[0] = 0;
+        p.release(hs);
+    }
+}
+
+fn testHandshake(request: []const u8, state: *Handshake.State) !?Handshake {
+    @memcpy(state.buf[0..request.len], request);
+    state.len = request.len;
+    return Handshake.parse(state);
+}

--- a/vendor/websocket/src/server/server.zig
+++ b/vendor/websocket/src/server/server.zig
@@ -1,0 +1,2103 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const proto = @import("../proto.zig");
+const buffer = @import("../buffer.zig");
+
+const net = std.net;
+const posix = std.posix;
+const Thread = std.Thread;
+const Allocator = std.mem.Allocator;
+const FixedBufferAllocator = std.heap.FixedBufferAllocator;
+
+const log = std.log.scoped(.websocket);
+
+const OpCode = proto.OpCode;
+const Reader = proto.Reader;
+const Message = proto.Message;
+pub const Handshake = @import("handshake.zig").Handshake;
+const Compression = @import("../websocket.zig").Compression;
+const FallbackAllocator = @import("fallback_allocator.zig").FallbackAllocator;
+
+const DEFAULT_MAX_CONN = 16_384;
+const DEFAULT_BUFFER_SIZE = 2048;
+const DEFAULT_MAX_MESSAGE_SIZE = 65_536;
+
+const EMPTY_PONG = ([2]u8{ @intFromEnum(OpCode.pong), 0 })[0..];
+// CLOSE, 2 length, code
+const CLOSE_NORMAL = ([_]u8{ @intFromEnum(OpCode.close), 2, 3, 232 })[0..]; // code: 1000
+const CLOSE_PROTOCOL_ERROR = ([_]u8{ @intFromEnum(OpCode.close), 2, 3, 234 })[0..]; //code: 1002
+
+const force_blocking: bool = blk: {
+    const build = @import("build");
+    if (@hasDecl(build, "websocket_blocking")) {
+        break :blk build.websocket_blocking;
+    }
+    break :blk false;
+};
+
+pub fn blockingMode() bool {
+    if (force_blocking) {
+        return true;
+    }
+    return switch (builtin.os.tag) {
+        .linux, .macos, .ios, .tvos, .watchos, .freebsd, .netbsd, .dragonfly, .openbsd => false,
+        else => true,
+    };
+}
+
+pub const Config = struct {
+    port: u16 = 9882,
+    address: []const u8 = "127.0.0.1",
+    unix_path: ?[]const u8 = null,
+
+    worker_count: ?u8 = null,
+
+    max_conn: ?usize = null,
+    max_message_size: ?usize = null,
+
+    handshake: Config.Handshake = .{},
+    thread_pool: ThreadPool = .{},
+    buffers: Config.Buffers = .{},
+    compression: ?Compression = null,
+
+    pub const ThreadPool = struct {
+        count: ?u16 = null,
+        backlog: ?u32 = null,
+        buffer_size: ?usize = null,
+    };
+
+    pub const Handshake = struct {
+        timeout: u32 = 10,
+        max_size: ?u16 = null,
+        max_headers: ?u16 = null,
+        max_res_headers: ?u16 = null,
+        count: ?u16 = null,
+    };
+
+    pub const Buffers = struct {
+        small_size: ?usize = null,
+        small_pool: ?usize = null,
+        large_size: ?usize = null,
+        large_pool: ?u16 = null,
+    };
+
+    fn workerCount(self: *const Config) usize {
+        if (comptime blockingMode()) {
+            return 1;
+        }
+        return self.worker_count orelse 1;
+    }
+};
+
+pub fn Server(comptime H: type) type {
+    return struct {
+        config: Config,
+        allocator: Allocator,
+
+        _state: WorkerState,
+        _signals: []posix.fd_t,
+        _mut: Thread.Mutex,
+        _cond: Thread.Condition,
+
+        const Self = @This();
+
+        pub fn init(allocator: Allocator, config: Config) !Self {
+            if (blockingMode()) {
+                if (config.buffers.small_pool) |p| {
+                    if (p > 1) {
+                        log.warn("blockingMode() cannot utilize a small buffer pool, using per-connection buffer instead", .{});
+                    }
+                }
+            }
+
+            if (config.compression != null) {
+                log.err("Compression is disabled as part of the 0.15 upgrade. I do hope to re-enable it soon.", .{});
+                return error.InvalidConfiguraion;
+            }
+
+            const signals = try allocator.alloc(posix.fd_t, config.workerCount());
+            errdefer allocator.free(signals);
+
+            var state = try WorkerState.init(allocator, config);
+            errdefer state.deinit();
+
+            return .{
+                ._mut = .{},
+                ._cond = .{},
+                ._state = state,
+                ._signals = signals,
+                .config = config,
+                .allocator = allocator,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self._state.deinit();
+            self.allocator.free(self._signals);
+        }
+
+        pub fn listenInNewThread(self: *Self, ctx: anytype) !Thread {
+            self._mut.lock();
+            defer self._mut.unlock();
+            const thrd = try Thread.spawn(.{}, Self.listen, .{ self, ctx });
+
+            // we don't return until listen() signals us that the server is up
+            self._cond.wait(&self._mut);
+            return thrd;
+        }
+
+        pub fn listen(self: *Self, ctx: anytype) !void {
+            self._mut.lock();
+            errdefer {
+                self._cond.signal();
+                self._mut.unlock();
+            }
+
+            const config = &self.config;
+
+            var no_delay = true;
+            const address = blk: {
+                if (config.unix_path) |unix_path| {
+                    if (comptime std.net.has_unix_sockets == false) {
+                        return error.UnixPathNotSupported;
+                    }
+                    no_delay = false;
+                    std.fs.deleteFileAbsolute(unix_path) catch {};
+                    break :blk try net.Address.initUnix(unix_path);
+                } else {
+                    const listen_port = config.port;
+                    const listen_address = config.address;
+                    break :blk try net.Address.parseIp(listen_address, listen_port);
+                }
+            };
+
+            const socket = blk: {
+                var sock_flags: u32 = posix.SOCK.STREAM | posix.SOCK.CLOEXEC;
+                if (blockingMode() == false) sock_flags |= posix.SOCK.NONBLOCK;
+
+                const socket_proto = if (address.any.family == posix.AF.UNIX) @as(u32, 0) else posix.IPPROTO.TCP;
+                break :blk try posix.socket(address.any.family, sock_flags, socket_proto);
+            };
+
+            if (no_delay) {
+                // TODO: Broken on darwin:
+                // https://github.com/ziglang/zig/issues/17260
+                // if (@hasDecl(os.TCP, "NODELAY")) {
+                //  try os.setsockopt(socket.sockfd.?, os.IPPROTO.TCP, os.TCP.NODELAY, &std.mem.toBytes(@as(c_int, 1)));
+                // }
+                try posix.setsockopt(socket, posix.IPPROTO.TCP, 1, &std.mem.toBytes(@as(c_int, 1)));
+            }
+
+            if (@hasDecl(posix.SO, "REUSEPORT_LB")) {
+                try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.REUSEPORT_LB, &std.mem.toBytes(@as(c_int, 1)));
+            } else if (@hasDecl(posix.SO, "REUSEPORT")) {
+                try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.REUSEPORT, &std.mem.toBytes(@as(c_int, 1)));
+            } else {
+                try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
+            }
+
+            {
+                const socklen = address.getOsSockLen();
+                try posix.bind(socket, &address.any, socklen);
+                try posix.listen(socket, 1024); // kernel backlog
+            }
+
+            const C = @TypeOf(ctx);
+
+            if (comptime blockingMode()) {
+                errdefer posix.close(socket);
+                var w = try Blocking(H).init(self.allocator, &self._state);
+                defer w.deinit();
+
+                const thrd = try std.Thread.spawn(.{}, Blocking(H).run, .{ &w, socket, ctx });
+                log.info("starting blocking worker to listen on {f}", .{address});
+
+                // incase listenInNewThread was used and is waiting for us to start
+                self._cond.signal();
+
+                // this is what we'll shutdown when stop() is called
+                self._signals[0] = socket;
+                self._mut.unlock();
+                thrd.join();
+            } else {
+                defer posix.close(socket);
+                const W = NonBlocking(H, C);
+
+                const allocator = self.allocator;
+
+                var signals = self._signals;
+                const worker_count = signals.len;
+                const threads = try allocator.alloc(Thread, worker_count);
+                const workers = try allocator.alloc(W, worker_count);
+
+                var started: usize = 0;
+
+                errdefer for (0..started) |i| {
+                    // on success, these will be closed by a call to stop();
+                    posix.close(signals[i]);
+                };
+
+                defer {
+                    for (0..started) |i| {
+                        workers[i].deinit();
+                    }
+                    allocator.free(threads);
+                    allocator.free(workers);
+                }
+
+                for (0..worker_count) |i| {
+                    const pipe = try posix.pipe2(.{ .NONBLOCK = true });
+                    errdefer posix.close(pipe[1]);
+
+                    workers[i] = try W.init(self.allocator, &self._state, ctx);
+                    errdefer workers[i].deinit();
+
+                    threads[i] = try Thread.spawn(.{}, W.run, .{ &workers[i], socket, pipe[0] });
+
+                    signals[i] = pipe[1];
+                    started += 1;
+                }
+
+                log.info("starting nonblocking worker to listen on {f}", .{address});
+
+                // in case startInNewThread is waiting
+                self._cond.signal();
+
+                self._mut.unlock();
+
+                for (threads) |thrd| {
+                    thrd.join();
+                }
+            }
+            self._cond.signal();
+        }
+
+        pub fn stop(self: *Self) void {
+            self._mut.lock();
+            defer self._mut.unlock();
+            for (self._signals) |s| {
+                if (blockingMode()) {
+                    // necessary to unblock accept on linux
+                    // (which might not be that necessary since, on Linux,
+                    // NonBlocking should be used)
+                    posix.shutdown(s, .recv) catch {};
+                }
+                posix.close(s);
+            }
+            self._cond.wait(&self._mut);
+        }
+    };
+}
+
+// This is our Blocking worker. It's very different than NonBlocking and much simpler.
+pub fn Blocking(comptime H: type) type {
+    return struct {
+        allocator: Allocator,
+        handshake_timeout: Timeout,
+        connection_buffer_size: usize,
+        conn_manager: ConnManager(H, false),
+        handshake_pool: *Handshake.Pool,
+        buffer_provider: *buffer.Provider,
+        compression: ?Compression,
+
+        const Timeout = struct {
+            sec: u32,
+            timeval: [@sizeOf(std.posix.timeval)]u8,
+
+            // if sec is null, it means we want to cancel the timeout.
+            fn init(sec: u32) Timeout {
+                return .{
+                    .sec = sec,
+                    .timeval = std.mem.toBytes(posix.timeval{ .sec = @intCast(sec), .usec = 0 }),
+                };
+            }
+
+            pub const none = std.mem.toBytes(posix.timeval{ .sec = 0, .usec = 0 });
+        };
+
+        const Self = @This();
+
+        pub fn init(allocator: Allocator, state: *WorkerState) !Self {
+            const config = &state.config;
+
+            var conn_manager = try ConnManager(H, false).init(allocator, config.compression);
+            errdefer conn_manager.deinit();
+
+            return .{
+                .conn_manager = conn_manager,
+                .allocator = allocator,
+                .compression = config.compression,
+                .handshake_pool = state.handshake_pool,
+                .buffer_provider = &state.buffer_provider,
+                .handshake_timeout = Timeout.init(config.handshake.timeout),
+                .connection_buffer_size = config.buffers.small_size orelse DEFAULT_BUFFER_SIZE,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.conn_manager.deinit();
+        }
+
+        pub fn run(self: *Self, listener: posix.socket_t, ctx: anytype) void {
+            defer self.shutdown();
+            while (true) {
+                var address: net.Address = undefined;
+                var address_len: posix.socklen_t = @sizeOf(net.Address);
+                const socket = posix.accept(listener, &address.any, &address_len, posix.SOCK.CLOEXEC) catch |err| {
+                    if (err == error.ConnectionAborted or err == error.SocketNotListening) {
+                        log.info("received shutdown signal", .{});
+                        return;
+                    }
+                    log.err("failed to accept socket: {}", .{err});
+                    continue;
+                };
+                log.debug("({f}) connected", .{address});
+
+                const thread = std.Thread.spawn(.{}, Self.handleConnection, .{ self, socket, address, ctx }) catch |err| {
+                    posix.close(socket);
+                    log.err("({f}) failed to spawn connection thread: {}", .{ address, err });
+                    continue;
+                };
+                thread.detach();
+            }
+        }
+
+        // Called in a thread started above in listen.
+        // Wrapper around _handleConnection so that we can handle erros
+        fn handleConnection(self: *Self, socket: posix.socket_t, address: net.Address, ctx: anytype) void {
+            self._handleConnection(socket, address, ctx) catch |err| {
+                log.err("({f}) uncaught error in connection handler: {}", .{ address, err });
+            };
+        }
+
+        fn _handleConnection(self: *Self, socket: posix.socket_t, address: net.Address, ctx: anytype) !void {
+            const conn_manager = &self.conn_manager;
+            const hc = try conn_manager.create(socket, address, timestamp());
+
+            {
+                // Do our handshake
+                errdefer self.cleanupConn(hc);
+                const timeout = self.handshake_timeout;
+                const deadline = timestamp() + timeout.sec;
+                try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &timeout.timeval);
+
+                while (true) {
+                    const compression, const ok = handleHandshake(H, self, hc, ctx);
+                    if (ok == false) {
+                        self.cleanupConn(hc);
+                        return;
+                    }
+                    if (hc.handler != null) {
+                        // if we have a handler, the our handshake completed
+                        if (compression) {
+                            try conn_manager.setupCompression(hc);
+                        }
+                        break;
+                    }
+                    if (timestamp() > deadline) {
+                        self.cleanupConn(hc);
+                        return;
+                    }
+                }
+            }
+
+            return self.readLoop(hc);
+        }
+
+        // The readloop is extracted from _handleConnection so that it can be called
+        // directly when integrating with an http server
+        pub fn readLoop(self: *Self, hc: *HandlerConn(H)) !void {
+            defer self.cleanupConn(hc);
+            try posix.setsockopt(hc.socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &Timeout.none);
+
+            // In BlockingMode, we always assign a reader for the duration of the connection
+            // In scenarios where client rarely send data, this is going to use up an unecessary amount
+            // of memory, but unlike nonblocking mode, we can't initialize the buffer just-in-time.
+            const reader_buf = try self.allocator.alloc(u8, self.connection_buffer_size);
+            defer self.allocator.free(reader_buf);
+
+            hc.reader = Reader.init(reader_buf, self.buffer_provider, hc.compression);
+            while (true) {
+                if (handleClientData(H, hc, self.allocator, undefined) == false) {
+                    break;
+                }
+            }
+        }
+
+        fn cleanupConn(self: *Self, hc: *HandlerConn(H)) void {
+            hc.conn.closeSocket();
+            self.conn_manager.cleanup(hc);
+        }
+
+        fn shutdown(self: *Self) void {
+            var conn_manager = &self.conn_manager;
+            conn_manager.shutdown(self);
+
+            // wait up to 1 second for every connection to cleanly shutdown
+            var i: usize = 0;
+            while (i < 10) : (i += 1) {
+                if (conn_manager.count() == 0) {
+                    return;
+                }
+                std.Thread.sleep(std.time.ns_per_ms * 100);
+            }
+        }
+
+        // called for each hc when shutting down
+        fn shutdownCleanup(_: *Self, hc: *HandlerConn(H)) void {
+            posix.shutdown(hc.socket, .recv) catch {};
+        }
+    };
+}
+
+fn NonBlocking(comptime H: type, comptime C: type) type {
+    return struct {
+        ctx: C,
+
+        max_conn: usize,
+
+        // KQueue or Epoll, depending on the platform
+        loop: Loop,
+        thread_pool: *ThreadPool,
+
+        handshake_timeout: u32,
+        handshake_pool: *Handshake.Pool,
+        base: NonBlockingBase(H, true),
+        compression: ?Compression,
+
+        const Self = @This();
+        const ThreadPool = @import("thread_pool.zig").ThreadPool(Self.dataAvailable);
+
+        pub fn init(allocator: Allocator, state: *WorkerState, ctx: C) !Self {
+            var base = try NonBlockingBase(H, true).init(allocator, state);
+            errdefer base.deinit();
+
+            const loop = try Loop.init();
+            errdefer loop.deinit();
+
+            const config = &state.config;
+            var thread_pool = try ThreadPool.init(allocator, .{
+                .count = config.thread_pool.count orelse 4,
+                .backlog = config.thread_pool.backlog orelse 500,
+                .buffer_size = config.thread_pool.buffer_size orelse if (needsAllocator(H)) 32_768 else 0,
+            });
+            errdefer thread_pool.deinit();
+
+            return .{
+                .ctx = ctx,
+                .loop = loop,
+                .base = base,
+                .thread_pool = thread_pool,
+                .compression = config.compression,
+                .handshake_pool = state.handshake_pool,
+                .handshake_timeout = state.config.handshake.timeout,
+                .max_conn = config.max_conn orelse DEFAULT_MAX_CONN,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.loop.deinit();
+            self.base.deinit();
+            self.thread_pool.deinit();
+        }
+
+        fn run(self: *Self, listener: posix.socket_t, signal: posix.fd_t) void {
+            self.loop.monitorAccept(listener) catch |err| {
+                log.err("failed to add monitor to listening socket: {}", .{err});
+                return;
+            };
+
+            self.loop.monitorSignal(signal) catch |err| {
+                log.err("failed to add monitor to signal pipe: {}", .{err});
+                return;
+            };
+
+            const thread_pool = self.thread_pool;
+            const conn_manager = &self.base.conn_manager;
+            const handshake_timeout = self.handshake_timeout;
+
+            var now = timestamp();
+            var oldest_pending_start_time: ?u32 = null;
+            while (true) {
+                const handshake_cutoff = now - handshake_timeout;
+                const timeout = self.prepareToWait(handshake_cutoff) orelse blk: {
+                    if (oldest_pending_start_time) |started| {
+                        break :blk if (started < handshake_cutoff) 1 else @as(i32, @intCast(started - handshake_cutoff));
+                    }
+                    break :blk null;
+                };
+
+                var it = self.loop.wait(timeout) catch |err| {
+                    log.err("failed to wait on events: {}", .{err});
+                    std.Thread.sleep(std.time.ns_per_s);
+                    continue;
+                };
+
+                now = timestamp();
+                oldest_pending_start_time = null;
+                while (it.next()) |data| {
+                    if (data == 0) {
+                        self.accept(listener, now) catch |err| {
+                            log.err("accept error: {}", .{err});
+                            std.Thread.sleep(std.time.ns_per_ms);
+                        };
+                        continue;
+                    }
+
+                    if (data == 1) {
+                        self.base.shutdown();
+                        return;
+                    }
+
+                    const hc: *HandlerConn(H) = @ptrFromInt(data);
+                    if (hc.state == .handshake) {
+                        // we need to get this out of the pending list, so that it doesn't
+                        // cause a timeout while we're processing it.
+                        // But we stll need to care about its timeout.
+                        if (oldest_pending_start_time) |s| {
+                            oldest_pending_start_time = @min(hc.conn.started, s);
+                        } else {
+                            oldest_pending_start_time = hc.conn.started;
+                        }
+                        conn_manager.activate(hc);
+                    }
+                    thread_pool.spawn(.{ self, hc });
+                }
+            }
+        }
+
+        // Enforces timeouts, and returns when the next timeout should be checked.
+        fn prepareToWait(self: *Self, cutoff: u32) ?i32 {
+            const cm = &self.base.conn_manager;
+
+            // always ordered from oldest to newest, so once we find a conneciton
+            // that isn't timed out, we can stop
+            cm.lock.lock();
+            defer cm.lock.unlock();
+
+            var next_conn = cm.pending.head;
+            while (next_conn) |hc| {
+                const conn = &hc.conn;
+                const started = conn.started;
+                if (started > cutoff) {
+                    // This is the first connection which hasn't timed out
+                    // return the time until it times out.
+                    return @intCast(started - cutoff);
+                }
+
+                next_conn = hc.next;
+
+                // this connection has timed out. Don't use self.cleanup since there's
+                // a bunch of stuff we can assume here..like there's no handler or reader
+                conn.closeSocket();
+                log.debug("({f}) handshake timeout", .{conn.address});
+                if (hc.handshake) |h| {
+                    h.release();
+                }
+                cm.pending.remove(hc);
+                cm.pool.destroy(hc);
+            }
+            return null;
+        }
+
+        fn accept(self: *Self, listener: posix.fd_t, now: u32) !void {
+            const max_conn = self.max_conn;
+            const conn_manager = &self.base.conn_manager;
+
+            while (conn_manager.count() < max_conn) {
+                var address: net.Address = undefined;
+                var address_len: posix.socklen_t = @sizeOf(net.Address);
+
+                const socket = posix.accept(listener, &address.any, &address_len, posix.SOCK.CLOEXEC) catch |err| {
+                    // When available, we use SO_REUSEPORT_LB or SO_REUSEPORT, so WouldBlock
+                    // should not be possible in those cases, but if it isn't available
+                    // this error should be ignored as it means another thread picked it up.
+                    return if (err == error.WouldBlock) {} else err;
+                };
+
+                log.debug("({f}) connected", .{address});
+
+                {
+                    errdefer posix.close(socket);
+                    // socket is _probably_ in NONBLOCKING mode (it inherits
+                    // the flag from the listening socket).
+                    const flags = try posix.fcntl(socket, posix.F.GETFL, 0);
+                    const nonblocking = @as(u32, @bitCast(posix.O{ .NONBLOCK = true }));
+                    if (flags & nonblocking == nonblocking) {
+                        // Yup, it's in nonblocking mode. Disable that flag to
+                        // put it in blocking mode.
+                        _ = try posix.fcntl(socket, posix.F.SETFL, flags & ~nonblocking);
+                    }
+                }
+                const hc = try self.base.newConn(socket, address, now);
+                self.loop.monitorRead(hc, false) catch |err| {
+                    self.base.cleanupConn(hc);
+                    return err;
+                };
+            }
+        }
+
+        // Called in a thread-pool thread/
+        // !! Access to self has to be synchronized !!
+        // There can only be 1 dataAvailable executing per HC at any given time.
+        // Access to HC *should not* need to be synchronized. Access to hc.conn
+        // needs to be synchronized once &hc.conn is passed to the handler during
+        // handshake (Conn is self-synchronized).
+        // Shutdown throws a wrench in our synchronization model, since we could
+        // be shutting down while we're processing data...but hopefully the way we
+        // shutdown (by waiting for all the thread pools threads to end) solves this.
+        // Else, we'll need to throw a bunch of locking around HC just to handle shutdown.
+        fn dataAvailable(self: *Self, hc: *HandlerConn(H), thread_buf: []u8) void {
+            var success = false;
+            {
+                hc.cleanup.lock();
+                defer hc.cleanup.unlock();
+                if (hc.handler == null) {
+                    success = self.dataForHandshake(hc) catch |err| blk: {
+                        log.err("({f}) error processing handshake: {}", .{ hc.conn.address, err });
+                        break :blk false;
+                    };
+                } else {
+                    success = self.base.dataAvailable(hc, thread_buf);
+                }
+            }
+
+            var conn = &hc.conn;
+            var closed: bool = undefined;
+            if (success == false) {
+                conn.closeSocket();
+                closed = true;
+            } else {
+                closed = conn.isClosed();
+            }
+
+            if (closed) {
+                self.base.cleanupConn(hc);
+            } else {
+                self.loop.monitorRead(hc, true) catch |err| {
+                    log.debug("({f}) failed to add read event monitor: {}", .{ conn.address, err });
+                    conn.closeSocket();
+                    self.base.cleanupConn(hc);
+                };
+            }
+        }
+
+        fn dataForHandshake(self: *Self, hc: *HandlerConn(H)) !bool {
+            var conn_manager = &self.base.conn_manager;
+            const compression, const ok = handleHandshake(H, self, hc, self.ctx);
+            if (ok == false) {
+                return false;
+            }
+
+            if (hc.handler == null) {
+                // still don't have a handshake
+                conn_manager.inactive(hc);
+            }
+
+            if (compression) {
+                try conn_manager.setupCompression(hc);
+            }
+            return true;
+        }
+    };
+}
+
+fn NonBlockingBase(comptime H: type, comptime MANAGE_HS: bool) type {
+    return struct {
+        allocator: Allocator,
+
+        buffer_provider: *buffer.Provider,
+
+        // App can configure the use of a "small" buffer pool. This is the difference
+        // between assigning a buffer to the connection just-in-time per message, or always
+        small_buffer_pool: ?buffer.Pool,
+        connection_buffer_size: usize,
+
+        conn_manager: ConnManager(H, MANAGE_HS),
+
+        const Self = @This();
+
+        fn init(allocator: Allocator, state: *WorkerState) !Self {
+            const config = &state.config;
+
+            var conn_manager = try ConnManager(H, MANAGE_HS).init(allocator, config.compression);
+            errdefer conn_manager.deinit();
+
+            const connection_buffer_size = config.buffers.small_size orelse DEFAULT_BUFFER_SIZE;
+            var small_buffer_pool: ?buffer.Pool = null;
+            if (config.buffers.small_pool) |pool_count| {
+                small_buffer_pool = try buffer.Pool.init(allocator, pool_count, connection_buffer_size);
+            }
+
+            errdefer if (small_buffer_pool) |sbp| {
+                sbp.deinit();
+            };
+
+            return .{
+                .allocator = allocator,
+                .conn_manager = conn_manager,
+                .small_buffer_pool = small_buffer_pool,
+                .buffer_provider = &state.buffer_provider,
+                .connection_buffer_size = connection_buffer_size,
+            };
+        }
+
+        fn deinit(self: *Self) void {
+            self.conn_manager.deinit();
+            if (self.small_buffer_pool) |*sbp| {
+                sbp.deinit();
+            }
+        }
+
+        fn newConn(self: *Self, socket: posix.socket_t, address: net.Address, time: u32) !*HandlerConn(H) {
+            return self.conn_manager.create(socket, address, time);
+        }
+
+        pub fn dataAvailable(self: *Self, hc: *HandlerConn(H), thread_buf: []u8) bool {
+            return self._dataAvailable(hc, thread_buf) catch |err| {
+                log.err("({f}) error processing client message: {}", .{ hc.conn.address, err });
+                return false;
+            };
+        }
+
+        fn _dataAvailable(self: *Self, hc: *HandlerConn(H), thread_buf: []u8) !bool {
+            if (hc.reader == null) {
+                const reader_buf = if (self.small_buffer_pool) |*sbp| try sbp.acquireOrCreate() else try self.allocator.alloc(u8, self.connection_buffer_size);
+                hc.reader = Reader.init(reader_buf, self.buffer_provider, hc.compression);
+            }
+            const reader = &hc.reader.?;
+
+            var fba = FixedBufferAllocator.init(thread_buf);
+            const ok = handleClientData(H, hc, self.allocator, &fba);
+
+            if (self.small_buffer_pool) |*sbp| {
+                if (reader.isEmpty()) {
+                    sbp.release(reader.static);
+                    hc.reader = null;
+                }
+            }
+
+            return ok;
+        }
+
+        fn cleanupConn(self: *Self, hc: *HandlerConn(H)) void {
+            {
+                hc.cleanup.lock();
+                defer hc.cleanup.unlock();
+                if (hc.reader) |*reader| {
+                    if (self.small_buffer_pool) |*sbp| {
+                        sbp.release(reader.static);
+                    } else {
+                        self.allocator.free(reader.static);
+                    }
+                    hc.reader = null;
+                }
+            }
+            self.conn_manager.cleanup(hc);
+        }
+
+        fn shutdown(self: *Self) void {
+            log.info("received shutdown signal", .{});
+            self.conn_manager.shutdown(self);
+        }
+
+        // called for each hc when shutting down
+        fn shutdownCleanup(self: *Self, hc: *HandlerConn(H)) void {
+            hc.cleanup.lock();
+            defer hc.cleanup.unlock();
+            if (hc.reader) |*reader| {
+                if (self.small_buffer_pool == null) {
+                    self.allocator.free(reader.static);
+                }
+                hc.reader = null;
+            }
+        }
+    };
+}
+
+const Loop = switch (@import("builtin").os.tag) {
+    .macos, .ios, .tvos, .watchos, .freebsd, .netbsd, .dragonfly, .openbsd => KQueue,
+    .linux => EPoll,
+    else => unreachable,
+};
+
+const KQueue = struct {
+    q: i32,
+    change_count: usize,
+    change_buffer: [16]Kevent,
+    event_list: [64]Kevent,
+
+    const Kevent = posix.Kevent;
+
+    fn init() !KQueue {
+        return .{
+            .q = try posix.kqueue(),
+            .change_count = 0,
+            .change_buffer = undefined,
+            .event_list = undefined,
+        };
+    }
+
+    fn deinit(self: KQueue) void {
+        posix.close(self.q);
+    }
+
+    fn monitorAccept(self: *KQueue, fd: c_int) !void {
+        try self.change(fd, 0, posix.system.EVFILT.READ, posix.system.EV.ADD);
+    }
+
+    fn monitorSignal(self: *KQueue, fd: c_int) !void {
+        try self.change(fd, 1, posix.system.EVFILT.READ, posix.system.EV.ADD);
+    }
+
+    // Normally, we add the socket in the worker thread with rearm == false.
+    // Because this is a DISPATCH, it'll only fire once until we rearm it which
+    // we do by re-enabling it with rearm == true.
+    // However, notice that the rearm path also has the EV.ADD flag. From the above
+    // description, this should not be necessary.
+    // But monitorRead where rearm == true is also used by our generic ServerLoop when
+    // taking over a connection (say from httpz). Hence, we need the EV.ADD flag too.
+    fn monitorRead(self: *KQueue, hc: anytype, comptime rearm: bool) !void {
+        if (rearm == false) {
+            return self.change(hc.socket, @intFromPtr(hc), posix.system.EVFILT.READ, posix.system.EV.ADD | posix.system.EV.ENABLE | posix.system.EV.DISPATCH);
+        }
+        const event = Kevent{
+            .ident = @intCast(hc.socket),
+            .filter = posix.system.EVFILT.READ,
+            .flags = posix.system.EV.ADD | posix.system.EV.ENABLE | posix.system.EV.DISPATCH,
+            .fflags = 0,
+            .data = 0,
+            .udata = @intFromPtr(hc),
+        };
+        _ = try posix.kevent(self.q, &.{event}, &[_]Kevent{}, null);
+    }
+
+    fn change(self: *KQueue, fd: posix.fd_t, data: usize, filter: i16, flags: u16) !void {
+        var change_count = self.change_count;
+        var change_buffer = &self.change_buffer;
+
+        if (change_count == change_buffer.len) {
+            // calling this with an empty event_list will return immediate
+            _ = try posix.kevent(self.q, change_buffer, &[_]Kevent{}, null);
+            change_count = 0;
+        }
+        change_buffer[change_count] = .{
+            .ident = @intCast(fd),
+            .filter = filter,
+            .flags = flags,
+            .fflags = 0,
+            .data = 0,
+            .udata = data,
+        };
+        self.change_count = change_count + 1;
+    }
+
+    fn wait(self: *KQueue, timeout_sec: ?i32) !Iterator {
+        const event_list = &self.event_list;
+        const timeout: ?posix.timespec = if (timeout_sec) |ts| posix.timespec{ .sec = ts, .nsec = 0 } else null;
+        const event_count = try posix.kevent(self.q, self.change_buffer[0..self.change_count], event_list, if (timeout) |ts| &ts else null);
+        self.change_count = 0;
+
+        return .{
+            .index = 0,
+            .events = event_list[0..event_count],
+        };
+    }
+
+    const Iterator = struct {
+        index: usize,
+        events: []Kevent,
+
+        fn next(self: *Iterator) ?usize {
+            const index = self.index;
+            const events = self.events;
+            if (index == events.len) {
+                return null;
+            }
+            self.index = index + 1;
+            return self.events[index].udata;
+        }
+    };
+};
+
+const EPoll = struct {
+    q: i32,
+    event_list: [64]EpollEvent,
+
+    const linux = std.os.linux;
+    const EpollEvent = linux.epoll_event;
+
+    fn init() !EPoll {
+        return .{
+            .event_list = undefined,
+            .q = try posix.epoll_create1(0),
+        };
+    }
+
+    fn deinit(self: EPoll) void {
+        posix.close(self.q);
+    }
+
+    fn monitorAccept(self: *EPoll, fd: c_int) !void {
+        var event = linux.epoll_event{ .events = linux.EPOLL.IN, .data = .{ .ptr = 0 } };
+        return std.posix.epoll_ctl(self.q, linux.EPOLL.CTL_ADD, fd, &event);
+    }
+
+    fn monitorSignal(self: *EPoll, fd: c_int) !void {
+        var event = linux.epoll_event{ .events = linux.EPOLL.IN, .data = .{ .ptr = 1 } };
+        return std.posix.epoll_ctl(self.q, linux.EPOLL.CTL_ADD, fd, &event);
+    }
+
+    fn monitorRead(self: *EPoll, hc: anytype, comptime rearm: bool) !void {
+        const op = if (rearm) linux.EPOLL.CTL_MOD else linux.EPOLL.CTL_ADD;
+        var event = linux.epoll_event{ .events = linux.EPOLL.IN | linux.EPOLL.ONESHOT, .data = .{ .ptr = @intFromPtr(hc) } };
+        return posix.epoll_ctl(self.q, op, hc.socket, &event);
+    }
+
+    fn wait(self: *EPoll, timeout_sec: ?i32) !Iterator {
+        const event_list = &self.event_list;
+        var timeout: i32 = -1;
+        if (timeout_sec) |sec| {
+            if (sec > 2147483) {
+                // max supported timeout by epoll_wait.
+                timeout = 2147483647;
+            } else {
+                timeout = sec * 1000;
+            }
+        }
+
+        const event_count = posix.epoll_wait(self.q, event_list, timeout);
+        return .{
+            .index = 0,
+            .events = event_list[0..event_count],
+        };
+    }
+
+    const Iterator = struct {
+        index: usize,
+        events: []EpollEvent,
+
+        fn next(self: *Iterator) ?usize {
+            const index = self.index;
+            const events = self.events;
+            if (index == events.len) {
+                return null;
+            }
+            self.index = index + 1;
+            return self.events[index].data.ptr;
+        }
+    };
+};
+
+// We want to extract as much common logic as possible from the Blocking and
+// NonBlockign workers. The code from this point on is meant to be used with
+// both workers, independently from the blocking/nonblocking nonsense.
+
+// Abstraction ontop of NonBlocking and Blocking. Exists solely for integration
+// with httpz (or any other http library I guess.). Serves a similar purpose
+// as Server, but doesn't accept/listen.
+pub fn Worker(comptime H: type) type {
+    return struct {
+        worker: W,
+
+        const Self = @This();
+        const W = if (blockingMode()) Blocking(H) else NonBlockingBase(H, false);
+
+        pub fn init(allocator: Allocator, state: *WorkerState) !Self {
+            return .{
+                .worker = try W.init(allocator, state),
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.worker.deinit();
+        }
+
+        pub fn createConn(self: *Self, socket: posix.socket_t, address: net.Address, now: u32) !*HandlerConn(H) {
+            return self.worker.conn_manager.create(socket, address, now);
+        }
+
+        pub fn cleanupConn(self: *Self, hc: *HandlerConn(H)) void {
+            self.worker.cleanupConn(hc);
+        }
+
+        pub fn canCompress(self: *const Self) bool {
+            return self.worker.conn_manager.compression != null;
+        }
+
+        pub fn setupConnection(
+            self: *Self,
+            hc: *HandlerConn(H),
+        ) !void {
+            return self.worker.conn_manager.setupCompression(hc);
+        }
+
+        pub fn shutdown(self: *Self) void {
+            self.worker.shutdown();
+        }
+    };
+}
+
+// These are things that both the Blocking and NonBlocking workers need. Just cleaner
+// to have a single place for it. This could used to be directly in Server(H), with
+// Server(H) having handshake_pool and buffer_provider fields, but it was extracted
+// into its own struct for integration with webservers (i.e. httpz). The goal is
+// that a webserver can have websocket support without starting a full Server.
+pub const WorkerState = struct {
+    config: Config,
+    handshake_pool: *Handshake.Pool,
+    buffer_provider: buffer.Provider,
+
+    pub fn init(allocator: Allocator, config: Config) !WorkerState {
+        const handshake_pool_count = config.handshake.count orelse 32;
+        const handshake_max_size = config.handshake.max_size orelse 1024;
+        const handshake_max_headers = config.handshake.max_headers orelse 10;
+        const handshake_max_res_headers = config.handshake.max_res_headers orelse 2;
+
+        var handshake_pool = try Handshake.Pool.init(allocator, handshake_pool_count, handshake_max_size, handshake_max_headers, handshake_max_res_headers);
+        errdefer handshake_pool.deinit();
+
+        const max_message_size = config.max_message_size orelse DEFAULT_MAX_MESSAGE_SIZE;
+        const large_buffer_pool = config.buffers.large_pool orelse 8;
+        const large_buffer_size = config.buffers.large_size orelse @min((config.buffers.small_size orelse DEFAULT_BUFFER_SIZE) * 2, max_message_size);
+
+        var buffer_provider = try buffer.Provider.init(allocator, .{
+            .max = max_message_size,
+            .size = large_buffer_size,
+            .count = large_buffer_pool,
+        });
+        errdefer buffer_provider.deinit();
+
+        return .{
+            .config = config,
+            .handshake_pool = handshake_pool,
+            .buffer_provider = buffer_provider,
+        };
+    }
+
+    pub fn deinit(self: *WorkerState) void {
+        self.handshake_pool.deinit();
+        self.buffer_provider.deinit();
+    }
+};
+
+// In the Blocking worker, all the state could be stored on the spawn'd threads
+// stack. The only reason we use a HandlerConn(H) in there is to be able to re-use
+// code with the NonBlocking worker.
+//
+// For the NonBlocking worker, HandlerConn(H) is critical as it contains all the
+// state for a connection. It lives on the heap, a pointer is registered into
+// the event loop, and passed back when data is ready to read.
+// * If handler is null, it means we haven't done our handshake yet.
+// * If handler is null AND handshake is null, it means we havent' received
+//   any data yet (we delay creating the handshake state until we at least have
+//   some data ready).
+pub fn HandlerConn(comptime H: type) type {
+    return struct {
+        state: State,
+        conn: Conn,
+        handler: ?H,
+        reader: ?Reader,
+        socket: posix.socket_t, // denormalization from conn.stream.handle
+        handshake: ?*Handshake.State,
+        cleanup: Thread.Mutex = .{},
+        compression: ?Compression = null,
+        next: ?*HandlerConn(H) = null,
+        prev: ?*HandlerConn(H) = null,
+
+        const State = enum {
+            handshake,
+            active,
+        };
+    };
+}
+
+pub fn ConnManager(comptime H: type, comptime MANAGE_HS: bool) type {
+    return struct {
+        lock: Thread.Mutex,
+        allocator: Allocator,
+        active: List(HandlerConn(H)),
+        pending: List(HandlerConn(H)),
+        pool: std.heap.MemoryPool(HandlerConn(H)),
+        compression: ?Compression,
+        compression_pool: std.heap.MemoryPool(Conn.Compression),
+
+        const Self = @This();
+
+        pub fn init(allocator: Allocator, compression: ?Compression) !Self {
+            var pool = std.heap.MemoryPool(HandlerConn(H)).init(allocator);
+            errdefer pool.deinit();
+
+            var compression_pool = std.heap.MemoryPool(Conn.Compression).init(allocator);
+            errdefer compression_pool.deinit();
+
+            return .{
+                .lock = .{},
+                .pool = pool,
+                .active = .{},
+                .pending = .{},
+                .allocator = allocator,
+                .compression = compression,
+                .compression_pool = compression_pool,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.pool.deinit();
+            self.compression_pool.deinit();
+        }
+
+        pub fn count(self: *Self) usize {
+            self.lock.lock();
+            defer self.lock.unlock();
+            if (MANAGE_HS == false) {
+                return self.active.len;
+            }
+            return self.active.len + self.pending.len;
+        }
+
+        pub fn create(self: *Self, socket: posix.socket_t, address: net.Address, now: u32) !*HandlerConn(H) {
+            errdefer posix.close(socket);
+
+            self.lock.lock();
+            defer self.lock.unlock();
+
+            const hc = try self.pool.create();
+            hc.* = .{
+                .state = if (MANAGE_HS) .handshake else .active,
+                .socket = socket,
+                .handler = null,
+                .handshake = null,
+                .reader = null,
+                .compression = null,
+                .conn = .{
+                    ._closed = false,
+                    .started = now,
+                    .address = address,
+                    .stream = .{ .handle = socket },
+                    .compression = null,
+                },
+            };
+
+            if (comptime MANAGE_HS) {
+                // Still waiting for a handshake. Only care about this with the full
+                // NonBlocking worker
+                self.pending.insert(hc);
+            } else {
+                self.active.insert(hc);
+            }
+            return hc;
+        }
+
+        pub fn activate(self: *Self, hc: *HandlerConn(H)) void {
+            std.debug.assert(MANAGE_HS == true);
+
+            // our caller made sute this was the case
+            std.debug.assert(hc.state == .handshake);
+            self.lock.lock();
+            defer self.lock.unlock();
+            self.pending.remove(hc);
+            self.active.insert(hc);
+            hc.state = .active;
+        }
+
+        pub fn inactive(self: *Self, hc: *HandlerConn(H)) void {
+            std.debug.assert(MANAGE_HS == true);
+
+            // this should only be called when we need more data to complete the handshake
+            // which should only happen on an active connection
+            std.debug.assert(hc.state == .active);
+            hc.state = .handshake;
+
+            self.lock.lock();
+            defer self.lock.unlock();
+            self.active.remove(hc);
+            self.pending.insert(hc);
+        }
+
+        pub fn cleanup(self: *Self, hc: *HandlerConn(H)) void {
+            if (hc.handshake) |h| {
+                h.release();
+            }
+
+            if (hc.reader) |*r| {
+                r.deinit();
+            }
+
+            if (hc.handler) |*h| {
+                if (comptime std.meta.hasFn(H, "close")) {
+                    h.close();
+                }
+                hc.handler = null;
+            }
+
+            if (hc.conn.compression) |c| {
+                c.writer.deinit();
+            }
+
+            self.lock.lock();
+            if (hc.state == .active) {
+                self.active.remove(hc);
+            } else {
+                self.pending.remove(hc);
+            }
+
+            if (hc.conn.compression) |c| {
+                self.compression_pool.destroy(c);
+            }
+
+            self.pool.destroy(hc);
+            self.lock.unlock();
+        }
+
+        fn setupCompression(self: *Self, hc: *HandlerConn(H)) !void {
+            const config = self.compression orelse return;
+
+            hc.compression = config;
+
+            if (config.write_threshold == null) {
+                // if write_treshold is null, then we never want to compress
+                // outgoing messages. We don't need to set the conn.compression
+                // field.
+                // We'll still [potentially] decompress incoming messages, but
+                // that's set on the proto.
+                return;
+            }
+
+            const compression = try self.compression_pool.create();
+            errdefer self.compression_pool.destroy(compression);
+
+            compression.* = .{
+                .allocator = self.allocator,
+                .write_treshold = config.write_threshold.?,
+                .retain_writer = config.retain_write_buffer,
+                .writer = std.Io.Writer.Allocating.init(self.allocator),
+            };
+            hc.conn.compression = compression;
+        }
+
+        pub fn shutdown(self: *Self, worker: anytype) void {
+            self.lock.lock();
+            defer self.lock.unlock();
+
+            shutdownList(self.active.head, worker);
+            shutdownList(self.pending.head, worker);
+        }
+
+        // This is sloppy and leaves things in an unrecoverable state. To keep
+        // things clean, we should call self.cleanup(hc) on each entry in the list
+        // but that does a bunch of things we don't need if we know that we're
+        // shutting down - like returning data to the pools, and popping items
+        // out of the list.
+        fn shutdownList(head: ?*HandlerConn(H), worker: anytype) void {
+            var next_node = head;
+            while (next_node) |hc| {
+                if (comptime std.meta.hasFn(H, "close")) {
+                    hc.cleanup.lock();
+                    defer hc.cleanup.unlock();
+                    if (hc.handler) |*h| {
+                        h.close();
+                        hc.handler = null;
+                    }
+                }
+
+                worker.shutdownCleanup(hc);
+                const conn = &hc.conn;
+                conn.closeSocket();
+                next_node = hc.next;
+            }
+        }
+    };
+}
+
+// This is what actually gets exposed to the app
+pub const Conn = struct {
+    _closed: bool,
+    started: u32,
+    stream: net.Stream,
+    address: net.Address,
+    lock: Thread.Mutex = .{},
+    compression: ?*Conn.Compression = null,
+
+    const Compression = struct {
+        allocator: Allocator,
+        retain_writer: bool,
+        write_treshold: usize,
+        writer: std.Io.Writer.Allocating,
+    };
+
+    pub fn isClosed(self: *Conn) bool {
+        // don't use lock to protect _closed. `isClosed` is called from
+        // the worker thread and we don't want that potentially blocked while
+        // a write is going on.
+        return @atomicLoad(bool, &self._closed, .monotonic);
+    }
+
+    pub fn writeBin(self: *Conn, data: []const u8) !void {
+        return self.writeFrame(.binary, data);
+    }
+
+    pub fn writeText(self: *Conn, data: []const u8) !void {
+        return self.writeFrame(.text, data);
+    }
+
+    pub fn write(self: *Conn, data: []const u8) !void {
+        return self.writeFrame(.text, data);
+    }
+
+    pub fn writePing(self: *Conn, data: []u8) !void {
+        return self.writeFrame(.ping, data);
+    }
+
+    pub fn writePong(self: *Conn, data: []u8) !void {
+        return self.writeFrame(.pong, data);
+    }
+
+    const CloseOpts = struct {
+        code: u16 = 1000,
+        reason: []const u8 = "",
+    };
+
+    pub fn close(self: *Conn, opts: CloseOpts) !void {
+        if (self.isClosed()) {
+            return;
+        }
+        defer self.closeSocket();
+
+        const reason = opts.reason;
+        if (reason.len == 0) {
+            var buf: [2]u8 = undefined;
+            std.mem.writeInt(u16, &buf, opts.code, .big);
+            return self.writeFrame(.close, &buf);
+        }
+
+        if (reason.len > 123) {
+            return error.ReasonTooLong;
+        }
+
+        var buf: [4]u8 = undefined;
+        buf[0] = @intFromEnum(OpCode.close);
+        buf[1] = @intCast(reason.len + 2);
+        std.mem.writeInt(u16, buf[2..], opts.code, .big);
+
+        var vec = [2]std.posix.iovec_const{
+            .{ .len = buf.len, .base = &buf },
+            .{ .len = reason.len, .base = reason.ptr },
+        };
+
+        try writeAllIOVec(self, &vec);
+    }
+
+    pub fn writeFrame(self: *Conn, op_code: OpCode, data: []const u8) !void {
+        const payload = data;
+
+        // Zig 0.15 compression disabled
+        const compressed = false;
+        // if (self.compression) |c| {
+        //     if (data.len >= c.write_treshold) {
+        //         compressed = true;
+        //         var compressor = std.compress.flate.Compress.init(&c.writer.writer, &.{}, .{});
+        //         try compressor.writer.writeAll(data);
+        //         try compressor.writer.flush();
+        //         const all = c.writer.written();
+        //         payload = all[0 .. all.len - 4];
+        //     }
+        // }
+
+        // defer if (compressed) {
+        //     const c = self.compression.?;
+        //     if (c.retain_writer) {
+        //         c.writer.clearRetainingCapacity();
+        //     } else {
+        //         c.writer.deinit();
+        //         c.writer = std.Io.Writer.Allocating.init(c.allocator);
+        //     }
+        // };
+
+        // maximum possible prefix length. op_code + length_type + 8byte length
+        var buf: [10]u8 = undefined;
+        const header = proto.writeFrameHeader(&buf, op_code, payload.len, compressed);
+
+        const stream = self.stream;
+
+        if (payload.len == 0) {
+            // no body, just write the header
+            self.lock.lock();
+            defer self.lock.unlock();
+            return stream.writeAll(header);
+        }
+
+        var vec = [2]std.posix.iovec_const{
+            .{ .len = header.len, .base = header.ptr },
+            .{ .len = payload.len, .base = payload.ptr },
+        };
+
+        return self.writeAllIOVec(&vec);
+    }
+
+    pub fn writeFramed(self: *Conn, data: []const u8) !void {
+        self.lock.lock();
+        defer self.lock.unlock();
+        try self.stream.writeAll(data);
+    }
+
+    fn writeAllIOVec(self: *Conn, vec: []std.posix.iovec_const) !void {
+        const socket = self.stream.handle;
+
+        self.lock.lock();
+        defer self.lock.unlock();
+
+        var i: usize = 0;
+        while (true) {
+            var n = try std.posix.writev(socket, vec[i..]);
+            while (n >= vec[i].len) {
+                n -= vec[i].len;
+                i += 1;
+                if (i >= vec.len) return;
+            }
+            vec[i].base += n;
+            vec[i].len -= n;
+        }
+    }
+
+    pub fn writeBuffer(self: *Conn, allocator: Allocator, op_code: OpCode) Writer {
+        return .{
+            .conn = self,
+            .buf = .empty,
+            .op_code = op_code,
+            .allocator = allocator,
+            .interface = .{
+                .vtable = &.{ .drain = Writer.drain },
+                .buffer = &.{},
+            },
+        };
+    }
+
+    fn closeSocket(self: *Conn) void {
+        if (@atomicRmw(bool, &self._closed, .Xchg, true, .monotonic) == false) {
+            posix.close(self.stream.handle);
+        }
+    }
+
+    pub const Writer = struct {
+        conn: *Conn,
+        op_code: OpCode,
+        allocator: Allocator,
+        buf: std.ArrayList(u8),
+        interface: std.Io.Writer,
+
+        pub const Error = Allocator.Error;
+
+        pub fn deinit(self: *Writer) void {
+            self.buf.deinit(self.allocator);
+        }
+
+        pub fn drain(io_w: *std.Io.Writer, data: []const []const u8, splat: usize) error{WriteFailed}!usize {
+            _ = splat;
+            const self: *Writer = @alignCast(@fieldParentPtr("interface", io_w));
+            self.buf.appendSlice(self.allocator, data[0]) catch return error.WriteFailed;
+            return data[0].len;
+        }
+
+        pub fn send(self: *Writer) !void {
+            return self.conn.writeFrame(self.op_code, self.buf.items) catch error.WriteFailed;
+        }
+    };
+};
+
+fn handleHandshake(comptime H: type, worker: anytype, hc: *HandlerConn(H), ctx: anytype) struct { bool, bool } {
+    return _handleHandshake(H, worker, hc, ctx) catch |err| {
+        log.warn("({f}) uncaugh error processing handshake: {}", .{ hc.conn.address, err });
+        return .{ false, false };
+    };
+}
+
+fn _handleHandshake(comptime H: type, worker: anytype, hc: *HandlerConn(H), ctx: anytype) !struct { bool, bool } {
+    std.debug.assert(hc.handler == null);
+
+    var state = hc.handshake orelse blk: {
+        const s = try worker.handshake_pool.acquire();
+        hc.handshake = s;
+        break :blk s;
+    };
+
+    var buf = state.buf;
+    var conn = &hc.conn;
+    const len = state.len;
+
+    if (len == buf.len) {
+        log.warn("({f}) handshake request exceeded maximum configured size ({d})", .{ conn.address, buf.len });
+        return .{ false, false };
+    }
+
+    const n = posix.recv(hc.socket, buf[len..], 0) catch |err| {
+        if (err == error.ConnectionResetByPeer or
+            (builtin.os.tag != .windows and err == error.BrokenPipe))
+        {
+            log.debug("({f}) handshake connection closed: {}", .{ conn.address, err });
+        } else switch (err) {
+            error.WouldBlock => {
+                std.debug.assert(blockingMode());
+                log.debug("({f}) handshake timeout", .{conn.address});
+            },
+            else => log.warn("({f}) handshake error reading from socket: {}", .{ conn.address, err }),
+        }
+        return .{ false, false };
+    };
+
+    if (n == 0) {
+        log.debug("({f}) handshake connection closed", .{conn.address});
+        return .{ false, false };
+    }
+
+    state.len = len + n;
+    var handshake = Handshake.parse(state) catch |err| {
+        log.debug("({f}) error parsing handshake: {}", .{ conn.address, err });
+        respondToHandshakeError(conn, err);
+        return .{ false, false };
+    } orelse {
+        // we need more data
+        return .{ false, true };
+    };
+
+    const compression = handshake.compression != null and worker.compression != null;
+    defer state.release();
+    hc.handshake = null;
+
+    // After this, the app has access to &hc.conn, so any access to the
+    // conn has to be synchronized (which the conn does internally).
+
+    const handler = H.init(&handshake, conn, ctx) catch |err| {
+        if (comptime std.meta.hasFn(H, "handshakeErrorResponse")) {
+            preHandOffWrite(H.handshakeErrorResponse(err));
+        } else {
+            respondToHandshakeError(conn, err);
+        }
+        log.debug("({f}) " ++ @typeName(H) ++ ".init rejected request {}", .{ conn.address, err });
+        return .{ false, false };
+    };
+
+    hc.handler = handler;
+
+    var reply_buf: [2048]u8 = undefined;
+    const handshake_reply = try Handshake.createReply(handshake.key, handshake.res_headers, compression, &reply_buf);
+    try conn.writeFramed(handshake_reply);
+
+    if (comptime std.meta.hasFn(H, "afterInit")) {
+        const params = @typeInfo(@TypeOf(H.afterInit)).@"fn".params;
+        const res = if (params.len == 1) hc.handler.?.afterInit() else hc.handler.?.afterInit(ctx);
+        res catch |err| {
+            log.debug("({f}) " ++ @typeName(H) ++ ".afterInit error: {}", .{ conn.address, err });
+            return .{ false, false };
+        };
+    }
+
+    log.debug("({f}) connection successfully upgraded", .{conn.address});
+    return .{ compression, true };
+}
+
+fn handleClientData(comptime H: type, hc: *HandlerConn(H), allocator: Allocator, fba: *FixedBufferAllocator) bool {
+    std.debug.assert(hc.handshake == null);
+    return _handleClientData(H, hc, allocator, fba) catch |err| {
+        log.warn("({f}) uncaugh error handling incoming data: {}", .{ hc.conn.address, err });
+        return false;
+    };
+}
+
+fn _handleClientData(comptime H: type, hc: *HandlerConn(H), allocator: Allocator, fba: *FixedBufferAllocator) !bool {
+    var conn = &hc.conn;
+    var reader = &hc.reader.?;
+    reader.fill(conn.stream) catch |err| {
+        switch (err) {
+            error.BrokenPipe, error.Closed, error.ConnectionResetByPeer => log.debug("({f}) connection closed: {}", .{ conn.address, err }),
+            else => log.warn("({f}) error reading from connection: {}", .{ conn.address, err }),
+        }
+        return false;
+    };
+
+    const handler = &hc.handler.?;
+    while (true) {
+        const has_more, const message = reader.read() catch |err| {
+            switch (err) {
+                error.LargeControl => conn.writeFramed(CLOSE_PROTOCOL_ERROR) catch {},
+                error.ReservedFlags => conn.writeFramed(CLOSE_PROTOCOL_ERROR) catch {},
+                error.CompressionDisabled => conn.writeFramed(CLOSE_PROTOCOL_ERROR) catch {},
+                error.CompressionError => conn.writeFramed(CLOSE_PROTOCOL_ERROR) catch {},
+                else => {},
+            }
+            log.debug("({f}) invalid websocket packet: {}", .{ conn.address, err });
+            return false;
+        } orelse {
+            // everything is fine, we just need more data
+            return true;
+        };
+
+        const message_type = message.type;
+        defer reader.done(message_type);
+
+        log.debug("({f}) received {s} message", .{ hc.conn.address, @tagName(message_type) });
+        switch (message_type) {
+            .text, .binary => {
+                const params = @typeInfo(@TypeOf(H.clientMessage)).@"fn".params;
+                const needs_allocator = comptime needsAllocator(H);
+
+                var arena: std.heap.ArenaAllocator = undefined;
+                var fallback_allocator: FallbackAllocator = undefined;
+                var aa: Allocator = undefined;
+
+                if (comptime needs_allocator) {
+                    arena = std.heap.ArenaAllocator.init(allocator);
+                    if (comptime blockingMode()) {
+                        aa = arena.allocator();
+                    } else {
+                        fallback_allocator = FallbackAllocator{
+                            .fba = fba,
+                            .fallback = arena.allocator(),
+                            .fixed = fba.allocator(),
+                        };
+                        aa = fallback_allocator.allocator();
+                    }
+                }
+
+                defer if (comptime needs_allocator) {
+                    arena.deinit();
+                };
+
+                switch (comptime params.len) {
+                    2 => handler.clientMessage(message.data) catch return false,
+                    3 => if (needs_allocator) {
+                        handler.clientMessage(aa, message.data) catch return false;
+                    } else {
+                        handler.clientMessage(message.data, if (message_type == .text) .text else .binary) catch return false;
+                    },
+                    4 => handler.clientMessage(aa, message.data, if (message_type == .text) .text else .binary) catch return false,
+                    else => @compileError(@typeName(H) ++ ".clientMessage has invalid parameter count"),
+                }
+            },
+            .pong => if (comptime std.meta.hasFn(H, "clientPong")) {
+                try handler.clientPong(message.data);
+            },
+            .ping => {
+                const data = message.data;
+                if (comptime std.meta.hasFn(H, "clientPing")) {
+                    try handler.clientPing(data);
+                } else if (data.len == 0) {
+                    try hc.conn.writeFramed(EMPTY_PONG);
+                } else {
+                    try hc.conn.writeFrame(.pong, data);
+                }
+            },
+            .close => {
+                const data = message.data;
+                if (comptime std.meta.hasFn(H, "clientClose")) {
+                    try handler.clientClose(data);
+                    return false;
+                }
+
+                const l = data.len;
+                if (l == 0) {
+                    try conn.close(.{});
+                    return false;
+                }
+
+                if (l == 1) {
+                    // close with a payload always has to have at least a 2-byte payload,
+                    // since a 2-byte code is required
+                    try conn.writeFramed(CLOSE_PROTOCOL_ERROR);
+                    return false;
+                }
+
+                const code = @as(u16, @intCast(data[1])) | (@as(u16, @intCast(data[0])) << 8);
+                if (code < 1000 or code == 1004 or code == 1005 or code == 1006 or (code > 1013 and code < 3000)) {
+                    try conn.writeFramed(CLOSE_PROTOCOL_ERROR);
+                    return false;
+                }
+
+                if (l == 2) {
+                    try conn.writeFramed(CLOSE_NORMAL);
+                    return false;
+                }
+
+                const payload = data[2..];
+                if (!std.unicode.utf8ValidateSlice(payload)) {
+                    // if we have a payload, it must be UTF8 (why?!)
+                    try conn.writeFramed(CLOSE_PROTOCOL_ERROR);
+                } else {
+                    try conn.close(.{});
+                }
+                return false;
+            },
+        }
+
+        if (conn.isClosed()) {
+            return false;
+        }
+
+        if (has_more == false) {
+            // we don't have more data ready to be processed in our buffer
+            // back to our caller for more data
+            return true;
+        }
+    }
+}
+
+fn needsAllocator(comptime H: type) bool {
+    const params = @typeInfo(@TypeOf(H.clientMessage)).@"fn".params;
+    return comptime params[1].type == Allocator;
+}
+
+fn respondToHandshakeError(conn: *Conn, err: anyerror) void {
+    const response = switch (err) {
+        error.Close => return,
+        error.RequestTooLarge => buildError(400, "too large"),
+        error.Timeout, error.WouldBlock => buildError(400, "timeout"),
+        error.InvalidProtocol => buildError(400, "invalid protocol"),
+        error.InvalidRequestLine => buildError(400, "invalid requestline"),
+        error.InvalidHeader => buildError(400, "invalid header"),
+        error.InvalidUpgrade => buildError(400, "invalid upgrade"),
+        error.InvalidVersion => buildError(400, "invalid version"),
+        error.InvalidConnection => buildError(400, "invalid connection"),
+        error.MissingHeaders => buildError(400, "missingheaders"),
+        error.Empty => buildError(400, "invalid request"),
+        else => buildError(400, "unknown"),
+    };
+    preHandOffWrite(conn, response);
+}
+
+fn buildError(comptime status: u16, comptime err: []const u8) []const u8 {
+    return std.fmt.comptimePrint("HTTP/1.1 {d} \r\nConnection: Close\r\nError: {s}\r\nContent-Length: 0\r\n\r\n", .{ status, err });
+}
+
+fn preHandOffWrite(conn: *Conn, response: []const u8) void {
+    // "preHandOff" means we haven't given the application handler a reference
+    // to *Conn yet. In theory, this means we don't need to worry about thread-safety
+    // However, it is possible for the worker to be stopped while we're doing this
+    // which causes issues unless we lock
+    conn.lock.lock();
+    defer conn.lock.unlock();
+
+    if (conn.isClosed()) {
+        return;
+    }
+
+    const socket = conn.stream.handle;
+    const timeout = std.mem.toBytes(posix.timeval{ .sec = 5, .usec = 0 });
+    posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &timeout) catch return;
+
+    var pos: usize = 0;
+    while (pos < response.len) {
+        const n = posix.write(socket, response[pos..]) catch return;
+        if (n == 0) {
+            // closed
+            return;
+        }
+        pos += n;
+    }
+}
+
+fn timestamp() u32 {
+    if (comptime @hasDecl(posix, "CLOCK") == false or posix.CLOCK == void) {
+        return @intCast(std.time.timestamp());
+    }
+    const ts = posix.clock_gettime(posix.CLOCK.REALTIME) catch unreachable;
+    return @intCast(ts.sec);
+}
+
+// intrusive doubly-linked list with count, not thread safe
+fn List(comptime T: type) type {
+    return struct {
+        len: usize = 0,
+        head: ?*T = null,
+        tail: ?*T = null,
+
+        const Self = @This();
+
+        pub fn insert(self: *Self, node: *T) void {
+            if (self.tail) |tail| {
+                tail.next = node;
+                node.prev = tail;
+                self.tail = node;
+            } else {
+                self.head = node;
+                self.tail = node;
+            }
+            self.len += 1;
+            node.next = null;
+        }
+
+        pub fn remove(self: *Self, node: *T) void {
+            if (node.prev) |prev| {
+                prev.next = node.next;
+            } else {
+                self.head = node.next;
+            }
+
+            if (node.next) |next| {
+                next.prev = node.prev;
+            } else {
+                self.tail = node.prev;
+            }
+            node.prev = null;
+            node.next = null;
+            self.len -= 1;
+        }
+    };
+}
+
+const t = @import("../t.zig");
+
+var test_thread: Thread = undefined;
+var test_server: Server(TestHandler) = undefined;
+var global_test_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+
+test "tests:beforeAll" {
+    test_server = try Server(TestHandler).init(global_test_allocator.allocator(), .{
+        .port = 9292,
+        .address = "127.0.0.1",
+    });
+    test_thread = try test_server.listenInNewThread({});
+}
+
+test "tests:afterAll" {
+    test_server.stop();
+    test_thread.join();
+    test_server.deinit();
+    try t.expectEqual(false, global_test_allocator.detectLeaks());
+}
+
+test "Server: invalid handshake" {
+    const stream = try testStream(false);
+    defer stream.close();
+
+    try stream.writeAll("GET / HTTP/1.1\r\n\r\n");
+    var buf: [1024]u8 = undefined;
+    var pos: usize = 0;
+    while (pos < buf.len) {
+        const n = try stream.read(buf[0..]);
+        if (n == 0) {
+            break;
+        }
+        pos += n;
+    } else {
+        unreachable;
+    }
+
+    try t.expectString("HTTP/1.1 400 \r\nConnection: Close\r\nError: missingheaders\r\nContent-Length: 0\r\n\r\n", buf[0..pos]);
+}
+
+test "Server: read and write" {
+    const stream = try testStream(true);
+    defer stream.close();
+
+    try stream.writeAll(&proto.frame(.text, "over"));
+    var buf: [12]u8 = undefined;
+    _ = try stream.readAtLeast(&buf, 6);
+    try t.expectSlice(u8, &.{ 129, 4, '9', '0', '0', '0' }, buf[0..6]);
+}
+
+test "Server: clientMessage allocator" {
+    const stream = try testStream(true);
+    defer stream.close();
+
+    try stream.writeAll(&proto.frame(.text, "dyn"));
+    var buf: [12]u8 = undefined;
+    _ = try stream.readAtLeast(&buf, 12);
+    try t.expectSlice(u8, &.{ 129, 10, 'o', 'v', 'e', 'r', ' ', '9', '0', '0', '0', '!' }, buf[0..12]);
+}
+
+test "Server: clientMessage writer" {
+    const stream = try testStream(true);
+    defer stream.close();
+
+    try stream.writeAll(&proto.frame(.text, "writer"));
+    var buf: [9]u8 = undefined;
+    _ = try stream.readAtLeast(&buf, 9);
+    try t.expectSlice(u8, &.{ 129, 7, '9', '0', '0', '0', '!', '!', '!' }, buf[0..9]);
+}
+
+// Same as above, but client doesn't shutdown the connection
+// When afterAll is runs and things are shutdown, this should still be properly cleaned up
+test "Server: dirty clientMessage allocator" {
+    const stream = try testStream(true);
+
+    try stream.writeAll(&proto.frame(.text, "dyn"));
+    var buf: [12]u8 = undefined;
+    _ = try stream.readAtLeast(&buf, 12);
+    try t.expectSlice(u8, &.{ 129, 10, 'o', 'v', 'e', 'r', ' ', '9', '0', '0', '0', '!' }, buf[0..12]);
+}
+
+test "Conn: close" {
+    {
+        // plain close
+        const stream = try testStream(true);
+        defer stream.close();
+        try stream.writeAll(&proto.frame(.text, "close1"));
+        var buf: [4]u8 = undefined;
+        _ = try stream.readAtLeast(&buf, 4);
+        try t.expectSlice(u8, &.{ 136, 2, 3, 232 }, buf[0..4]);
+    }
+
+    {
+        // close with code
+        const stream = try testStream(true);
+        defer stream.close();
+        try stream.writeAll(&proto.frame(.text, "close2"));
+        var buf: [4]u8 = undefined;
+        _ = try stream.readAtLeast(&buf, 4);
+        try t.expectSlice(u8, &.{ 136, 2, 0, 0x7b }, buf[0..4]);
+    }
+
+    {
+        // close with reason
+        const stream = try testStream(true);
+        defer stream.close();
+        try stream.writeAll(&proto.frame(.text, "close3"));
+        var buf: [7]u8 = undefined;
+        _ = try stream.readAtLeast(&buf, 7);
+        try t.expectSlice(u8, &.{ 136, 5, 0, 0xea, 'b', 'y', 'e' }, buf[0..7]);
+    }
+}
+
+fn testStream(handshake: bool) !net.Stream {
+    const timeout = std.mem.toBytes(std.posix.timeval{ .sec = 0, .usec = 20_000 });
+    const address = try std.net.Address.parseIp("127.0.0.1", 9292);
+    const stream = try std.net.tcpConnectToAddress(address);
+    try std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, &timeout);
+    try std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, &timeout);
+
+    if (handshake == false) {
+        return stream;
+    }
+
+    try stream.writeAll("GET / HTTP/1.1\r\ncontent-length: 0\r\nupgrade: websocket\r\nsec-websocket-version: 13\r\nconnection: upgrade\r\nsec-websocket-key: my-key\r\n\r\n");
+    var buf: [1024]u8 = undefined;
+    var pos: usize = 0;
+    while (pos < buf.len) {
+        const n = try stream.read(buf[0..]);
+        if (n == 0) break;
+
+        pos += n;
+        if (std.mem.endsWith(u8, buf[0..pos], "\r\n\r\n")) {
+            break;
+        }
+    } else {
+        unreachable;
+    }
+
+    try t.expectString("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: upgrade\r\nSec-Websocket-Accept: L8KGBs4w2MNLLzhfzlVoM0scCIE=\r\n\r\n", buf[0..pos]);
+
+    return stream;
+}
+
+const TestHandler = struct {
+    conn: *Conn,
+
+    pub fn init(h: *const Handshake, conn: *Conn, _: void) !TestHandler {
+        try t.expectString("upgrade", h.headers.get("connection").?);
+        return .{
+            .conn = conn,
+        };
+    }
+    pub fn clientMessage(
+        self: *TestHandler,
+        allocator: Allocator,
+        data: []const u8,
+    ) !void {
+        if (std.mem.eql(u8, data, "over")) {
+            return self.conn.writeText("9000");
+        }
+        if (std.mem.eql(u8, data, "dyn")) {
+            return self.conn.writeText(try std.fmt.allocPrint(allocator, "over {d}!", .{9000}));
+        }
+        if (std.mem.eql(u8, data, "writer")) {
+            var wb = self.conn.writeBuffer(allocator, .text);
+            try wb.interface.print("{d}!!!", .{9000});
+            return wb.send();
+        }
+        if (std.mem.eql(u8, data, "ping")) {
+            var buf = [_]u8{ 'a', '-', 'p', 'i', 'n', 'g' };
+            return self.conn.writePing(&buf);
+        }
+        if (std.mem.eql(u8, data, "pong")) {
+            var buf = [_]u8{ 'a', '-', 'p', 'o', 'n', 'g' };
+            return self.conn.writePong(&buf);
+        }
+        if (std.mem.eql(u8, data, "close1")) {
+            return self.conn.close(.{});
+        }
+        if (std.mem.eql(u8, data, "close2")) {
+            return self.conn.close(.{ .code = 123 });
+        }
+        if (std.mem.eql(u8, data, "close3")) {
+            return self.conn.close(.{ .code = 234, .reason = "bye" });
+        }
+    }
+};
+
+test "List" {
+    var list = List(TestNode){};
+    try expectList(&.{}, list);
+
+    var n1 = TestNode{ .id = 1 };
+    list.insert(&n1);
+    try expectList(&.{1}, list);
+
+    list.remove(&n1);
+    try expectList(&.{}, list);
+
+    var n2 = TestNode{ .id = 2 };
+    list.insert(&n2);
+    list.insert(&n1);
+    try expectList(&.{ 2, 1 }, list);
+
+    var n3 = TestNode{ .id = 3 };
+    list.insert(&n3);
+    try expectList(&.{ 2, 1, 3 }, list);
+
+    list.remove(&n1);
+    try expectList(&.{ 2, 3 }, list);
+
+    list.insert(&n1);
+    try expectList(&.{ 2, 3, 1 }, list);
+
+    list.remove(&n2);
+    try expectList(&.{ 3, 1 }, list);
+
+    list.remove(&n1);
+    try expectList(&.{3}, list);
+
+    list.remove(&n3);
+    try expectList(&.{}, list);
+}
+
+const TestNode = struct {
+    id: i32,
+    next: ?*TestNode = null,
+    prev: ?*TestNode = null,
+};
+
+fn expectList(expected: []const i32, list: List(TestNode)) !void {
+    if (expected.len == 0) {
+        try t.expectEqual(null, list.head);
+        try t.expectEqual(null, list.tail);
+        return;
+    }
+
+    var i: usize = 0;
+    var next = list.head;
+    while (next) |node| {
+        try t.expectEqual(expected[i], node.id);
+        i += 1;
+        next = node.next;
+    }
+    try t.expectEqual(expected.len, i);
+
+    i = expected.len;
+    var prev = list.tail;
+    while (prev) |node| {
+        i -= 1;
+        try t.expectEqual(expected[i], node.id);
+        prev = node.prev;
+    }
+    try t.expectEqual(0, i);
+}

--- a/vendor/websocket/src/server/thread_pool.zig
+++ b/vendor/websocket/src/server/thread_pool.zig
@@ -1,0 +1,224 @@
+const std = @import("std");
+
+const Thread = std.Thread;
+const Allocator = std.mem.Allocator;
+
+pub const Opts = struct {
+    count: u16,
+    backlog: u32,
+    buffer_size: usize,
+};
+
+pub fn ThreadPool(comptime F: anytype) type {
+    // When the worker thread calls F, it'll inject its static buffer.
+    // So F would be: handle(server: *Server, conn: *Conn, buf: []u8)
+    // and FullArgs would be our 3 args....
+    const FullArgs = std.meta.ArgsTuple(@TypeOf(F));
+    const full_fields = std.meta.fields(FullArgs);
+    const ARG_COUNT = full_fields.len - 1;
+
+    // Args will be FullArgs[0..len-1], so in the above example, args would be
+    // (*Server, *Conn)
+    // Args is what we expect the caller to pass to spawn. The worker thread
+    // will convert an Args into FullArgs by injecting its static buffer as
+    // the final argument.
+
+    // TODO: We could verify that the last argument to FullArgs is, in fact, a
+    // []u8. But this ThreadPool is private and being used for 2 specific cases
+    // that we control.
+
+    var fields: [ARG_COUNT]std.builtin.Type.StructField = undefined;
+    inline for (full_fields[0..ARG_COUNT], 0..) |field, index| fields[index] = field;
+
+    const Args = comptime @Type(.{
+        .@"struct" = .{
+            .layout = .auto,
+            .is_tuple = true,
+            .fields = &fields,
+            .decls = &.{},
+        },
+    });
+
+    return struct {
+        stopped: bool,
+        push: usize,
+        pull: usize,
+        pending: usize,
+        queue: []Args,
+        threads: []Thread,
+        mutex: Thread.Mutex,
+        pull_cond: Thread.Condition,
+        push_cond: Thread.Condition,
+        queue_end: usize,
+        allocator: Allocator,
+
+        const Self = @This();
+
+        pub fn init(allocator: Allocator, opts: Opts) !*Self {
+            const queue = try allocator.alloc(Args, opts.backlog);
+            errdefer allocator.free(queue);
+
+            const threads = try allocator.alloc(Thread, opts.count);
+            errdefer allocator.free(threads);
+
+            const thread_pool = try allocator.create(Self);
+            errdefer allocator.destroy(thread_pool);
+
+            thread_pool.* = .{
+                .pull = 0,
+                .push = 0,
+                .pending = 0,
+                .mutex = .{},
+                .stopped = false,
+                .queue = queue,
+                .pull_cond = .{},
+                .push_cond = .{},
+                .threads = threads,
+                .allocator = allocator,
+                .queue_end = queue.len - 1,
+            };
+
+            var started: usize = 0;
+            errdefer {
+                thread_pool.stopped = true;
+                thread_pool.pull_cond.broadcast();
+                for (0..started) |i| {
+                    threads[i].join();
+                }
+            }
+
+            for (0..threads.len) |i| {
+                // This becomes owned by the thread, it'll free it as it ends
+                const buffer = try allocator.alloc(u8, opts.buffer_size);
+                errdefer allocator.free(buffer);
+
+                threads[i] = try Thread.spawn(.{}, Self.worker, .{ thread_pool, buffer });
+                started += 1;
+            }
+
+            return thread_pool;
+        }
+
+        pub fn deinit(self: *Self) void {
+            const allocator = self.allocator;
+            self.stop();
+            allocator.free(self.threads);
+            allocator.free(self.queue);
+
+            allocator.destroy(self);
+        }
+
+        pub fn stop(self: *Self) void {
+            {
+                self.mutex.lock();
+                defer self.mutex.unlock();
+                if (self.stopped == true) {
+                    return;
+                }
+                self.stopped = true;
+            }
+
+            self.pull_cond.broadcast();
+            for (self.threads) |thrd| {
+                thrd.join();
+            }
+        }
+
+        pub fn empty(self: *Self) bool {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            return self.pull == self.push;
+        }
+
+        pub fn spawn(self: *Self, args: Args) void {
+            const queue = self.queue;
+            const len = queue.len;
+
+            self.mutex.lock();
+            while (self.pending == len) {
+                self.push_cond.wait(&self.mutex);
+            }
+
+            const push = self.push;
+            self.queue[push] = args;
+            self.push = if (push == self.queue_end) 0 else push + 1;
+            self.pending += 1;
+            self.mutex.unlock();
+
+            self.pull_cond.signal();
+        }
+
+        fn worker(self: *Self, buffer: []u8) void {
+            // Having a re-usable buffer per thread is the most efficient way
+            // we can do any dynamic allocations. We'll pair this later with
+            // a FallbackAllocator. The main issue is that some data must outlive
+            // the worker thread (in nonblocking mode), but this isn't something
+            // we need to worry about here. As far as this worker thread is
+            // concerned, it has a chunk of memory (buffer) which it'll pass
+            // to the callback function to do with as it wants.
+            defer self.allocator.free(buffer);
+
+            while (true) {
+                self.mutex.lock();
+                while (self.pending == 0) {
+                    if (self.stopped) {
+                        self.mutex.unlock();
+                        return;
+                    }
+                    self.pull_cond.wait(&self.mutex);
+                }
+                const pull = self.pull;
+                const args = self.queue[pull];
+                self.pull = if (pull == self.queue_end) 0 else pull + 1;
+                self.pending -= 1;
+                self.mutex.unlock();
+                self.push_cond.signal();
+
+                // convert Args to FullArgs, i.e. inject buffer as the last argument
+                var full_args: FullArgs = undefined;
+                full_args[ARG_COUNT] = buffer;
+                inline for (0..ARG_COUNT) |i| {
+                    full_args[i] = args[i];
+                }
+                @call(.auto, F, full_args);
+            }
+        }
+    };
+}
+
+const t = @import("../t.zig");
+test "ThreadPool: small fuzz" {
+    testSum = 0; // global defined near the end of this file
+    var tp = try ThreadPool(testIncr).init(t.allocator, .{ .count = 3, .backlog = 3, .buffer_size = 512 });
+
+    for (0..50_000) |_| {
+        tp.spawn(.{1});
+    }
+    while (tp.empty() == false) {
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
+    tp.deinit();
+    try t.expectEqual(50_000, testSum);
+}
+
+test "ThreadPool: large fuzz" {
+    testSum = 0; // global defined near the end of this file
+    var tp = try ThreadPool(testIncr).init(t.allocator, .{ .count = 50, .backlog = 1000, .buffer_size = 512 });
+
+    for (0..50_000) |_| {
+        tp.spawn(.{1});
+    }
+    while (tp.empty() == false) {
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
+    tp.deinit();
+    try t.expectEqual(50_000, testSum);
+}
+
+var testSum: u64 = 0;
+fn testIncr(c: u64, buf: []u8) void {
+    std.debug.assert(buf.len == 512);
+    _ = @atomicRmw(u64, &testSum, .Add, c, .monotonic);
+    // let the threadpool queue get backed up
+    std.Thread.sleep(std.time.ns_per_us * 100);
+}

--- a/vendor/websocket/src/t.zig
+++ b/vendor/websocket/src/t.zig
@@ -1,0 +1,212 @@
+const std = @import("std");
+const proto = @import("proto.zig");
+
+const posix = std.posix;
+const ArrayList = std.ArrayList;
+
+const Message = proto.Message;
+
+pub const allocator = std.testing.allocator;
+
+pub fn expectEqual(expected: anytype, actual: anytype) !void {
+    try std.testing.expectEqual(@as(@TypeOf(actual), expected), actual);
+}
+
+pub const expectError = std.testing.expectError;
+pub const expectString = std.testing.expectEqualStrings;
+pub const expectSlice = std.testing.expectEqualSlices;
+
+pub fn getRandom() std.Random.DefaultPrng {
+    var seed: u64 = undefined;
+    std.posix.getrandom(std.mem.asBytes(&seed)) catch unreachable;
+    return std.Random.DefaultPrng.init(seed);
+}
+
+pub var arena = std.heap.ArenaAllocator.init(allocator);
+pub fn reset() void {
+    _ = arena.reset(.free_all);
+}
+
+pub const Writer = struct {
+    pos: usize,
+    buf: std.ArrayList(u8),
+    random: std.Random.DefaultPrng,
+
+    pub fn init() Writer {
+        return .{
+            .pos = 0,
+            .buf = .empty,
+            .random = getRandom(),
+        };
+    }
+
+    pub fn deinit(self: *Writer) void {
+        self.buf.deinit(allocator);
+    }
+
+    pub fn ping(self: *Writer) void {
+        return self.pingPayload("");
+    }
+
+    pub fn pong(self: *Writer) void {
+        return self.frame(true, 10, "", 0);
+    }
+
+    pub fn pingPayload(self: *Writer, payload: []const u8) void {
+        return self.frame(true, 9, payload, 0);
+    }
+
+    pub fn textFrame(self: *Writer, fin: bool, payload: []const u8) void {
+        return self.frame(fin, 1, payload, 0);
+    }
+
+    pub fn cont(self: *Writer, fin: bool, payload: []const u8) void {
+        return self.frame(fin, 0, payload, 0);
+    }
+
+    pub fn frame(self: *Writer, fin: bool, op_code: u8, payload: []const u8, reserved: u8) void {
+        var buf = &self.buf;
+
+        const l = payload.len;
+        var length_of_length: usize = 0;
+
+        if (l > 125) {
+            if (l < 65536) {
+                length_of_length = 2;
+            } else {
+                length_of_length = 8;
+            }
+        }
+
+        // 2 byte header + length_of_length + mask + payload_length
+        const needed = 2 + length_of_length + 4 + l;
+        buf.ensureUnusedCapacity(allocator, needed) catch unreachable;
+
+        if (fin) {
+            buf.appendAssumeCapacity(128 | op_code | reserved);
+        } else {
+            buf.appendAssumeCapacity(op_code | reserved);
+        }
+
+        if (length_of_length == 0) {
+            buf.appendAssumeCapacity(128 | @as(u8, @intCast(l)));
+        } else if (length_of_length == 2) {
+            buf.appendAssumeCapacity(128 | 126);
+            buf.appendAssumeCapacity(@intCast((l >> 8) & 0xFF));
+            buf.appendAssumeCapacity(@intCast(l & 0xFF));
+        } else {
+            buf.appendAssumeCapacity(128 | 127);
+            buf.appendAssumeCapacity(@intCast((l >> 56) & 0xFF));
+            buf.appendAssumeCapacity(@intCast((l >> 48) & 0xFF));
+            buf.appendAssumeCapacity(@intCast((l >> 40) & 0xFF));
+            buf.appendAssumeCapacity(@intCast((l >> 32) & 0xFF));
+            buf.appendAssumeCapacity(@intCast((l >> 24) & 0xFF));
+            buf.appendAssumeCapacity(@intCast((l >> 16) & 0xFF));
+            buf.appendAssumeCapacity(@intCast((l >> 8) & 0xFF));
+            buf.appendAssumeCapacity(@intCast(l & 0xFF));
+        }
+
+        var mask: [4]u8 = undefined;
+        self.random.random().bytes(&mask);
+        // var mask = [_]u8{1, 1, 1, 1};
+
+        buf.appendSliceAssumeCapacity(&mask);
+        for (payload, 0..) |b, i| {
+            buf.appendAssumeCapacity(b ^ mask[i & 3]);
+        }
+    }
+
+    pub fn bytes(self: *const Writer) []const u8 {
+        return self.buf.items;
+    }
+
+    pub fn clear(self: *Writer) void {
+        self.pos = 0;
+        self.buf.clearRetainingCapacity();
+    }
+
+    pub fn read(
+        self: *Writer,
+        buf: []u8,
+    ) !usize {
+        const data = self.buf.items[self.pos..];
+
+        if (data.len == 0 or buf.len == 0) {
+            return 0;
+        }
+
+        // randomly fragment the data
+        const to_read = self.random.random().intRangeAtMost(usize, 1, @min(data.len, buf.len));
+        @memcpy(buf[0..to_read], data[0..to_read]);
+        self.pos += to_read;
+        return to_read;
+    }
+};
+
+pub const SocketPair = struct {
+    writer: Writer,
+    client: std.net.Stream,
+    server: std.net.Stream,
+
+    const Opts = struct {
+        port: ?u16 = null,
+    };
+
+    pub fn init(opts: Opts) SocketPair {
+        var address = std.net.Address.parseIp("127.0.0.1", opts.port orelse 0) catch unreachable;
+        var address_len = address.getOsSockLen();
+
+        const listener = posix.socket(address.any.family, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, posix.IPPROTO.TCP) catch unreachable;
+        defer posix.close(listener);
+
+        {
+            // setup our listener
+            posix.bind(listener, &address.any, address_len) catch unreachable;
+            posix.listen(listener, 1) catch unreachable;
+            posix.getsockname(listener, &address.any, &address_len) catch unreachable;
+        }
+
+        const client = posix.socket(address.any.family, posix.SOCK.STREAM, posix.IPPROTO.TCP) catch unreachable;
+        {
+            // connect the client
+            const flags = posix.fcntl(client, posix.F.GETFL, 0) catch unreachable;
+            _ = posix.fcntl(client, posix.F.SETFL, flags | posix.SOCK.NONBLOCK) catch unreachable;
+            posix.connect(client, &address.any, address_len) catch |err| switch (err) {
+                error.WouldBlock => {},
+                else => unreachable,
+            };
+            _ = posix.fcntl(client, posix.F.SETFL, flags) catch unreachable;
+        }
+
+        const server = posix.accept(listener, &address.any, &address_len, posix.SOCK.CLOEXEC) catch unreachable;
+
+        return .{
+            .client = .{ .handle = client },
+            .server = .{ .handle = server },
+            .writer = Writer.init(),
+        };
+    }
+
+    pub fn deinit(self: *SocketPair) void {
+        self.writer.deinit();
+        // assume test closes self.server
+        self.client.close();
+    }
+
+    pub fn pingPayload(self: *SocketPair, payload: []const u8) void {
+        self.writer.pingPayload(payload);
+    }
+
+    pub fn textFrame(self: *SocketPair, fin: bool, payload: []const u8) void {
+        self.writer.textFrame(fin, payload);
+    }
+
+    pub fn cont(self: *SocketPair, fin: bool, payload: []const u8) void {
+        self.writer.cont(fin, payload);
+    }
+
+    pub fn sendBuf(self: *SocketPair) void {
+        self.client.writeAll(self.writer.bytes()) catch unreachable;
+        self.writer.clear();
+    }
+};

--- a/vendor/websocket/src/testing.zig
+++ b/vendor/websocket/src/testing.zig
@@ -1,0 +1,144 @@
+const std = @import("std");
+const t = @import("t.zig");
+const ws = @import("websocket.zig");
+
+pub fn init() Testing {
+    return Testing.init();
+}
+
+pub const Testing = struct {
+    closed: bool,
+    conn: ws.Conn,
+    pair: t.SocketPair,
+    reader: ws.proto.Reader,
+    arena: *std.heap.ArenaAllocator,
+
+    received: std.ArrayList(ws.Message),
+    received_index: usize,
+
+    const Opts = struct {
+        port: ?u16 = null,
+    };
+    fn init(opts: Opts) Testing {
+        const arena = t.allocator.create(std.heap.ArenaAllocator) catch unreachable;
+        errdefer t.allocator.destroy(arena);
+
+        arena.* = std.heap.ArenaAllocator.init(t.allocator);
+        errdefer arena.deinit();
+
+        const port = opts.port orelse 0;
+        const pair = t.SocketPair.init(.{ .port = port });
+        const timeout = std.mem.toBytes(std.posix.timeval{
+            .sec = 0,
+            .usec = 50_000,
+        });
+        std.posix.setsockopt(pair.client.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, &timeout) catch unreachable;
+
+        const aa = arena.allocator();
+        const buffer_provider = aa.create(ws.buffer.Provider) catch unreachable;
+        buffer_provider.* = ws.buffer.Provider.init(aa, .{
+            .size = 0,
+            .count = 0,
+            .max = 20_971_520,
+        }) catch unreachable;
+
+        const reader_buf = aa.alloc(u8, 1024) catch unreachable;
+        const reader = ws.proto.Reader.init(reader_buf, buffer_provider, null);
+
+        return .{
+            .closed = false,
+            .pair = pair,
+            .arena = arena,
+            .conn = .{
+                ._closed = false,
+                .started = 0,
+                .stream = pair.server,
+                .address = std.net.Address.parseIp("127.0.0.1", port) catch unreachable,
+            },
+            .reader = reader,
+            .received = std.ArrayList(ws.Message).init(aa),
+            .received_index = 0,
+        };
+    }
+
+    pub fn deinit(self: *Testing) void {
+        self.pair.writer.deinit();
+        close(self.pair.client.handle);
+        close(self.pair.server.handle);
+
+        self.arena.deinit();
+        t.allocator.destroy(self.arena);
+    }
+
+    pub fn expectMessage(self: *Testing, op: ws.Message.Type, data: []const u8) !void {
+        try self.ensureMessage();
+
+        const message = self.received.items[self.received_index];
+        self.received_index += 1;
+
+        try t.expectEqual(op, message.type);
+        if (op == .text) {
+            try t.expectString(data, message.data);
+        } else {
+            try t.expectSlice(u8, data, message.data);
+        }
+    }
+
+    pub fn expectClose(self: *Testing) !void {
+        if (self.closed) {
+            return;
+        }
+
+        self.fill() catch if (self.closed) {
+            return;
+        };
+
+        return error.NotClosed;
+    }
+
+    // we have a 50ms timeout on this socket. It's all localhost. We expect
+    // to be able to read messages in that time.
+    pub fn ensureMessage(self: *Testing) !void {
+        if (self.received_index < self.received.items.len) {
+            return;
+        }
+        return self.fill();
+    }
+
+    fn fill(self: *Testing) !void {
+        self.reader.fill(self.pair.client) catch |err| switch (err) {
+            error.WouldBlock => return error.NoMoreData,
+            else => {
+                self.closed = true;
+                return err;
+            },
+        };
+
+        while (true) {
+            const more, const message = (try self.reader.read()) orelse return error.NoMoreData;
+            try self.received.append(message);
+            if (more == false) {
+                return;
+            }
+        }
+    }
+};
+
+// std.posix.close panics on EBADF
+// This is a general issue in Zig:
+// https://github.com/ziglang/zig/issues/6389
+//
+// For these tests, we realy don't know if the server-side of the connection
+// is closed, so we try to close and ignore any errors.
+fn close(fd: std.posix.fd_t) void {
+    const builtin = @import("builtin");
+    const native_os = builtin.os.tag;
+    if (native_os == .windows) {
+        return std.os.windows.CloseHandle(fd);
+    }
+    if (native_os == .wasi and !builtin.link_libc) {
+        _ = std.os.wasi.fd_close(fd);
+        return;
+    }
+    _ = std.posix.system.close(fd);
+}

--- a/vendor/websocket/src/websocket.zig
+++ b/vendor/websocket/src/websocket.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+
+pub const buffer = @import("buffer.zig");
+
+pub const proto = @import("proto.zig");
+pub const OpCode = proto.OpCode;
+pub const Message = proto.Message;
+pub const MessageType = Message.Type;
+pub const MessageTextType = Message.TextType;
+
+pub const Client = @import("client/client.zig").Client;
+
+pub const server = @import("server/server.zig");
+pub const testing = @import("testing.zig");
+
+pub const Conn = server.Conn;
+pub const Config = server.Config;
+pub const Server = server.Server;
+pub const blockingMode = server.blockingMode;
+pub const Handshake = @import("server/handshake.zig").Handshake;
+
+pub const Compression = struct {
+    write_threshold: ?usize = null,
+    retain_write_buffer: bool = true,
+    // don't know how to support these with the Zig 0.15 changes. So, for now
+    // we'll always require these to be true
+    // client_no_context_takeover: bool = false,
+    // server_no_context_takeover: bool = false,
+};
+
+pub fn bufferProvider(allocator: std.mem.Allocator, config: buffer.Config) !buffer.Provider {
+    return buffer.Provider.init(allocator, config);
+}
+
+pub fn frameText(comptime msg: []const u8) [proto.calculateFrameLen(msg)]u8 {
+    return proto.frame(.text, msg);
+}
+
+pub fn frameBin(comptime msg: []const u8) [proto.calculateFrameLen(msg)]u8 {
+    return proto.frame(.binary, msg);
+}
+
+comptime {
+    std.testing.refAllDecls(@This());
+}
+
+const t = @import("t.zig");
+test "frameText" {
+    {
+        const framed = frameText("");
+        try t.expectString(&[_]u8{ 129, 0 }, &framed);
+    }
+
+    {
+        // short
+        const framed = frameText("hello");
+        try t.expectString(&[_]u8{ 129, 5, 'h', 'e', 'l', 'l', 'o' }, &framed);
+    }
+
+    {
+        const msg = "A" ** 130;
+        const framed = frameText(msg);
+
+        try t.expectEqual(134, framed.len);
+
+        // text type
+        try t.expectEqual(129, framed[0]);
+
+        // 2 byte length marker
+        try t.expectEqual(126, framed[1]);
+
+        try t.expectEqual(0, framed[2]);
+        try t.expectEqual(130, framed[3]);
+
+        // payload
+        for (framed[4..]) |f| {
+            try t.expectEqual('A', f);
+        }
+    }
+}
+
+test "frameBin" {
+    {
+        // short
+        const framed = frameBin("hello");
+        try t.expectString(&[_]u8{ 130, 5, 'h', 'e', 'l', 'l', 'o' }, &framed);
+    }
+
+    {
+        const msg = "A" ** 130;
+        const framed = frameBin(msg);
+
+        try t.expectEqual(134, framed.len);
+
+        // text type
+        try t.expectEqual(130, framed[0]);
+
+        // 2 byte length marker
+        try t.expectEqual(126, framed[1]);
+
+        try t.expectEqual(0, framed[2]);
+        try t.expectEqual(130, framed[3]);
+
+        // payload
+        for (framed[4..]) |f| {
+            try t.expectEqual('A', f);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR vendors the `websocket.zig` library into the `vendor/websocket/` directory. By moving from a remote Git dependency to a local one, we ensure more stable and reproducible builds, especially in environments with restricted internet access.

### Key Changes
- **Library Vendoring**: Copied `websocket.zig` (targeting Zig 0.15.x) into `vendor/websocket/`.
- **Dependency Update**: Updated `build.zig.zon` to point to the local path.
- **Windows Fixes**: Included specific improvements for Windows support, such as using `recv` for socket reads to improve reliability on that platform.
- **Build Integration**: Adjusted the build system to correctly handle the vendored module and its configuration options.

## Validation
- `zig build`: Verified that the project builds correctly with the vendored dependency.
- `zig build test --summary all`: Verified that WebSocket-related tests pass on both Linux and Windows environments.
- Verified manual connectivity via the `web` and `lark` (websocket mode) channels.

## Notes
- Closes #317, #220.
- This change reduces reliance on external Git repositories during the build process.
- The vendored version is aligned with the project's current Zig 0.15 compiler requirements.

---

## 中文

### 摘要
本 PR 将 `websocket.zig` 库同步（Vendor）到 `vendor/websocket/` 目录下。通过从远程 Git 依赖切换为本地依赖，我们确保了构建过程更加稳定且可重复，特别是在互联网受限的环境中。

### 主要改动
- **库同步 (Vendoring)**: 将 `websocket.zig`（适配 Zig 0.15.x 版本）拷贝至 `vendor/websocket/`。
- **依赖更新**: 修改了 `build.zig.zon` 文件，将其指向本地路径。
- **Windows 修复**: 包含了针对 Windows 支持的特定改进，例如使用 `recv` 进行套接字读取，以提高该平台上的可靠性。
- **构建集成**: 调整了构建系统，以正确处理 Vendor 化的模块及其配置选项。

### 验证
- `zig build`: 验证了项目在使用 Vendor 依赖时能够正确构建。
- `zig build test --summary all`: 验证了 WebSocket 相关测试在 Linux 和 Windows 环境下均能通过。
- 验证了通过 `web` 和 `lark`（WebSocket 模式）渠道的手动连接。

### 备注
- 关联并关闭 #317, #220。
- 此项改动减少了构建过程中对外部 Git 仓库的依赖。
- Vendor 化的版本与项目当前要求的 Zig 0.15 编译器版本保持一致。
