### PR TITLE
fix(agent): avoid double-free after history ownership transfer

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -362,6 +362,15 @@ pub const Agent = struct {
         }
     };
 
+    /// Append a history message that owns its content.
+    /// On append failure, the message is deinitialized to avoid leaks.
+    fn appendOwnedHistoryMessage(self: *Agent, msg: OwnedMessage) !void {
+        self.history.append(self.allocator, msg) catch |err| {
+            msg.deinit(self.allocator);
+            return err;
+        };
+    }
+
     /// Initialize agent from a loaded Config.
     pub fn fromConfig(
         allocator: std.mem.Allocator,
@@ -1073,12 +1082,9 @@ pub const Agent = struct {
             try memory_loader.enrichMessageWithRuntime(self.allocator, mem, self.mem_rt, effective_user_message, self.memory_session_id)
         else
             try self.allocator.dupe(u8, effective_user_message);
-        errdefer self.allocator.free(enriched);
 
-        try self.history.append(self.allocator, .{
-            .role = .user,
-            .content = enriched,
-        });
+        // Keep the user message retained even if provider/tool steps fail.
+        try self.appendOwnedHistoryMessage(.{ .role = .user, .content = enriched });
 
         // ── Response cache check ──
         if (self.response_cache) |rc| {
@@ -1460,16 +1466,10 @@ pub const Agent = struct {
                     iteration + 1 < self.max_tool_iterations and
                     shouldForceActionFollowThrough(display_text))
                 {
-                    try self.history.append(self.allocator, .{
-                        .role = .assistant,
-                        .content = try self.allocator.dupe(u8, display_text),
-                    });
-                    try self.history.append(self.allocator, .{
-                        .role = .user,
-                        .content = try self.allocator.dupe(u8, "SYSTEM: You just promised to take action now (for example: \"I'll try/check now\"). " ++
-                            "Do it in this turn by issuing the appropriate tool call(s). " ++
-                            "If no tool can perform it, respond with a clear limitation now and do not promise another future attempt."),
-                    });
+                    try self.appendOwnedHistoryMessage(.{ .role = .assistant, .content = try self.allocator.dupe(u8, display_text) });
+                    try self.appendOwnedHistoryMessage(.{ .role = .user, .content = try self.allocator.dupe(u8, "SYSTEM: You just promised to take action now (for example: \"I'll try/check now\"). " ++
+                        "Do it in this turn by issuing the appropriate tool call(s). " ++
+                        "If no tool can perform it, respond with a clear limitation now and do not promise another future attempt.") });
                     self.trimHistory();
                     self.freeResponseFields(&response);
                     forced_follow_through_count += 1;
@@ -1566,12 +1566,9 @@ pub const Agent = struct {
                 free_assistant_history = false;
                 break :blk assistant_history_content;
             } else try self.allocator.dupe(u8, assistant_history_content);
-            errdefer self.allocator.free(assistant_content);
 
-            try self.history.append(self.allocator, .{
-                .role = .assistant,
-                .content = assistant_content,
-            });
+            // Once appended, history owns the buffer.
+            try self.appendOwnedHistoryMessage(.{ .role = .assistant, .content = assistant_content });
 
             // Execute each tool call
             var results_buf: std.ArrayListUnmanaged(ToolExecutionResult) = .empty;
@@ -3542,6 +3539,73 @@ test "turn /reset with argument stays slash-only command" {
     try std.testing.expect(std.mem.indexOf(u8, response, "Session cleared.") != null);
     try std.testing.expect(std.mem.indexOf(u8, response, "gpt-4o-mini") != null);
     try std.testing.expectEqualStrings("gpt-4o-mini", agent.model_name);
+}
+
+test "turn retains user message on provider error" {
+    const FailProvider = struct {
+        fn chatWithSystem(_: *anyopaque, allocator: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator.dupe(u8, "");
+        }
+
+        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            return error.ProviderFailed;
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return false;
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "fail-provider";
+        }
+
+        fn deinitFn(_: *anyopaque) void {}
+    };
+
+    const allocator = std.testing.allocator;
+
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = FailProvider.chatWithSystem,
+        .chat = FailProvider.chat,
+        .supportsNativeTools = FailProvider.supportsNativeTools,
+        .getName = FailProvider.getName,
+        .deinit = FailProvider.deinitFn,
+    };
+    const provider = Provider{ .ptr = @ptrFromInt(1), .vtable = &provider_vtable };
+
+    var noop = observability.NoopObserver{};
+    var agent = Agent{
+        .allocator = allocator,
+        .provider = provider,
+        .tools = &.{},
+        .tool_specs = try allocator.alloc(ToolSpec, 0),
+        .mem = null,
+        .observer = noop.observer(),
+        .model_name = "test-model",
+        .temperature = 0.7,
+        .workspace_dir = "/tmp",
+        .max_tool_iterations = 2,
+        .max_history_messages = 20,
+        .auto_save = false,
+        .history = .empty,
+        .has_system_prompt = true,
+    };
+    defer agent.deinit();
+
+    // Seed a system prompt so turn() does not rebuild it (which can load
+    // user config and introduce non-deterministic side effects in tests).
+    try agent.history.append(allocator, .{
+        .role = .system,
+        .content = try allocator.dupe(u8, "sys"),
+    });
+
+    try std.testing.expectError(error.ProviderFailed, agent.turn("hello"));
+    try std.testing.expectEqual(@as(usize, 2), agent.historyLen());
+    try std.testing.expectEqualStrings("hello", agent.history.items[1].content);
+
+    // Should not double-free when clearing history after a failed turn.
+    agent.clearHistory();
+    try std.testing.expectEqual(@as(usize, 0), agent.historyLen());
 }
 
 test "slash /help returns help text" {


### PR DESCRIPTION

## Problem

When a turn failed after appending the user message (or assistant tool content) to `self.history`, we'd hit a double-free (detectable with GPA).

The issue is that `errdefer allocator.free(enriched)` in `Agent.turn()` stayed armed after ownership transferred to the history list, so any later error (e.g., provider failure) would free memory that history still referenced, causing a second free when history was cleared in `OwnedMessage.deinit()` (via `/new`, `/reset`, or `clearHistory()`).

<details>
<summary>Relevant stack-trace</summary>

```
error(gpa): Double free detected. Allocation:
/lib/std/mem/Allocator.zig:436:40: 0x12ca7f2 in dupe__anon_10007 (std.zig)
./src/agent/memory_loader.zig:211:34: 0x1561e94 in enrichMessageWithRuntime (root.zig)
./src/agent/root.zig:1073:55: 0x15b0c0f in turn (root.zig)
./src/session.zig:420:48: 0x16b45bd in processMessageStreaming (root.zig)
./src/channel_loop.zig:83:62: 0x2903ddf in processTelegramMessage (root.zig)
./src/channel_loop.zig:133:31: 0x296c96f in run (root.zig)
 First free:
./src/agent/root.zig:1076:37: 0x15b7164 in turn (root.zig)
./src/session.zig:420:48: 0x16b45bd in processMessageStreaming (root.zig)
./src/channel_loop.zig:83:62: 0x2903ddf in processTelegramMessage (root.zig)
./src/channel_loop.zig:133:31: 0x296c96f in run (root.zig)
./src/channel_loop.zig:160:17: 0x296099a in messageTaskWorker (root.zig)
/lib/std/Thread.zig:509:13: 0x294bcf0 in callFn__anon_596754 (std.zig)
 Second free:
./src/agent/root.zig:357:27: 0x183299d in deinit (root.zig)
./src/agent/root.zig:2201:23: 0x19daa3c in clearHistory (root.zig)
./src/agent/commands.zig:675:22: 0x17ea185 in clearSessionState__anon_32129 (root.zig)
./src/agent/commands.zig:2351:26: 0x1523174 in handleSlashCommand__anon_32101 (root.zig)
./src/agent/root.zig:881:43: 0x152a102 in handleSlashCommand (root.zig)
./src/agent/root.zig:976:48: 0x15adc4b in turn (root.zig)
Segmentation fault at address 0x7fe31f240028
/lib/std/mem/Allocator.zig:430:26: 0x12caf98 in free__anon_10028 (std.zig)
./src/agent/root.zig:357:27: 0x183299d in deinit (root.zig)
./src/agent/root.zig:2201:23: 0x19daa3c in clearHistory (root.zig)
./src/agent/commands.zig:675:22: 0x17ea185 in clearSessionState__anon_32129 (root.zig)
./src/agent/commands.zig:2351:26: 0x1523174 in handleSlashCommand__anon_32101 (root.zig)
./src/agent/root.zig:881:43: 0x152a102 in handleSlashCommand (root.zig)
./src/agent/root.zig:976:48: 0x15adc4b in turn (root.zig)
./src/session.zig:420:48: 0x16b45bd in processMessageStreaming (root.zig)
./src/channel_loop.zig:83:62: 0x2903ddf in processTelegramMessage (root.zig)
./src/channel_loop.zig:133:31: 0x296c96f in run (root.zig)
./src/channel_loop.zig:160:17: 0x296099a in messageTaskWorker (root.zig)
/lib/std/Thread.zig:509:13: 0x294bcf0 in callFn__anon_596754 (std.zig)
/lib/std/Thread.zig:781:30: 0x2937d85 in entryFn (std.zig)
/lib/libc/musl/src/thread/pthread_create.c:207:17: 0x30573f3 in start (/lib/libc/musl/src/thread/pthread_create.c)
/lib/libc/musl/src/thread/x86_64/clone.s:23:0: 0x3058493 in ??? (/lib/libc/musl/src/thread/x86_64/clone.s)
Unwind error at address `exe:0x3058493` (error.MissingFDE), trace may be incomplete

```

</details>

## Fix

- Add `appendOwnedHistoryMessage()` helper that transfers ownership explicitly: deinitializes the message only if append fails; otherwise history owns the buffer.
- Updated all append sites in turn() to use this helper.

## Tests

Added regression test: `test "turn retains user message on provider error"`. Simulates a provider failure mid-turn and verifies no double-free occurs when clearing history afterwards. And all tests passed locally (`zig build test --summary all`).
