### PR TITLE
docs(readme): label Chinese doc links in English

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,17 +668,17 @@ Implement a vtable interface, submit a PR:
 - New `Peripheral` -> `src/peripherals.zig`
 - New `Skill` -> `~/.nullclaw/workspace/skills/<name>/`
 
-## 中文文档
+## Chinese Docs (中文文档)
 
-- [中文文档总览](docs/zh/README.md)
-- [安装指南](docs/zh/installation.md)
-- [配置指南](docs/zh/configuration.md)
-- [使用与运维](docs/zh/usage.md)
-- [架构总览](docs/zh/architecture.md)
-- [安全机制](docs/zh/security.md)
-- [Gateway API](docs/zh/gateway-api.md)
-- [命令参考](docs/zh/commands.md)
-- [开发指南](docs/zh/development.md)
+- [Chinese docs overview (中文文档总览)](docs/zh/README.md)
+- [Installation guide (安装指南)](docs/zh/installation.md)
+- [Configuration guide (配置指南)](docs/zh/configuration.md)
+- [Usage and operations (使用与运维)](docs/zh/usage.md)
+- [Architecture overview (架构总览)](docs/zh/architecture.md)
+- [Security model (安全机制)](docs/zh/security.md)
+- [Gateway API (中文)](docs/zh/gateway-api.md)
+- [Commands reference (命令参考)](docs/zh/commands.md)
+- [Development guide (开发指南)](docs/zh/development.md)
 
 ## English Docs
 


### PR DESCRIPTION
## Summary

This updates the Chinese docs section in `README.md` so each link remains understandable even on systems without CJK language packs installed.

## Problem

Issue #320 points out that the GitHub landing page can show tofu / unreadable boxes for users who do not have Asian language fonts installed.

The repository already has both English and Chinese docs, but the bottom README section still exposed the Chinese doc links with Chinese-only labels. That makes the section look broken on systems that cannot render those glyphs.

## What changed

- rename the section header to `Chinese Docs (中文文档)`
- give every Chinese doc link an English label first, while preserving the original Chinese title in parentheses
- keep the English docs section unchanged

## Why this shape

This keeps the multilingual intent of the README intact, but makes the links self-explanatory even when CJK glyphs are not available.

## Validation

- `git diff --check`

Closes #320.
