### PR TITLE
feat(skills): parse skill metadata from YAML frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Every subsystem is a **vtable interface** — swap implementations with a config
 | **Identity** | `IdentityConfig` | OpenClaw (markdown), AIEOS v1.1 (JSON) | Any identity format |
 | **Tunnel** | `Tunnel` | None, Cloudflare, Tailscale, ngrok, Custom | Any tunnel binary |
 | **Heartbeat** | Engine | HEARTBEAT.md periodic tasks | — |
-| **Skills** | Loader | TOML manifests + SKILL.md instructions | Community skill packs |
+| **Skills** | Loader | TOML/JSON manifests or YAML frontmatter in `SKILL.md` | Community skill packs |
 | **Peripherals** | `Peripheral` | Serial, Arduino, Raspberry Pi GPIO, STM32/Nucleo | Any hardware interface |
 | **Cron** | Scheduler | Cron expressions + one-shot timers with JSON persistence | — |
 

--- a/src/skills.zig
+++ b/src/skills.zig
@@ -418,7 +418,7 @@ fn parseFrontmatterStringArray(allocator: std.mem.Allocator, meta: []const u8, k
 
         var parts = std.mem.splitScalar(u8, inner, ',');
         while (parts.next()) |part_raw| {
-            const part = std.mem.trim(u8, part_raw, " \t");
+            const part = std.mem.trim(u8, stripFrontmatterInlineComment(part_raw), " \t");
             if (part.len == 0) continue;
 
             // Strip quotes if present
@@ -436,10 +436,11 @@ fn parseFrontmatterStringArray(allocator: std.mem.Allocator, meta: []const u8, k
 
         // Check if line is indented and starts with "- "
         const trimmed = std.mem.trimLeft(u8, line, " \t");
+        if (trimmed.len > 0 and trimmed[0] == '#') continue;
         if (trimmed.len < 2 or trimmed[0] != '-') break; // end of block sequence
         if (trimmed[1] != ' ' and trimmed[1] != '\t') break;
 
-        const val_raw = std.mem.trim(u8, trimmed[2..], " \t");
+        const val_raw = std.mem.trim(u8, stripFrontmatterInlineComment(trimmed[2..]), " \t");
         const val = stripYamlQuotes(val_raw);
         if (val.len == 0) continue;
         try items.append(allocator, try allocator.dupe(u8, val));
@@ -4340,6 +4341,22 @@ test "parseFrontmatterStringArray block sequence with quoted items" {
     try std.testing.expectEqualStrings("item-two", arr[1]);
 }
 
+test "parseFrontmatterStringArray block sequence ignores comments" {
+    const allocator = std.testing.allocator;
+    const meta =
+        \\requires_bins:
+        \\  - docker # primary runtime
+        \\  # keep git for repo access
+        \\  - git
+    ;
+    const arr = try parseFrontmatterStringArray(allocator, meta, "requires_bins");
+    defer freeStringArray(allocator, arr);
+
+    try std.testing.expectEqual(@as(usize, 2), arr.len);
+    try std.testing.expectEqualStrings("docker", arr[0]);
+    try std.testing.expectEqualStrings("git", arr[1]);
+}
+
 test "parseFrontmatterSkill full frontmatter" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -4575,4 +4592,39 @@ test "loadSkill SKILL.md frontmatter with requires_bins" {
     try std.testing.expectEqualStrings("docker", skill.requires_bins[0]);
     try std.testing.expectEqualStrings("git", skill.requires_bins[1]);
     try std.testing.expectEqualStrings("Instructions.", skill.instructions);
+}
+
+test "loadSkill SKILL.md frontmatter requires_bins ignores comments" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("skills/commented-bins");
+    {
+        const f = try tmp.dir.createFile("skills/commented-bins/SKILL.md", .{});
+        defer f.close();
+        try f.writeAll(
+            "---\n" ++
+                "name: commented-bins\n" ++
+                "requires_bins:\n" ++
+                "  - docker # primary runtime\n" ++
+                "  # keep git for repo access\n" ++
+                "  - git\n" ++
+                "---\n" ++
+                "Instructions.\n",
+        );
+    }
+
+    const base = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+    const skill_dir = try std.fs.path.join(allocator, &.{ base, "skills", "commented-bins" });
+    defer allocator.free(skill_dir);
+
+    const skill = try loadSkill(allocator, skill_dir);
+    defer freeSkill(allocator, &skill);
+
+    try std.testing.expectEqualStrings("commented-bins", skill.name);
+    try std.testing.expectEqual(@as(usize, 2), skill.requires_bins.len);
+    try std.testing.expectEqualStrings("docker", skill.requires_bins[0]);
+    try std.testing.expectEqualStrings("git", skill.requires_bins[1]);
 }


### PR DESCRIPTION
SKILL.md files can carry manifest metadata (name, description, version, author, always, requires_bins, requires_env) in a YAML frontmatter block delimited by `---`. When a skill directory has only SKILL.md (no SKILL.toml or skill.json), the frontmatter is parsed to populate manifest fields and only the body after the closing delimiter is used as instructions.

When no frontmatter is present, behavior is unchanged (dirname as name, full content as instructions). When frontmatter exists but name is missing, the directory basename is used as fallback.