### PR TITLE
fix(session): resolve dangling provider pointer in named-agent sessions

### DIFF
--- a/src/session.zig
+++ b/src/session.zig
@@ -195,20 +195,37 @@ pub const SessionManager = struct {
         errdefer if (!key_owned_by_session) self.allocator.free(owned_key);
 
         const session = try self.allocator.create(Session);
+        session.provider_holder = null;
+        session.owned_provider_api_key = null;
         var session_initialized = false;
         errdefer {
             if (session_initialized) session.deinit(self.allocator);
             self.allocator.destroy(session);
         }
+        errdefer if (!session_initialized) {
+            if (session.provider_holder) |*holder| holder.deinit();
+            if (session.owned_provider_api_key) |key| self.allocator.free(key);
+        };
 
         const agent_profile = findProfileForSessionKey(self.config, session_key);
         var provider_ctx = try self.resolveProviderForSession(agent_profile);
         errdefer provider_ctx.deinit(self.allocator);
 
+        session.* = undefined;
+        session.provider_holder = provider_ctx.holder;
+        session.owned_provider_api_key = provider_ctx.owned_api_key;
+        provider_ctx.holder = null;
+        provider_ctx.owned_api_key = null;
+
+        const session_provider = if (session.provider_holder) |*holder|
+            holder.provider()
+        else
+            provider_ctx.provider;
+
         var agent = try Agent.fromConfigWithProfile(
             self.allocator,
             self.config,
-            provider_ctx.provider,
+            session_provider,
             self.tools,
             self.mem,
             self.observer,
@@ -224,10 +241,12 @@ pub const SessionManager = struct {
             agent.usage_record_ctx = @ptrCast(self);
         }
 
+        const session_provider_holder = session.provider_holder;
+        const session_owned_provider_api_key = session.owned_provider_api_key;
         session.* = .{
             .agent = agent,
-            .provider_holder = provider_ctx.holder,
-            .owned_provider_api_key = provider_ctx.owned_api_key,
+            .provider_holder = session_provider_holder,
+            .owned_provider_api_key = session_owned_provider_api_key,
             .created_at = std.time.timestamp(),
             .last_active = std.time.timestamp(),
             .last_consolidated = 0,
@@ -238,8 +257,6 @@ pub const SessionManager = struct {
         };
         key_owned_by_session = true;
         session_initialized = true;
-        provider_ctx.holder = null;
-        provider_ctx.owned_api_key = null;
 
         // Restore persisted conversation history from session store
         if (self.session_store) |store| {
@@ -1360,6 +1377,30 @@ test "getOrCreate applies named agent profile from routed session key" {
     try testing.expectEqualStrings("ollama", session.agent.default_provider);
     try testing.expectApproxEqAbs(@as(f64, 0.25), session.agent.temperature, 0.000001);
     try testing.expectEqual(@as(usize, 0), session.agent.model_routes.len);
+}
+
+test "getOrCreate stores named agent provider interface from session-owned holder" {
+    var mock = MockProvider{ .response = "ok" };
+    var cfg = testConfig();
+    cfg.default_provider = "openrouter";
+    cfg.agents = &.{
+        .{
+            .name = "Coder Agent",
+            .provider = "ollama",
+            .model = "qwen2.5-coder:14b",
+        },
+    };
+
+    var sm = testSessionManager(testing.allocator, &mock, &cfg);
+    defer sm.deinit();
+
+    const session = try sm.getOrCreate("agent:coder-agent:telegram:group:-100123");
+    try testing.expect(session.provider_holder != null);
+
+    var holder = &session.provider_holder.?;
+    const holder_provider = holder.provider();
+    try testing.expect(session.agent.provider.ptr == holder_provider.ptr);
+    try testing.expect(session.agent.provider.vtable == holder_provider.vtable);
 }
 
 test "getOrCreate falls back to default config for unknown routed agent id" {


### PR DESCRIPTION
## Summary

Fixes a post-merge regression from PR #450 (topic agent bindings) where named-agent sessions created via `/bind <agent>` would silently fail — the agent received no responses and `/new` would hang.

## Root Cause

In `getOrCreate()`, `Agent.fromConfigWithProfile()` received a `Provider` vtable interface whose `ptr` pointed into a **stack-local** `SessionProviderContext.holder`. When the holder was later moved into `session.provider_holder` via struct assignment, the agent's provider `ptr` became **dangling**.

**Before (broken flow):**
1. `resolveProviderForSession()` → `provider_ctx` with holder on stack
2. `holder.provider()` → vtable `ptr` points into `provider_ctx.holder`
3. `Agent.fromConfigWithProfile(provider_ctx.provider, ...)` → agent stores dangling ptr
4. `session.provider_holder = provider_ctx.holder` → holder moved, agent ptr is stale

**After (fixed flow):**
1. `resolveProviderForSession()` → `provider_ctx` with holder on stack
2. `session.provider_holder = provider_ctx.holder` → move holder to session-owned memory **first**
3. `session.provider_holder.provider()` → vtable `ptr` points into session-owned memory
4. `Agent.fromConfigWithProfile(session_provider, ...)` → agent stores stable ptr

## Live Reproduction

- **Before fix**: `/bind repro` → messages hung with ⚡ reaction, no bot response
- **After fix**: `/bind repro` → bot replied correctly; `/new` → fresh greeting

## Changes

- `src/session.zig`: Reorder provider initialization in `getOrCreate()` so `ProviderHolder` is moved to session-owned memory before `holder.provider()` is called
- Adds regression test: `"getOrCreate stores named agent provider interface from session-owned holder"` — verifies `agent.provider.ptr` points into session-owned `provider_holder`

## Validation

- All tests pass: **5586 passed, 11 skipped, 0 failures, 0 leaks**
- Live Telegram test confirmed fix works end-to-end

Relates to #450