### PR TITLE
fix(onebot): run websocket gateway loop

### DIFF
--- a/src/channels/onebot.zig
+++ b/src/channels/onebot.zig
@@ -418,14 +418,14 @@ pub const OneBotChannel = struct {
         self.running.store(false, .release);
         self.connected.store(false, .release);
 
-        const fd = self.ws_fd.load(.acquire);
+        // Unblock a blocking read without stealing final ownership from WsClient.deinit().
+        const fd = self.ws_fd.swap(invalid_socket, .acq_rel);
         if (fd != invalid_socket) {
             if (comptime builtin.os.tag == .windows) {
-                _ = std.os.windows.ws2_32.closesocket(fd);
+                _ = std.os.windows.ws2_32.shutdown(fd, std.os.windows.ws2_32.SD_RECEIVE);
             } else {
-                std.posix.close(fd);
+                std.posix.shutdown(fd, .recv) catch {};
             }
-            self.ws_fd.store(invalid_socket, .release);
         }
 
         if (self.gateway_thread) |t| {

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -1,6 +1,6 @@
-//! Generic RFC 6455 WebSocket client over TLS.
-//! Used by Discord, Lark, DingTalk, QQ gateway channels.
-//! All connections are TLS-only (wss://).
+//! Generic RFC 6455 WebSocket client.
+//! Used by Discord, Lark, DingTalk, QQ gateway channels and OneBot.
+//! Supports both `wss://` and `ws://` transports.
 
 const std = @import("std");
 
@@ -39,7 +39,6 @@ pub const TlsState = struct {
     write_buf: []u8,
     tls_read_buf: []u8,
     tls_write_buf: []u8,
-    scratch: [4096]u8 = undefined,
 
     pub fn deinit(self: *TlsState, allocator: std.mem.Allocator) void {
         allocator.free(self.read_buf);
@@ -195,7 +194,12 @@ pub const WsClient = struct {
         var resp_len: usize = 0;
         var headers_complete = false;
         while (resp_len < resp_buf.len) {
-            try self.readExact(resp_buf[resp_len .. resp_len + 1]);
+            if (self.tls) |tls| {
+                const byte_ptr = tls.tls_client.reader.take(1) catch return error.WsHandshakeFailed;
+                resp_buf[resp_len] = byte_ptr[0];
+            } else {
+                self.readExact(resp_buf[resp_len .. resp_len + 1]) catch return error.WsHandshakeFailed;
+            }
             resp_len += 1;
             if (resp_len >= 4 and
                 resp_buf[resp_len - 4] == '\r' and


### PR DESCRIPTION
## Summary
- add real OneBot gateway-loop startup instead of only marking the channel as running
- add plain `ws://` support to the shared WebSocket client while keeping existing `wss://` channels unchanged
- normalize OneBot API URL derivation so outbound `/send_msg` calls use `http(s)` host roots instead of reusing the websocket URL verbatim

## Why
Issue #308 is not a user configuration problem. The OneBot channel is catalogued as a `gateway_loop` channel, but the adapter never opened a websocket connection. `start()` only flipped `running = true`, so nullclaw would report the channel as started while never actually receiving events from NapCat/go-cqhttp/Lagrange.

There was also a second transport mismatch: the shared websocket client only supported TLS `wss://`, while `OneBotConfig` defaults to `ws://localhost:6700` and the issue report uses plain `ws://127.0.0.1:3001`.

## What changed
- `src/websocket.zig`
  - keep the existing TLS websocket path for Discord/Lark/QQ/etc.
  - add a plain websocket connect path for `ws://` endpoints
  - share the HTTP upgrade handshake across both paths
- `src/channels/onebot.zig`
  - add a real gateway thread with reconnect/backoff semantics
  - parse the configured OneBot websocket URL into host/port/path
  - connect with `ws://` or `wss://` as configured
  - store/close the live socket on shutdown so `stop()` can interrupt blocking reads
  - build outbound `/send_msg` URLs from the HTTP(S) host root instead of appending to the websocket URL
  - add regression tests for websocket URL parsing and API URL normalization

## Validation
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseSmall`

Fixes #308.
