### PR TITLE
chore: bump version to 2026.3.13

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .nullclaw,
-    .version = "2026.3.12",
+    .version = "2026.3.13",
     .fingerprint = 0xe73e13d1c95956c2,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{


### PR DESCRIPTION
## Summary
- Bump CalVer version from 2026.3.12 to 2026.3.13 in `build.zig.zon`