### PR TITLE
fix(onboard): add yolo autonomy option to wizard

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -401,6 +401,7 @@ Tunnel providers for exposing the gateway to the public internet. Required for w
 ### `autonomy`
 
 - `level`: start with `supervised`.
+- `level = "yolo"`: bypasses command policy checks; use only for trusted local debugging.
 - `workspace_only`: keep `true` to limit file access scope.
 - `max_actions_per_hour`: keep conservative limits first.
 

--- a/docs/en/security.md
+++ b/docs/en/security.md
@@ -103,6 +103,7 @@ With the config above and `LD_LIBRARY_PATH=/opt/tools/usr/lib:/opt/tools/lib` se
 These settings significantly widen trust boundaries and should be used only in controlled environments:
 
 - `autonomy.level = "full"`
+- `autonomy.level = "yolo"`
 - `allowed_commands = ["*"]`
 - `allowed_paths = ["*"]`
 - `gateway.allow_public_bind = true`

--- a/src/export_manifest.zig
+++ b/src/export_manifest.zig
@@ -264,7 +264,7 @@ test "export_manifest produces valid structure" {
     try std.testing.expect(onboard.known_providers.len >= 29);
     try std.testing.expect(onboard.wizard_memory_backend_order.len == 10);
     try std.testing.expect(onboard.tunnel_options.len == 4);
-    try std.testing.expect(onboard.autonomy_options.len == 3);
+    try std.testing.expect(onboard.autonomy_options.len == 4);
     try std.testing.expect(channel_catalog.known_channels.len >= 20);
 
     // Verify first provider
@@ -272,4 +272,5 @@ test "export_manifest produces valid structure" {
 
     // Verify memory backends start with hybrid
     try std.testing.expectEqualStrings("hybrid", onboard.wizard_memory_backend_order[0]);
+    try std.testing.expectEqualStrings("yolo", onboard.autonomy_options[3]);
 }

--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -1089,7 +1089,7 @@ fn promptChoice(out: *std.Io.Writer, buf: []u8, max: usize, default_idx: usize) 
 }
 
 pub const tunnel_options = [_][]const u8{ "none", "cloudflare", "ngrok", "tailscale" };
-pub const autonomy_options = [_][]const u8{ "supervised", "autonomous", "fully_autonomous" };
+pub const autonomy_options = [_][]const u8{ "supervised", "autonomous", "fully_autonomous", "yolo" };
 pub const wizard_memory_backend_order = [_][]const u8{
     "hybrid",
     "sqlite",
@@ -2006,7 +2006,7 @@ pub fn runWizard(allocator: std.mem.Allocator) !void {
 
     // ── Step 6: Autonomy level ──
     try out.writeAll("  Step 6/8: Autonomy level\n");
-    try out.writeAll("    [1] supervised\n    [2] autonomous\n    [3] fully_autonomous\n");
+    try out.writeAll("    [1] supervised\n    [2] autonomous\n    [3] fully_autonomous\n    [4] yolo\n");
     try out.writeAll("  Choice [1]: ");
     const autonomy_idx = promptChoice(out, &input_buf, autonomy_options.len, 0) orelse {
         try out.writeAll("\n  Aborted.\n");
@@ -2028,6 +2028,12 @@ pub fn runWizard(allocator: std.mem.Allocator) !void {
         2 => {
             // "fully_autonomous": fully acts and does not hard-block high-risk commands.
             cfg.autonomy.level = .full;
+            cfg.autonomy.require_approval_for_medium_risk = false;
+            cfg.autonomy.block_high_risk_commands = false;
+        },
+        3 => {
+            // "yolo": bypasses all command-level policy checks.
+            cfg.autonomy.level = .yolo;
             cfg.autonomy.require_approval_for_medium_risk = false;
             cfg.autonomy.block_high_risk_commands = false;
         },
@@ -3740,11 +3746,12 @@ test "tunnel_options has 4 entries" {
     try std.testing.expectEqualStrings("tailscale", tunnel_options[3]);
 }
 
-test "autonomy_options has 3 entries" {
-    try std.testing.expect(autonomy_options.len == 3);
+test "autonomy_options has 4 entries" {
+    try std.testing.expect(autonomy_options.len == 4);
     try std.testing.expectEqualStrings("supervised", autonomy_options[0]);
     try std.testing.expectEqualStrings("autonomous", autonomy_options[1]);
     try std.testing.expectEqualStrings("fully_autonomous", autonomy_options[2]);
+    try std.testing.expectEqualStrings("yolo", autonomy_options[3]);
 }
 
 test "catalog_providers has entries" {
@@ -3795,10 +3802,11 @@ test "findChannelOptionIndex supports number and key" {
 test "wizard maps autonomy index to enum correctly" {
     // Verify the mapping used in runWizard
     const Config2 = @import("config.zig");
-    const mapping = [_]Config2.AutonomyLevel{ .supervised, .full, .full };
+    const mapping = [_]Config2.AutonomyLevel{ .supervised, .full, .full, .yolo };
     try std.testing.expect(mapping[0] == .supervised);
     try std.testing.expect(mapping[1] == .full);
     try std.testing.expect(mapping[2] == .full);
+    try std.testing.expect(mapping[3] == .yolo);
 }
 
 // ── New template tests ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds missing `yolo` autonomy option to onboarding and aligns docs/tests with the effective runtime autonomy model.

Closes #493.

## What’s Included

- Added `yolo` to onboarding autonomy choices (Step 6/8) and to `autonomy_options`.
- Mapped onboarding choice `[4] yolo` to `cfg.autonomy.level = .yolo`.
- Updated onboarding/unit mapping tests and export manifest test expectations for 4 autonomy options.
- Updated security/configuration docs to explicitly document `autonomy.level = "yolo"` as high-risk.

## Why It Matters

Rerunning onboarding no longer forces users away from `yolo`, and docs now match actual supported autonomy levels. This removes a configuration footgun and reduces user confusion.

## Verification

- `zig build test --summary all`
