### PR TITLE
fix(claude-cli): harden resume session handling

### DIFF
--- a/src/verbose.zig
+++ b/src/verbose.zig
@@ -1,5 +1,5 @@
 //! verbose.zig - Verbose logging control
-//! 
+//!
 //! This module provides thread-safe functions to control and check verbose logging status.
 //! The verbose flag is used to enable detailed debug output across the application.
 
@@ -9,7 +9,7 @@ const std = @import("std");
 var verbose_enabled: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
 /// Set the verbose logging status
-/// 
+///
 /// Args:
 ///   enabled: Whether to enable verbose logging
 pub fn setVerbose(enabled: bool) void {
@@ -17,7 +17,7 @@ pub fn setVerbose(enabled: bool) void {
 }
 
 /// Check if verbose logging is enabled
-/// 
+///
 /// Returns:
 ///   bool: True if verbose logging is enabled, false otherwise
 pub fn isVerbose() bool {


### PR DESCRIPTION
## Summary

This is a follow-up to #478. It keeps that branch untouched and fixes the concrete correctness issues that surfaced during review.

## What changed

- pass `session_id` through the tool-iteration-exhausted summary request so the final fallback summary stays inside the same NullClaw session boundary
- serialize `claude-cli` resumed session execution under the provider mutex so two concurrent turns cannot `--resume` and mutate the same Claude CLI session state at the same time
- evict reset/expired Claude CLI session entries instead of keeping empty per-chat map entries forever
- tolerate the common case where the assistant text stored in NullClaw history is normalized relative to the raw Claude CLI response, avoiding unnecessary resume resets on the next turn
- add regression tests for the summary `session_id` path, normalized assistant mismatch handling, and session-state eviction

## Why this is separate

Per request, this is a new PR instead of a force-push on #478.

This branch is stacked on top of #478:
- if #478 merges first, this PR should collapse to the hardening commit only
- until then, GitHub will show the base Claude CLI session patch plus this follow-up

## Validation

- `zig build test --summary all`
- `zig build -Doptimize=ReleaseSmall`

Refs #218
