### PR TITLE
fix(lark): use correct websocket config endpoint URL (no open-apis path)

### DIFF
--- a/src/channels/lark.zig
+++ b/src/channels/lark.zig
@@ -99,6 +99,9 @@ pub const LarkChannel = struct {
 
     pub const FEISHU_BASE_URL = "https://open.feishu.cn/open-apis";
     pub const LARK_BASE_URL = "https://open.larksuite.com/open-apis";
+    /// Host root for callback endpoints (e.g. websocket config). Path is /callback/ws/endpoint, not under /open-apis.
+    pub const FEISHU_CALLBACK_HOST = "https://open.feishu.cn";
+    pub const LARK_CALLBACK_HOST = "https://open.larksuite.com";
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -436,8 +439,9 @@ pub const LarkChannel = struct {
     }
 
     fn buildWebsocketConfigUrl(self: *const LarkChannel, buf: []u8) ![]const u8 {
+        const host = if (self.use_feishu) FEISHU_CALLBACK_HOST else LARK_CALLBACK_HOST;
         var fbs = std.io.fixedBufferStream(buf);
-        try fbs.writer().print("{s}/callback/ws/endpoint", .{self.apiBase()});
+        try fbs.writer().print("{s}/callback/ws/endpoint", .{host});
         return fbs.getWritten();
     }
 
@@ -1649,14 +1653,14 @@ test "lark buildWebsocketConfigUrl follows region" {
     ch.use_feishu = true;
     var feishu_buf: [256]u8 = undefined;
     try std.testing.expectEqualStrings(
-        "https://open.feishu.cn/open-apis/callback/ws/endpoint",
+        "https://open.feishu.cn/callback/ws/endpoint",
         try ch.buildWebsocketConfigUrl(&feishu_buf),
     );
 
     ch.use_feishu = false;
     var lark_buf: [256]u8 = undefined;
     try std.testing.expectEqualStrings(
-        "https://open.larksuite.com/open-apis/callback/ws/endpoint",
+        "https://open.larksuite.com/callback/ws/endpoint",
         try ch.buildWebsocketConfigUrl(&lark_buf),
     );
 }


### PR DESCRIPTION
## Summary

- **Fix websocket config endpoint URL in Lark/Feishu channel.**  
  The URL used to fetch websocket config was `{domain}/open-apis/callback/ws/endpoint`. It is corrected to `{domain}/callback/ws/endpoint`.
- Per the [Lark official Node SDK](https://github.com/larksuite/node-sdk), open APIs are under `/open-apis/`, but the **websocket config** endpoint is an exception and is exposed at `{domain}/callback/ws/endpoint` (no `/open-apis` segment).
- **Implementation:** Added `FEISHU_CALLBACK_HOST` / `LARK_CALLBACK_HOST` and updated `buildWebsocketConfigUrl` to use these for the WS config request only. Other APIs (auth, messages, etc.) still use the existing `apiBase()` (`/open-apis`).
- Fixes ** #423  **.

## Validation

- `zig fmt src/channels/lark.zig`
- `zig build test --summary all` (only `src/channels/lark.zig` touched; lark-related tests pass)

## Notes

- Single-file change: `src/channels/lark.zig` (constants, `buildWebsocketConfigUrl`, and one test expectation).
