### PR TITLE
fix(skills): accept direct skill manifest paths

### DIFF
--- a/src/skills.zig
+++ b/src/skills.zig
@@ -646,6 +646,11 @@ const SKILL_SCRIPT_SUFFIXES = [_][]const u8{
     ".bat",
     ".cmd",
 };
+const SKILL_MARKER_BASENAMES = [_][]const u8{
+    "SKILL.md",
+    "SKILL.toml",
+    "skill.json",
+};
 
 fn startsWithAsciiIgnoreCase(haystack: []const u8, needle: []const u8) bool {
     if (needle.len == 0) return true;
@@ -1186,17 +1191,12 @@ fn pathExists(path: []const u8) bool {
 }
 
 fn hasSkillMarkers(allocator: std.mem.Allocator, dir_path: []const u8) !bool {
-    const md = try std.fmt.allocPrint(allocator, "{s}/SKILL.md", .{dir_path});
-    defer allocator.free(md);
-    if (pathExists(md)) return true;
-
-    const toml = try std.fmt.allocPrint(allocator, "{s}/SKILL.toml", .{dir_path});
-    defer allocator.free(toml);
-    if (pathExists(toml)) return true;
-
-    const json = try std.fmt.allocPrint(allocator, "{s}/skill.json", .{dir_path});
-    defer allocator.free(json);
-    return pathExists(json);
+    for (SKILL_MARKER_BASENAMES) |marker| {
+        const marker_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir_path, marker });
+        defer allocator.free(marker_path);
+        if (pathExists(marker_path)) return true;
+    }
+    return false;
 }
 
 fn hasInstallableSkillContent(allocator: std.mem.Allocator, dir_path: []const u8) !bool {
@@ -1204,9 +1204,10 @@ fn hasInstallableSkillContent(allocator: std.mem.Allocator, dir_path: []const u8
 }
 
 fn isSkillMarkerBasename(base_name: []const u8) bool {
-    return std.mem.eql(u8, base_name, "SKILL.md") or
-        std.mem.eql(u8, base_name, "SKILL.toml") or
-        std.mem.eql(u8, base_name, "skill.json");
+    for (SKILL_MARKER_BASENAMES) |marker| {
+        if (std.mem.eql(u8, base_name, marker)) return true;
+    }
+    return false;
 }
 
 fn resolveInstallableSkillSourceRoot(allocator: std.mem.Allocator, source_path: []const u8) ![]u8 {
@@ -2874,33 +2875,66 @@ test "installSkillFromPath supports markdown-only source directory" {
     try std.testing.expectEqualStrings("# Markdown only install", content);
 }
 
-test "installSkillFromPath accepts direct SKILL.md file path" {
+test "installSkillFromPath accepts direct manifest file paths" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try tmp.dir.makePath("workspace");
-    try tmp.dir.makePath("source-file");
-    {
-        const f = try tmp.dir.createFile("source-file/SKILL.md", .{});
-        defer f.close();
-        try f.writeAll("# File path install");
-    }
+
+    const cases = [_]struct {
+        source_dir_name: []const u8,
+        manifest_name: []const u8,
+        manifest_body: []const u8,
+    }{
+        .{
+            .source_dir_name = "source-file-md",
+            .manifest_name = "SKILL.md",
+            .manifest_body = "# File path install",
+        },
+        .{
+            .source_dir_name = "source-file-toml",
+            .manifest_name = "SKILL.toml",
+            .manifest_body =
+            \\[skill]
+            \\name = "file-path-install"
+            \\description = "toml manifest path"
+            ,
+        },
+        .{
+            .source_dir_name = "source-file-json",
+            .manifest_name = "skill.json",
+            .manifest_body = "{\"name\":\"file-path-install-json\",\"version\":\"1.0.0\"}",
+        },
+    };
 
     const base = try tmp.dir.realpathAlloc(allocator, ".");
     defer allocator.free(base);
     const workspace = try std.fs.path.join(allocator, &.{ base, "workspace" });
     defer allocator.free(workspace);
-    const source_file = try std.fs.path.join(allocator, &.{ base, "source-file", "SKILL.md" });
-    defer allocator.free(source_file);
 
-    try installSkillFromPath(allocator, source_file, workspace);
+    for (cases) |case| {
+        try tmp.dir.makePath(case.source_dir_name);
 
-    const installed_path = try std.fs.path.join(allocator, &.{ workspace, "skills", "source-file", "SKILL.md" });
-    defer allocator.free(installed_path);
-    const content = try std.fs.cwd().readFileAlloc(allocator, installed_path, 1024);
-    defer allocator.free(content);
-    try std.testing.expectEqualStrings("# File path install", content);
+        const source_rel = try std.fs.path.join(allocator, &.{ case.source_dir_name, case.manifest_name });
+        defer allocator.free(source_rel);
+        {
+            const f = try tmp.dir.createFile(source_rel, .{});
+            defer f.close();
+            try f.writeAll(case.manifest_body);
+        }
+
+        const source_file = try std.fs.path.join(allocator, &.{ base, case.source_dir_name, case.manifest_name });
+        defer allocator.free(source_file);
+
+        try installSkillFromPath(allocator, source_file, workspace);
+
+        const installed_path = try std.fs.path.join(allocator, &.{ workspace, "skills", case.source_dir_name, case.manifest_name });
+        defer allocator.free(installed_path);
+        const content = try std.fs.cwd().readFileAlloc(allocator, installed_path, 1024);
+        defer allocator.free(content);
+        try std.testing.expectEqualStrings(case.manifest_body, content);
+    }
 }
 
 test "installSkillFromPath supports legacy skill.json-only source directory" {


### PR DESCRIPTION
## Summary
- accept direct manifest file paths like `.../SKILL.md`, `.../SKILL.toml`, and `.../skill.json` in `installSkillFromPath`
- resolve manifest file inputs back to the containing skill directory before deriving the installed skill name and copying files
- add a regression test covering install from a direct `SKILL.md` path

## Root Cause
`installSkillFromPath` assumed the caller always passed a directory. When the CLI received a direct manifest path, it resolved the file path and then looked for installable markers under `<file>/SKILL.md`, which always failed with `error.ManifestNotFound`.

## Validation
- `/home/micelio/.local/share/mise/installs/zig/0.15.2/zig build test --summary all`
  - `9/9 steps succeeded; 5265/5276 tests passed; 11 skipped`

Refs #427