### PR TITLE
fix(websocket): stop TLS connections from closing prematurely on empty reads

### DIFF
--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -894,10 +894,51 @@ test "ws buildFrame zero-len payload close" {
 }
 
 // Regression: v2026.3.12 applied a blanket `n == 0 → ConnectionClosed` check
-// to both TLS and plain socket paths.  TLS readVec can return 0 transiently
-// (empty TLS records, session tickets, re-keying) without the connection being
-// closed — the old code simply looped.  The fix confines the EOF-by-zero check
-// to the plain-socket branch only.  These tests lock that contract.
+// to both TLS and plain socket paths. TLS readVec may return 0 while it
+// refills its internal buffer or processes post-handshake records, so only
+// plain sockets should treat a zero-byte read as EOF.
+
+fn fake_tls_test_stream(_: *std.Io.Reader, _: *std.Io.Writer, _: std.Io.Limit) std.Io.Reader.StreamError!usize {
+    return error.EndOfStream;
+}
+
+fn fake_tls_read_vec_zero_then_byte(reader: *std.Io.Reader, data: [][]u8) std.Io.Reader.Error!usize {
+    if (reader.seek == 0 and reader.end == 0) {
+        // Mimic std.crypto.tls.Client.readVec buffering internal TLS records
+        // before returning any application bytes to the caller.
+        reader.seek = 1;
+        reader.end = 1;
+        return 0;
+    }
+    data[0][0] = 'Z';
+    return 1;
+}
+
+test "ws readExact TLS tolerates transient zero readVec return" {
+    var tls_reader_storage = [_]u8{0};
+    var tls_state: TlsState = undefined;
+    tls_state.tls_client = undefined;
+    tls_state.tls_client.reader = .{
+        .buffer = &tls_reader_storage,
+        .seek = 0,
+        .end = 0,
+        .vtable = &.{
+            .stream = fake_tls_test_stream,
+            .readVec = fake_tls_read_vec_zero_then_byte,
+        },
+    };
+
+    var client = WsClient{
+        .allocator = std.testing.allocator,
+        .stream = undefined,
+        .tls = &tls_state,
+        .write_mu = .{},
+    };
+
+    var buf: [1]u8 = undefined;
+    try client.readExact(&buf);
+    try std.testing.expectEqual(@as(u8, 'Z'), buf[0]);
+}
 
 test "ws readExact plain returns ConnectionClosed on immediate EOF" {
     if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;


### PR DESCRIPTION
### Summary

v2026.3.12 introduced plain-socket (ws://) support in src/websocket.zig for the OneBot channel. The refactor added a blanket n == 0 → ConnectionClosed check in readExact that applied to both TLS and plain-socket paths.

This broke all wss:// channels (Discord, Lark, DingTalk, QQ, etc.): the TLS readVec can return 0 bytes transiently — e.g. when processing session tickets, re-keying, or empty TLS records — without the connection actually being closed. The check caused these transient zero-returns to be misinterpreted as EOF, triggering an immediate error.ConnectionClosed and putting the gateway into a reconnect loop.


### Root Cause
```zig
// Before (v2026.3.12 — broken):
const n = if (self.tls) |tls| blk: {
    // ... TLS readVec ...
} else self.stream.read(buf[total..]) catch |e| return e;
if (n == 0) return error.ConnectionClosed;  // ← applied to BOTH paths
```
The TLS path already handles real connection closure via error.EndOfStream. The zero-return check is only meaningful for plain sockets (POSIX EOF convention).

### Fix
Confine the bytes == 0 EOF check to the plain-socket branch only. TLS continues to rely on error.EndOfStream as it did in v2026.3.11.

```zig
// After (fixed):
const n = if (self.tls) |tls| blk: {
    // ... TLS readVec (EndOfStream → ConnectionClosed) ...
} else blk: {
    const bytes = self.stream.read(buf[total..]) catch |e| return e;
    if (bytes == 0) return error.ConnectionClosed;  // ← plain-socket only
    break :blk bytes;
};
```

### Validation
``zig build test --summary`` all — 5584/5588 passed, 4 skipped, 0 leaks
``zig build -Doptimize=ReleaseSmall`` — builds clean
``zig fmt --check src/websocket.zig`` — no issues


### Capture Error:
<img width="1720" height="482" alt="SCR-20260313-bxbi" src="https://github.com/user-attachments/assets/33e354d4-8df7-497b-83ae-6bddf5ada99b" />


### Capture Fix:
<img width="3529" height="1018" alt="SCR-20260313-bxnz" src="https://github.com/user-attachments/assets/7bd2000c-5635-4d04-8106-dd5e0bfe8a47" />
