### PR TITLE
feat(telegram): add /allowlist and /skill to bot command menu

### DIFF
--- a/src/control_plane.zig
+++ b/src/control_plane.zig
@@ -130,7 +130,9 @@ test "isStopLikeCommand rejects non-control commands" {
     try std.testing.expect(!isStopLikeCommand(""));
 }
 
-test "telegram bot command payload includes memory and doctor commands" {
+test "telegram bot command payload includes registered menu commands" {
+    try std.testing.expect(std.mem.indexOf(u8, TELEGRAM_BOT_COMMANDS_JSON, "\"command\":\"allowlist\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, TELEGRAM_BOT_COMMANDS_JSON, "\"command\":\"skill\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, TELEGRAM_BOT_COMMANDS_JSON, "\"command\":\"memory\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, TELEGRAM_BOT_COMMANDS_JSON, "\"command\":\"doctor\"") != null);
 }


### PR DESCRIPTION

Both `/skill` and `/allowlist` can be used often to check the capabilities, so registering both commands in Telegram's "/" command menu.