### PR TITLE
fix(web): make websocket handshake size configurable

### DIFF
--- a/src/channels/web.zig
+++ b/src/channels/web.zig
@@ -64,6 +64,7 @@ pub const WebChannel = struct {
     listen_address: []const u8,
     ws_path: []const u8,
     max_connections: u16,
+    max_handshake_size: u16,
     account_id: []const u8,
     configured_auth_token: ?[]const u8,
     allowed_origins: []const []const u8,
@@ -127,6 +128,10 @@ pub const WebChannel = struct {
         else
             cfg.max_connections;
         const normalized_path = config_types.WebConfig.normalizePath(cfg.path);
+        const normalized_max_handshake_size: u16 = if (cfg.max_handshake_size == 0)
+            config_types.WebConfig.DEFAULT_MAX_HANDSHAKE_SIZE
+        else
+            cfg.max_handshake_size;
         return .{
             .allocator = allocator,
             .transport = parseTransport(cfg.transport),
@@ -134,6 +139,7 @@ pub const WebChannel = struct {
             .listen_address = cfg.listen,
             .ws_path = normalized_path,
             .max_connections = clamped_max_connections,
+            .max_handshake_size = normalized_max_handshake_size,
             .account_id = cfg.account_id,
             .configured_auth_token = cfg.auth_token,
             .allowed_origins = cfg.allowed_origins,
@@ -1027,6 +1033,9 @@ pub const WebChannel = struct {
             .port = self.port,
             .address = self.listen_address,
             .max_conn = @intCast(self.max_connections),
+            .handshake = .{
+                .max_size = self.max_handshake_size,
+            },
         }) catch |err| {
             log.err("Failed to init WebSocket server: {}", .{err});
             return err;
@@ -1807,6 +1816,7 @@ test "WebChannel initFromConfig uses defaults" {
     try std.testing.expectEqualStrings("127.0.0.1", ch.listen_address);
     try std.testing.expectEqualStrings(config_types.WebConfig.DEFAULT_PATH, ch.ws_path);
     try std.testing.expectEqual(@as(u16, 10), ch.max_connections);
+    try std.testing.expectEqual(config_types.WebConfig.DEFAULT_MAX_HANDSHAKE_SIZE, ch.max_handshake_size);
     try std.testing.expectEqualStrings("default", ch.account_id);
     try std.testing.expect(ch.configured_auth_token == null);
     try std.testing.expectEqual(@as(usize, 0), ch.allowed_origins.len);
@@ -1828,6 +1838,7 @@ test "WebChannel initFromConfig uses custom values" {
         .listen = "0.0.0.0",
         .path = "/relay/",
         .max_connections = 5,
+        .max_handshake_size = 12_288,
         .account_id = "web-main",
         .auth_token = "test-token-123456",
         .message_auth_mode = "token",
@@ -1837,6 +1848,7 @@ test "WebChannel initFromConfig uses custom values" {
     try std.testing.expectEqualStrings("0.0.0.0", ch.listen_address);
     try std.testing.expectEqualStrings("/relay", ch.ws_path);
     try std.testing.expectEqual(@as(u16, 5), ch.max_connections);
+    try std.testing.expectEqual(@as(u16, 12_288), ch.max_handshake_size);
     try std.testing.expectEqualStrings("web-main", ch.account_id);
     try std.testing.expectEqualStrings("test-token-123456", ch.configured_auth_token.?);
     try std.testing.expectEqual(WebChannel.MessageAuthMode.token, ch.message_auth_mode);
@@ -1891,6 +1903,13 @@ test "WebChannel initFromConfig clamps max_connections to tracked limit" {
         .max_connections = 500,
     });
     try std.testing.expectEqual(@as(u16, 64), ch.max_connections);
+}
+
+test "WebChannel initFromConfig normalizes zero handshake size to default" {
+    const ch = WebChannel.initFromConfig(std.testing.allocator, .{
+        .max_handshake_size = 0,
+    });
+    try std.testing.expectEqual(config_types.WebConfig.DEFAULT_MAX_HANDSHAKE_SIZE, ch.max_handshake_size);
 }
 
 test "WebChannel vtable name returns web" {

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -545,6 +545,7 @@ pub const WebConfig = struct {
     pub const DEFAULT_PATH: []const u8 = "/ws";
     pub const DEFAULT_TRANSPORT: []const u8 = "local";
     pub const DEFAULT_MESSAGE_AUTH_MODE: []const u8 = "pairing";
+    pub const DEFAULT_MAX_HANDSHAKE_SIZE: u16 = 8_192;
     pub const MIN_AUTH_TOKEN_LEN: usize = 16;
     pub const MAX_AUTH_TOKEN_LEN: usize = 128;
     pub const MAX_RELAY_AGENT_ID_LEN: usize = 64;
@@ -563,6 +564,9 @@ pub const WebConfig = struct {
     listen: []const u8 = "127.0.0.1",
     path: []const u8 = DEFAULT_PATH,
     max_connections: u16 = 10,
+    /// Max bytes allowed for the HTTP upgrade request headers during WS handshake.
+    /// Increase this when running behind reverse proxies that append many headers.
+    max_handshake_size: u16 = DEFAULT_MAX_HANDSHAKE_SIZE,
     /// Optional WebSocket-upgrade auth token for browser/extension clients.
     /// Used for WebSocket-upgrade hardening and for `message_auth_mode="token"`.
     /// If null, WebChannel falls back to env (NULLCLAW_WEB_TOKEN/NULLCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_TOKEN),
@@ -1464,6 +1468,7 @@ test "WebConfig defaults" {
     try std.testing.expectEqualStrings("127.0.0.1", cfg.listen);
     try std.testing.expectEqualStrings(WebConfig.DEFAULT_PATH, cfg.path);
     try std.testing.expectEqual(@as(u16, 10), cfg.max_connections);
+    try std.testing.expectEqual(WebConfig.DEFAULT_MAX_HANDSHAKE_SIZE, cfg.max_handshake_size);
     try std.testing.expect(cfg.auth_token == null);
     try std.testing.expectEqualStrings(WebConfig.DEFAULT_MESSAGE_AUTH_MODE, cfg.message_auth_mode);
     try std.testing.expectEqual(@as(usize, 0), cfg.allowed_origins.len);


### PR DESCRIPTION
## Summary
- Add channels.web.max_handshake_size (default 8192) to configure maximum WebSocket upgrade handshake request size.
- Wire channels.web.max_handshake_size into websocket server handshake.max_size.
- Add WebConfig/WebChannel tests for defaults, custom value, and zero->default normalization.

## Validation
- zig build test --summary all

## Notes
- closes #565
- This PR is scoped to issue #565 only.

## 摘要
- 新增 channels.web.max_handshake_size 配置（默认 8192），用于控制 WebSocket 升级握手请求最大大小。
- 将该配置传递到 websocket 服务器 handshake.max_size。
- 补充 WebConfig/WebChannel 的默认值、自定义值与 0 归一化测试。

## 验证
- zig build test --summary all

## 备注
- 本 PR 仅覆盖 issue #565。

