### PR TITLE
fix(lark): use HEAVY_RUNTIME_STACK_SIZE for websocket thread to fix bus error on startup

### DIFF
--- a/src/channels/lark.zig
+++ b/src/channels/lark.zig
@@ -798,7 +798,7 @@ pub const LarkChannel = struct {
         }
 
         self.connected.store(false, .release);
-        self.ws_thread = std.Thread.spawn(.{ .stack_size = thread_stacks.CONTROL_LOOP_STACK_SIZE }, websocketLoop, .{self}) catch |err| {
+        self.ws_thread = std.Thread.spawn(.{ .stack_size = thread_stacks.HEAVY_RUNTIME_STACK_SIZE }, websocketLoop, .{self}) catch |err| {
             self.running.store(false, .release);
             return err;
         };


### PR DESCRIPTION
Fixes #423 

## Summary

- **Fix:** Lark gateway no longer crashes with a bus error (SIGBUS) on startup when running `nullclaw gateway` with the Lark channel enabled in websocket mode.
- **Change:** The Lark websocket loop thread now uses `thread_stacks.HEAVY_RUNTIME_STACK_SIZE` (2 MiB) instead of `thread_stacks.CONTROL_LOOP_STACK_SIZE` (256 KiB) when spawning the websocket loop in `src/channels/lark.zig`.
- **Rationale:** The Lark websocket path (fetching connect config via HTTP, JSON parsing, and WebSocket connect) can exceed 256 KiB stack on some platforms (e.g. macOS), leading to stack overflow and a bus error shortly after "lark gateway started" is logged. Other gateway-style channels (Discord, Mattermost, QQ) already use `HEAVY_RUNTIME_STACK_SIZE` for their long-lived gateway threads; this change aligns Lark with that convention and with the intent of `thread_stacks.zig` ("Long-lived network/runtime threads such as channel gateways").

## Problem

When starting the gateway with Lark configured in websocket receive mode, the process logs `info(channel_manager): lark gateway started` then crashes with a bus error (SIGBUS). Increasing the websocket thread stack size resolves the crash. ses #423 

## Validation

- `zig build test --summary all`
- `zig fmt --check src/`
- Manual: `./zig-out/bin/nullclaw gateway` with Lark websocket config — no crash.

## Notes

- **Scope:** Single-file change; no config, CLI, or doc changes.
- **Risk:** Low. Only the reserved stack size for one thread is changed; RSS impact is minimal (stack pages are demand-backed).