### PR TITLE
fix(cron): handle InvalidExe on macOS after in-place binary replacement

### DIFF
--- a/src/cron.zig
+++ b/src/cron.zig
@@ -1049,7 +1049,13 @@ fn runAgentJob(
         child.cwd = exec_cwd;
 
         child.spawn() catch |err| switch (err) {
-            error.FileNotFound => {
+            error.FileNotFound,
+            // On macOS the kernel returns ENOEXEC (InvalidExe) when the on-disk
+            // binary was replaced while the gateway was running (in-place rebuild
+            // or redeploy).  Treat it identically to FileNotFound so we fall
+            // through to the PATH-based fallback below.
+            error.InvalidExe,
+            => {
                 // If cwd disappeared, retry from process cwd.
                 if (exec_cwd != null and !tried_no_cwd) {
                     exec_cwd = null;


### PR DESCRIPTION
## Summary

- On macOS, spawning a cron agent subprocess from a binary path that was replaced on disk while the gateway is running returns \`ENOEXEC\` (\`error.InvalidExe\`) rather than \`ENOENT\` (\`error.FileNotFound\`).
- The existing fallback chain in \`runAgentJob\` only triggered on \`FileNotFound\`, so \`InvalidExe\` fell through to \`else => return err\` — causing every cron agent job to silently fail after any in-place redeploy until the gateway was manually restarted.
- Fix: add \`error.InvalidExe\` to the same match arm as \`error.FileNotFound\` so the existing fallback chain (no-cwd retry → Linux \`/proc/self/exe\` → PATH lookup) is attempted on both errors.

## Validation

```
zig build test --summary all
Build Summary: 7/9 steps succeeded; 1 failed; 5640/5645 tests passed; 4 skipped; 1 failed
```

The one failing test (`tools.http_request.test.execute rejects non-allowlisted domain`) is pre-existing on `main` and unrelated to this change (verified by running the same suite against upstream `main` — identical result).

`zig fmt --check src/cron.zig` passes cleanly.

Reproduced on macOS arm64 (Zig 0.15.2):
1. Start gateway
2. Rebuild and replace `zig-out/bin/nullclaw` in-place
3. Observe `error(cron): cron agent job '...' execution failed: InvalidExe` on every tick
4. Error absent with this patch applied

## Notes

- Change is confined to the error match arm in `runAgentJob` in `src/cron.zig` — no new state, no new allocations, no behavior change on Linux or Windows.
- Risk tier: low-medium (no security boundary, no vtable interface change).
- The same `ENOEXEC` condition can occur on Linux after a binary replacement in certain filesystems, so the fix is beneficial cross-platform.