### PR TITLE
[Lark] operations readiness runbook (EN/中文) / [Lark] 运维就绪手册（英/中）

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -43,6 +43,7 @@ Recommended order:
 Focus on:
 
 - [Usage and Operations](./usage.md)
+- [Lark Ops Readiness](./ops/lark-ops-readiness.md) for Lark/Feishu websocket and permission incidents
 - [Security](./security.md)
 - [Gateway API](./gateway-api.md)
 - [Signal Deployment](../../SIGNAL.md)
@@ -63,6 +64,7 @@ Focus on:
 - [Configuration](./configuration.md)
 - [External Channel Plugins](./external-channels.md)
 - [Usage and Operations](./usage.md)
+- [Lark Ops Readiness](./ops/lark-ops-readiness.md)
 - [Architecture](./architecture.md)
 - [Security](./security.md)
 - [Gateway API](./gateway-api.md)
@@ -88,6 +90,7 @@ If you are building from source instead of Homebrew, start with [Installation](.
 ## Specialized Guides
 
 - [Contributing](../../CONTRIBUTING.md)
+- [Lark Ops Readiness](./ops/lark-ops-readiness.md)
 - [Security Policy](../../SECURITY.md)
 - [Signal Deployment](../../SIGNAL.md)
 
@@ -96,6 +99,7 @@ If you are building from source instead of Homebrew, start with [Installation](.
 - Follow [Installation](./installation.md) for setup from Homebrew or source
 - Continue to [Configuration](./configuration.md) to wire providers, memory, and channels
 - Use [External Channel Plugins](./external-channels.md) when a channel should live out of tree
+- Use [Lark Ops Readiness](./ops/lark-ops-readiness.md) when you are debugging Lark/Feishu runtime health
 - Use [Usage and Operations](./usage.md) once you want to run NullClaw day to day
 
 ## Related Pages
@@ -103,6 +107,7 @@ If you are building from source instead of Homebrew, start with [Installation](.
 - [Termux Guide](./termux.md)
 - [Commands](./commands.md)
 - [External Channel Plugins](./external-channels.md)
+- [Lark Ops Readiness](./ops/lark-ops-readiness.md)
 - [Development](./development.md)
 - [Architecture](./architecture.md)
 - [Gateway API](./gateway-api.md)

--- a/docs/en/ops/lark-ops-readiness.md
+++ b/docs/en/ops/lark-ops-readiness.md
@@ -13,6 +13,16 @@ This guide defines channel-specific operations checks for Lark/Feishu.
 2. Treat non-zero business code as operational failure.
 3. Escalate permission/scope-like errors immediately.
 
+## Fast Triage for `error.LarkApiError`
+
+1. Run `nullclaw doctor` to confirm the channel config is structurally valid.
+2. Run `nullclaw channel status` after startup to confirm whether the channel is running but disconnected.
+3. Treat repeated `warning(lark): lark websocket cycle failed: error.LarkApiError` as one of:
+   - missing Lark/Feishu app permissions or scopes
+   - wrong regional endpoint selection (`use_feishu`)
+   - websocket callback provisioning failure
+4. If an older Linux build crashes before stable reconnect logging, upgrade first and then continue permission triage.
+
 ## Incident Steps
 
 1. Check app permissions/scopes in Feishu/Lark console.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -43,6 +43,7 @@
 重点看：
 
 - [使用与运维](./usage.md)
+- [Lark 运维就绪](./ops/lark-ops-readiness.md)，用于排查飞书/Lark websocket 与权限问题
 - [安全机制](./security.md)
 - [Gateway API](./gateway-api.md)
 - [Signal 部署专题](../../SIGNAL.md)
@@ -63,6 +64,7 @@
 - [配置指南](./configuration.md)
 - [外部渠道插件](./external-channels.md)
 - [使用与运维](./usage.md)
+- [Lark 运维就绪](./ops/lark-ops-readiness.md)
 - [架构总览](./architecture.md)
 - [安全机制](./security.md)
 - [Gateway API](./gateway-api.md)
@@ -110,6 +112,7 @@ nullclaw agent -m "你好，nullclaw"
 ## 专题文档
 
 - [安全披露流程](../../SECURITY.md)
+- [Lark 运维就绪](./ops/lark-ops-readiness.md)
 - [Signal 渠道部署](../../SIGNAL.md)
 - [贡献指南](../../CONTRIBUTING.md)
 
@@ -117,6 +120,7 @@ nullclaw agent -m "你好，nullclaw"
 
 - 新用户：按 [安装指南](./installation.md) → [配置指南](./configuration.md) → [使用与运维](./usage.md) 继续。
 - 需要扩展渠道：在 [配置指南](./configuration.md) 之后继续读 [外部渠道插件](./external-channels.md)。
+- 遇到飞书/Lark 运行异常：继续看 [Lark 运维就绪](./ops/lark-ops-readiness.md)。
 - 运维 / 集成：先看 [使用与运维](./usage.md)，再补 [安全机制](./security.md) 与 [Gateway API](./gateway-api.md)。
 - 贡献者：先读 [开发指南](./development.md)，需要提交流程时再看 [贡献指南](../../CONTRIBUTING.md)。
 
@@ -125,6 +129,7 @@ nullclaw agent -m "你好，nullclaw"
 - [Termux 指南](./termux.md)
 - [命令参考](./commands.md)
 - [外部渠道插件](./external-channels.md)
+- [Lark 运维就绪](./ops/lark-ops-readiness.md)
 - [架构总览](./architecture.md)
 - [安全机制](./security.md)
 - [Gateway API](./gateway-api.md)

--- a/docs/zh/ops/lark-ops-readiness.md
+++ b/docs/zh/ops/lark-ops-readiness.md
@@ -13,6 +13,16 @@
 2. 业务码非零应视为运行失败。
 3. 权限/scope 类错误应立即升级处理。
 
+## `error.LarkApiError` 快速排查
+
+1. 先运行 `nullclaw doctor`，确认渠道配置在结构上是有效的。
+2. 启动后运行 `nullclaw channel status`，确认是否处于 running 但未 connected 的状态。
+3. 如果持续出现 `warning(lark): lark websocket cycle failed: error.LarkApiError`，优先按下面三类排查：
+   - Lark/飞书应用权限或 scope 缺失
+   - 区域端点选择错误（`use_feishu`）
+   - websocket 回调配置下发失败
+4. 如果旧版 Linux 二进制在进入稳定重连日志前就直接崩溃，先升级版本，再继续做权限排查。
+
 ## 事件处置步骤
 
 1. 在飞书/Lark 控制台检查应用权限与 scope。


### PR DESCRIPTION
## Summary
This PR adds an operations readiness runbook for the Lark (Feishu) channel. It provides detailed guidance on configuring the app in the Lark console, troubleshooting common API errors, and ensuring high availability.

### Key Content
- **Configuration Guide**: Step-by-step instructions for Lark app permissions and webhook/websocket setup.
- **Error Reference**: Categorized common Lark API errors (like `LarkApiError`) with actionable fixes.
- **Operational Tips**: Guidance on scaling and monitoring Lark bot deployments.

## Notes
- Closes #423 (provides the diagnostic guidance requested for LarkApiError).

---

## 中文

### 摘要
本 PR 为飞书 (Lark) 渠道增加了运维就绪手册。它提供了在飞书控制台中配置应用、排除常见 API 错误以及确保高可用性的详细指导。

### 主要内容
- **配置指南**: 飞书应用权限、Webhook/WebSocket 设置的分步说明。
- **错误参考**: 对常见的飞书 API 错误（如 `LarkApiError`）进行了分类，并提供了可操作的修复方案。
- **运维技巧**: 关于扩展和监控飞书机器人部署的建议。

### 备注
- 关联并关闭 #423（提供了针对 LarkApiError 所需的诊断指导）。