### PR TITLE
fix(http_request): make redaction buffer ownership explicit / 修复(http_request): 明确脱敏缓冲区的内存所有权

### DIFF
--- a/src/tools/http_request.zig
+++ b/src/tools/http_request.zig
@@ -131,8 +131,8 @@ pub const HttpRequestTool = struct {
         const success = status_code >= 200 and status_code < 300;
 
         // Build redacted headers display for custom request headers
-        const redacted = redactHeadersForDisplay(allocator, custom_headers) catch "";
-        defer if (redacted.len > 0) allocator.free(redacted);
+        const redacted = redactHeadersForDisplay(allocator, custom_headers) catch try allocator.dupe(u8, "");
+        defer allocator.free(redacted);
 
         const output = if (redacted.len > 0)
             try std.fmt.allocPrint(
@@ -455,7 +455,7 @@ fn parseHeaders(allocator: std.mem.Allocator, headers_json: ?[]const u8) ![]cons
 /// Headers with names containing authorization, api-key, apikey, token, secret,
 /// or password (case-insensitive) get their values replaced with "***REDACTED***".
 fn redactHeadersForDisplay(allocator: std.mem.Allocator, headers: []const [2][]const u8) ![]const u8 {
-    if (headers.len == 0) return "";
+    if (headers.len == 0) return allocator.dupe(u8, "");
 
     var buf: std.ArrayList(u8) = .{};
     errdefer buf.deinit(allocator);
@@ -570,6 +570,7 @@ test "redactHeadersForDisplay redacts api-key and token" {
 
 test "redactHeadersForDisplay empty returns empty" {
     const result = try redactHeadersForDisplay(std.testing.allocator, &.{});
+    defer std.testing.allocator.free(result);
     try std.testing.expectEqualStrings("", result);
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a memory ownership inconsistency in the `redactHeadersForDisplay` function within `http_request.zig`. Previously, the function would return a static `""` literal in some paths while returning heap-allocated strings in others, leading to potential invalid free operations.

### Key Changes
- **Explicit Allocation**: Modified `redactHeadersForDisplay` to always return a heap-allocated string (using `allocator.dupe`) even for empty results.
- **Consistent Cleanup**: Updated the caller to always call `allocator.free()` on the result, ensuring consistent memory management and avoiding use-after-free or invalid free risks.
- **Test Updates**: Updated the unit tests for `redactHeadersForDisplay` to correctly handle the allocated return value.

## Validation

- `zig build test --summary all`: All tests in `src/tools/http_request.zig` pass with 0 leaks reported by the Zig test runner.
- Verified that the `http_request` tool no longer triggers memory errors when processing requests with empty or redacted headers.

## Notes
- Closes #521.

---

## 中文

### 摘要
本 PR 修复了 `http_request.zig` 中 `redactHeadersForDisplay` 函数的内存所有权不一致问题。此前，该函数在某些路径下返回静态字符串字面量 `""`，而在其他路径下返回堆分配的字符串，这可能导致无效的内存释放（free）操作。

### 主要改动
- **显式分配**: 修改了 `redactHeadersForDisplay`，使其始终返回堆分配的字符串（使用 `allocator.dupe`），即使结果为空。
- **一致的清理**: 更新了调用方，使其始终对结果调用 `allocator.free()`，从而确保内存管理的一致性，避免 Use-after-free 或无效释放的风险。
- **测试更新**: 更新了 `redactHeadersForDisplay` 的单元测试，以正确处理分配的返回值。

### 验证
- `zig build test --summary all`: `src/tools/http_request.zig` 中的所有测试均已通过，且 Zig 测试运行器报告 0 内存泄漏。
- 验证了 `http_request` 工具在处理带有空标头或脱敏标头的请求时，不再触发内存错误。

### 备注
- 关联并关闭 #521。
