### PR TITLE
feat(http_request): include curl stderr in failure diagnostics

### DIFF
--- a/src/tools/http_request.zig
+++ b/src/tools/http_request.zig
@@ -108,6 +108,9 @@ pub const HttpRequestTool = struct {
 
         const body: ?[]const u8 = root.getString(args, "body");
 
+        var curl_stderr: ?[]u8 = null;
+        defer if (curl_stderr) |s| allocator.free(s);
+
         const status_result = runCurlRequestWithStatus(
             allocator,
             methodToSlice(method),
@@ -117,12 +120,16 @@ pub const HttpRequestTool = struct {
             connect_host,
             custom_headers,
             body,
+            &curl_stderr,
             @intCast(self.max_response_size),
         ) catch |err| {
             if (err == error.CurlInterrupted) {
                 return ToolResult.fail("Interrupted by /stop");
             }
-            const msg = try std.fmt.allocPrint(allocator, "HTTP request failed: {}", .{err});
+            const msg = if (curl_stderr) |stderr_msg|
+                try std.fmt.allocPrint(allocator, "HTTP request failed: {}\ncurl stderr: {s}", .{ err, stderr_msg })
+            else
+                try std.fmt.allocPrint(allocator, "HTTP request failed: {}", .{err});
             return ToolResult{ .success = false, .output = "", .error_msg = msg };
         };
         defer allocator.free(status_result.body);
@@ -198,8 +205,11 @@ fn runCurlRequestWithStatus(
     connect_host: []const u8,
     headers: []const [2][]const u8,
     body: ?[]const u8,
+    stderr_out: ?*?[]u8,
     max_response_size: usize,
 ) !http_util.HttpResponse {
+    if (stderr_out) |out| out.* = null;
+
     var argv_buf: [64][]const u8 = undefined;
     var argc: usize = 0;
     const reserved_tail_args: usize = if (body != null) 5 else 3;
@@ -264,7 +274,7 @@ fn runCurlRequestWithStatus(
     var child = std.process.Child.init(argv_buf[0..argc], allocator);
     child.stdin_behavior = if (body != null) .Pipe else .Ignore;
     child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Ignore;
+    child.stderr_behavior = .Pipe;
 
     try child.spawn();
 
@@ -327,18 +337,51 @@ fn runCurlRequestWithStatus(
     };
     errdefer allocator.free(stdout);
 
+    const stderr_raw = if (child.stderr) |stderr_file|
+        stderr_file.readToEndAlloc(allocator, 16 * 1024) catch null
+    else
+        null;
+    defer if (stderr_raw) |buf| allocator.free(buf);
+
+    var stderr_copy: ?[]u8 = try duplicateTrimmedStderr(allocator, stderr_raw);
+    defer if (stderr_copy) |buf| allocator.free(buf);
+
     const term = child.wait() catch return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWaitError;
     switch (term) {
-        .Exited => |code| if (code != 0 and !(cancel_flag != null and cancel_flag.?.load(.acquire))) return error.CurlFailed,
+        .Exited => |code| if (code != 0 and !(cancel_flag != null and cancel_flag.?.load(.acquire))) {
+            if (stderr_out) |out| {
+                out.* = stderr_copy;
+                stderr_copy = null;
+            }
+            return error.CurlFailed;
+        },
         else => return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed,
     }
 
     if (cancel_flag != null and cancel_flag.?.load(.acquire)) return error.CurlInterrupted;
 
-    const status_sep = std.mem.lastIndexOfScalar(u8, stdout, '\n') orelse return error.CurlParseError;
+    const status_sep = std.mem.lastIndexOfScalar(u8, stdout, '\n') orelse {
+        if (stderr_out) |out| {
+            out.* = stderr_copy;
+            stderr_copy = null;
+        }
+        return error.CurlParseError;
+    };
     const status_raw = std.mem.trim(u8, stdout[status_sep + 1 ..], " \t\r\n");
-    if (status_raw.len != 3) return error.CurlParseError;
-    const status_code = std.fmt.parseInt(u16, status_raw, 10) catch return error.CurlParseError;
+    if (status_raw.len != 3) {
+        if (stderr_out) |out| {
+            out.* = stderr_copy;
+            stderr_copy = null;
+        }
+        return error.CurlParseError;
+    }
+    const status_code = std.fmt.parseInt(u16, status_raw, 10) catch {
+        if (stderr_out) |out| {
+            out.* = stderr_copy;
+            stderr_copy = null;
+        }
+        return error.CurlParseError;
+    };
     const body_slice = stdout[0..status_sep];
     const response_body = try allocator.dupe(u8, body_slice);
     allocator.free(stdout);
@@ -347,6 +390,14 @@ fn runCurlRequestWithStatus(
         .status_code = status_code,
         .body = response_body,
     };
+}
+
+fn duplicateTrimmedStderr(allocator: std.mem.Allocator, raw: ?[]const u8) !?[]u8 {
+    const bytes = raw orelse return null;
+    const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    const copied = try allocator.dupe(u8, trimmed);
+    return copied;
 }
 
 fn ensureTlsCaBundleLoaded(client: *std.http.Client) !void {
@@ -746,6 +797,17 @@ test "buildHttpRequestErrorMessage includes TLS hint" {
     const msg = try buildHttpRequestErrorMessage(std.testing.allocator, "HTTP request failed", error.TlsInitializationFailed);
     defer std.testing.allocator.free(msg);
     try std.testing.expect(std.mem.indexOf(u8, msg, "system CA certificates") != null);
+}
+
+test "duplicateTrimmedStderr trims non-empty stderr" {
+    const copied = (try duplicateTrimmedStderr(std.testing.allocator, "\n curl: (6) Could not resolve host \n")).?;
+    defer std.testing.allocator.free(copied);
+    try std.testing.expectEqualStrings("curl: (6) Could not resolve host", copied);
+}
+
+test "duplicateTrimmedStderr ignores empty stderr" {
+    try std.testing.expect((try duplicateTrimmedStderr(std.testing.allocator, "  \n\t  ")) == null);
+    try std.testing.expect((try duplicateTrimmedStderr(std.testing.allocator, null)) == null);
 }
 
 // ── parseHeaders tests ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Improves `HttpRequestTool` failure diagnostics by capturing curl stderr and surfacing it in tool error messages.

Closes #520.

## What’s Included

- Switched curl subprocess stderr from `.Ignore` to `.Pipe`.
- Captured and trimmed stderr output (up to 16 KB) for failed requests.
- Included stderr text in `ToolResult` error messages when available.
- Added focused unit tests for stderr trimming helper behavior.

## Why It Matters

Users can now see actionable root causes (TLS, DNS, connectivity errors) instead of only generic `CurlFailed` diagnostics.

## Verification

- `zig build test --summary all`
