### PR TITLE
docs(docker): document the official container install path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,10 @@ RUN --mount=type=cache,target=/root/.cache/zig \
 # ── Stage 2: Config Prep ─────────────────────────────────────
 FROM busybox:1.37 AS config
 
-RUN mkdir -p /nullclaw-data/.nullclaw /nullclaw-data/workspace
+# Keep config.json at the volume root so existing compose volumes remain readable.
+RUN mkdir -p /nullclaw-data/workspace
 
-RUN cat > /nullclaw-data/.nullclaw/config.json << 'EOF'
+RUN cat > /nullclaw-data/config.json << 'EOF'
 {
   "api_key": "",
   "default_provider": "openrouter",
@@ -65,6 +66,7 @@ COPY --from=builder /app/zig-out/bin/nullclaw /usr/local/bin/nullclaw
 COPY --from=config /nullclaw-data /nullclaw-data
 
 ENV NULLCLAW_WORKSPACE=/nullclaw-data/workspace
+ENV NULLCLAW_HOME=/nullclaw-data
 ENV HOME=/nullclaw-data
 ENV NULLCLAW_GATEWAY_PORT=3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     profiles: ["gateway"]
     command: ["gateway", "--port", "3000", "--host", "::"]
     ports:
-      - "${NULLCLAW_GATEWAY_PORT:-3000}:3000"
+      - "127.0.0.1:${NULLCLAW_GATEWAY_PORT:-3000}:3000"
     env_file:
       - path: .env
         required: false

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -50,7 +50,7 @@ NullClaw publishes an official OCI image at `ghcr.io/nullclaw/nullclaw`.
 
 The container stores its persistent state under `/nullclaw-data`:
 
-- config: `/nullclaw-data/.nullclaw/config.json`
+- config: `/nullclaw-data/config.json`
 - workspace: `/nullclaw-data/workspace`
 
 ### Quick one-off commands
@@ -81,7 +81,7 @@ Run the HTTP gateway:
 
 ```bash
 docker run --rm -it \
-  -p 3000:3000 \
+  -p 127.0.0.1:3000:3000 \
   -v nullclaw-data:/nullclaw-data \
   ghcr.io/nullclaw/nullclaw:latest
 ```
@@ -111,7 +111,9 @@ docker compose --profile gateway up -d gateway
 Profile behavior:
 
 - `agent`: one-off interactive CLI container
-- `gateway`: long-running HTTP gateway on port `3000`
+- `gateway`: long-running HTTP gateway published on host loopback port `3000`
+
+If you need LAN or public exposure, change the published host IP deliberately and review [Security](./security.md) first.
 
 To pin a release tag or switch registries later, override `NULLCLAW_IMAGE`:
 

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -36,7 +36,7 @@ NullClaw 当前提供官方 OCI 镜像：`ghcr.io/nullclaw/nullclaw`。
 
 容器内的持久化目录统一放在 `/nullclaw-data`：
 
-- 配置文件：`/nullclaw-data/.nullclaw/config.json`
+- 配置文件：`/nullclaw-data/config.json`
 - 工作区：`/nullclaw-data/workspace`
 
 ### 单次命令
@@ -67,7 +67,7 @@ docker run --rm -it \
 
 ```bash
 docker run --rm -it \
-  -p 3000:3000 \
+  -p 127.0.0.1:3000:3000 \
   -v nullclaw-data:/nullclaw-data \
   ghcr.io/nullclaw/nullclaw:latest
 ```
@@ -97,7 +97,9 @@ docker compose --profile gateway up -d gateway
 Profile 含义：
 
 - `agent`：一次性的交互式 CLI 容器
-- `gateway`：长期运行的 HTTP gateway，默认监听 `3000`
+- `gateway`：长期运行的 HTTP gateway，默认发布到宿主机回环地址 `3000`
+
+如果你需要局域网或公网访问，请显式修改发布地址，并先阅读 [安全指南](./security.md)。
 
 如果你要固定版本标签，或者以后切换到其他镜像仓库，可以覆盖 `NULLCLAW_IMAGE`：
 


### PR DESCRIPTION
## Summary

This PR documents the existing official container path for nullclaw and fixes the repository's compose example so it matches the image's actual runtime layout.

## Problem

Issue #449 asks for an official container image path and clearer installation guidance.

Today the repository already has most of the pieces:

- a published OCI image flow via `ghcr.io`
- a `Dockerfile`
- a `docker-compose.yml`

But the user-facing path is still confusing:

- installation docs do not explain the official image at all
- the compose file was wired to the wrong data path
- the gateway service published the wrong port
- the `agent` profile did not actually run the `agent` command

## What changed

- document the official container install path in English and Chinese installation guides
- add `docker run` examples for `status`, `onboard --interactive`, `agent`, and `gateway`
- explain the `agent` vs `gateway` compose profiles
- switch `docker-compose.yml` to use the published official image by default
- fix the compose volume mount to `/nullclaw-data`
- fix the gateway port mapping and healthcheck to `3000`
- make the compose image overridable with `NULLCLAW_IMAGE` so tags or registries can be swapped cleanly later

## Why this shape

This PR solves the part of the issue that the repository can solve directly:

- clear install docs
- a working compose example
- an image reference that users can pin by tag

It does **not** create a Docker Hub namespace or publish credentials by itself. That remains a maintainer/release-infra decision. The compose file is now registry-agnostic through `NULLCLAW_IMAGE`, so a Docker Hub mirror can be adopted later without changing the docs structure.

## Validation

- `docker compose config`
- `docker compose --profile agent --profile gateway config`
- `git diff --check`

## Notes

The image path documented here is the existing official OCI image at `ghcr.io/nullclaw/nullclaw`.
