### PR TITLE
fix(sse): accept no-space SSE data prefix

### DIFF
--- a/src/providers/sse.zig
+++ b/src/providers/sse.zig
@@ -191,13 +191,16 @@ pub fn parseSseLine(allocator: std.mem.Allocator, line: []const u8) !SseLineResu
     if (trimmed.len == 0) return .skip;
     if (trimmed[0] == ':') return .skip;
 
-    // Accept both "data: " (standard SSE) and "data:" (no-space variant used by some providers, e.g. Kimi).
-    const data = if (std.mem.startsWith(u8, trimmed, "data: "))
-        trimmed["data: ".len..]
-    else if (std.mem.startsWith(u8, trimmed, "data:"))
-        trimmed["data:".len..]
+    // SSE uses "data:" with an optional single leading space before the value.
+    const prefix = "data:";
+    if (!std.mem.startsWith(u8, trimmed, prefix)) return .skip;
+
+    const data = if (trimmed.len > prefix.len and trimmed[prefix.len] == ' ')
+        trimmed[prefix.len + 1 ..]
     else
-        return .skip;
+        trimmed[prefix.len..];
+
+    if (data.len == 0) return .skip;
 
     if (std.mem.eql(u8, data, "[DONE]")) return .done;
 
@@ -829,6 +832,18 @@ test "parseSseLine valid delta" {
     }
 }
 
+test "parseSseLine valid delta without optional space" {
+    const allocator = std.testing.allocator;
+    const result = try parseSseLine(allocator, "data:{\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}");
+    switch (result) {
+        .delta => |text| {
+            defer allocator.free(text);
+            try std.testing.expectEqualStrings("Hello", text);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
 test "prepareCurlBodyArg uses temp file only on Windows" {
     const allocator = std.testing.allocator;
     const body = [_]u8{'x'} ** 4096;
@@ -846,6 +861,11 @@ test "prepareCurlBodyArg uses temp file only on Windows" {
 
 test "parseSseLine DONE sentinel" {
     const result = try parseSseLine(std.testing.allocator, "data: [DONE]");
+    try std.testing.expect(result == .done);
+}
+
+test "parseSseLine DONE sentinel without optional space" {
+    const result = try parseSseLine(std.testing.allocator, "data:[DONE]");
     try std.testing.expect(result == .done);
 }
 
@@ -869,6 +889,11 @@ test "parseSseLine empty line" {
 
 test "parseSseLine comment" {
     const result = try parseSseLine(std.testing.allocator, ":keep-alive");
+    try std.testing.expect(result == .skip);
+}
+
+test "parseSseLine empty data field" {
+    const result = try parseSseLine(std.testing.allocator, "data:");
     try std.testing.expect(result == .skip);
 }
 


### PR DESCRIPTION
The SSE parser has been updated to support both standard `data: ` and no-space `data:` prefixes, resolving a bug where content from providers like Kimi Code was silently skipped. By adding this fallback, the parser avoids producing empty responses when encountering compressed SSE formatting, ensuring that JSON chunks are correctly extracted even when the standard trailing space is missing.