### PR TITLE
fix(subagent): avoid double-free of system prompt in runTaskWithTools

### DIFF
--- a/src/subagent_runner.zig
+++ b/src/subagent_runner.zig
@@ -132,12 +132,15 @@ pub fn runTaskWithTools(
         "{s}\n\n{s}",
         .{ request.system_prompt, tool_instructions },
     );
-    errdefer allocator.free(full_system);
-
-    try agent.history.append(allocator, .{
+    // After append, ownership transfers to agent.history; agent.deinit() frees it.
+    // Use catch to free only if append itself fails (avoids double-free with deinit).
+    agent.history.append(allocator, .{
         .role = .system,
         .content = full_system,
-    });
+    }) catch |err| {
+        allocator.free(full_system);
+        return err;
+    };
     agent.has_system_prompt = true;
     agent.system_prompt_has_conversation_context = false;
     agent.workspace_prompt_fingerprint = agent_mod.prompt.workspacePromptFingerprint(allocator, request.workspace_dir, agent.bootstrap) catch null;


### PR DESCRIPTION
## Summary
- `runTaskWithTools()` allocates `full_system` and appends it to `agent.history`, transferring ownership. However, an `errdefer allocator.free(full_system)` remained armed. If `agent.turn()` returned an error, both the `errdefer` and `agent.deinit()` freed the same pointer — causing a double-free (segfault on macOS, allocator panic with GPA).
- This is the `subagent_runner.zig` counterpart to the `agent/root.zig` fix in #428. Same pattern, different call site.
- Replaced the `errdefer` with a `catch` on the `history.append` call so the buffer is only freed if the append itself fails.

## Validation
- `zig build test --summary all` — 5276/5281 passed, 4 skipped, 1 pre-existing failure (`tools.http_request.test.execute rejects non-allowlisted domain`)
- Confirmed the double-free is gone via GPA in debug build
- Tested end-to-end with subagent dispatch through OpenRouter

## Notes
- Discovered while building [nullharness](https://github.com/ActionData/nullharness), which exercises `SubagentManager` + `runTaskWithTools` as a library consumer
- The pre-existing test failure is unrelated to this change (same result on upstream/main)