### PR TITLE
fix(agent): robustify tool-call parsing for malformed LLM outputs / 修复(agent): 增强对格式错误 LLM 输出的工具调用解析

### DIFF
--- a/src/agent/dispatcher.zig
+++ b/src/agent/dispatcher.zig
@@ -1153,6 +1153,7 @@ fn parseInvokeTagCall(allocator: std.mem.Allocator, inner: []const u8) !ParsedTo
     const name_end = std.mem.indexOfScalar(u8, after_prefix[1..], name_quote) orelse return error.InvalidInvokeFormat;
     const tool_name = std.mem.trim(u8, after_prefix[1 .. name_end + 1], " \t\r\n");
     if (tool_name.len == 0) return error.EmptyToolName;
+    if (!isPlausibleToolName(tool_name)) return error.InvalidToolName;
 
     const invoke_close_tag = "</invoke>";
     // Look for the '>' that closes the <invoke ...> tag.
@@ -2828,6 +2829,29 @@ test "parseXmlToolCalls minimax format robustness" {
     try std.testing.expectEqual(@as(usize, 1), result.calls.len);
     try std.testing.expectEqualStrings("shell", result.calls[0].name);
     try std.testing.expect(std.mem.indexOf(u8, result.calls[0].arguments_json, "ls -la") != null);
+}
+
+test "parseXmlToolCalls rejects invalid minimax tool name" {
+    const allocator = std.testing.allocator;
+    const response =
+        \\<tool_call>
+        \\<invoke name=":">
+        \\<parameter name="command">ls</parameter>
+        \\</invoke>
+        \\</tool_call>
+    ;
+
+    const result = try parseToolCalls(allocator, response);
+    defer {
+        allocator.free(result.text);
+        for (result.calls) |call| {
+            allocator.free(call.name);
+            allocator.free(call.arguments_json);
+        }
+        allocator.free(result.calls);
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), result.calls.len);
 }
 
 test "parseXmlToolCalls hybrid format" {


### PR DESCRIPTION
## Summary
This PR robustifies tool-call parsing to handle various malformed JSON and XML formats often emitted by creative or non-deterministic LLMs. It specifically addresses issues where colons are incorrectly extracted as part of the tool name or when JSON-like structures are nested within the name field.

### Key Changes
- **Strict Name Validation**: Implemented `isPlausibleToolName` to reject obviously invalid tool names (e.g., a single colon, names with spaces, or JSON snippets).
- **Enhanced JSON Recovery**: 
    - Updated `repairMalformedParsedToolName` and `salvageMalformedToolCallJson` to correctly handle \"quoted-colon\" malformations (e.g., `{\"name\": \": memory_recall\"...}`).
    - Added a \"fail closed\" mechanism for implausible names, making one last attempt to salvage the payload before rejecting it.
- **Hybrid Parser Hardening**: Updated `parseHybridTagCall` to enforce strict tool name rules, preventing malformed tags from triggering incorrect tool lookups.
- **Regression Tests**: Added several new test cases in `src/agent/dispatcher.zig` covering:
    - Recovering from quoted-colon malformations.
    - Rejecting literal colon tool names.
    - Rejecting unrelated invalid tool names.
    - Handling JSON-like structures incorrectly placed in the name field.

## Validation
- `zig build test --summary all`: All new regression tests pass, and existing dispatcher tests remain green.
- Verified that common parsing failures seen with models like GLM-4 or MiniMax are now gracefully handled or correctly rejected.

## Notes
- Closes #407, #408.

---

## 中文

### 摘要
本 PR 增强了工具调用（tool-call）解析的鲁棒性，以处理由于 LLM 的非确定性而产生的各种格式错误的 JSON 和 XML。它特别解决了冒号被错误地提取为工具名称的一部分，或者在名称字段中嵌套了类似 JSON 结构的问题。

### 主要改动
- **严格的名称验证**: 实现了 `isPlausibleToolName`，用于拒绝明显无效的工具名称（例如：单个冒号、包含空格的名称或 JSON 片段）。
- **增强的 JSON 恢复**:
    - 更新了 `repairMalformedParsedToolName` 和 `salvageMalformedToolCallJson`，以正确处理“引号冒号”格式错误（例如：`{\"name\": \": memory_recall\"...}`）。
    - 为不可信的名称增加了“失败闭合 (fail closed)”机制，在拒绝前最后尝试挽救负载数据。
- **混合解析器加固**: 更新了 `parseHybridTagCall` 以执行严格的工具名称规则，防止错误的标签触发错误的工具查找。
- **回归测试**: 在 `src/agent/dispatcher.zig` 中新增了多个测试用例，涵盖：
    - 从引号冒号错误中恢复。
    - 拒绝字面量冒号工具名。
    - 拒绝无关的无效工具名。
    - 处理错误放置在名称字段中的类 JSON 结构。

### 验证
- `zig build test --summary all`: 所有新增的回归测试均已通过，且现有的调度器测试保持正常。
- 验证了在使用 GLM-4 或 MiniMax 等模型时常见的解析失败现在能够得到优雅处理或被正确拒绝。

### 备注
- 关联并关闭 #407, #408。
