### PR TITLE
fix(agent): enable empty-response retry and follow-through guardrail in streaming

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -7762,6 +7762,10 @@ test "Agent shouldForceActionFollowThrough detects english deferred promise" {
     try std.testing.expect(Agent.shouldForceActionFollowThrough("I will fetch the file now"));
     try std.testing.expect(Agent.shouldForceActionFollowThrough("Let me search for that"));
     try std.testing.expect(Agent.shouldForceActionFollowThrough("I'll run the tool now"));
+    // Regression: "let me get/fetch/find" must be caught (was the exact failure mode with vikunja-mcp)
+    try std.testing.expect(Agent.shouldForceActionFollowThrough("Found the Workstream Board (project ID 4). Let me get the Kanban columns (buckets) for it."));
+    try std.testing.expect(Agent.shouldForceActionFollowThrough("Let me fetch the list of projects."));
+    try std.testing.expect(Agent.shouldForceActionFollowThrough("Let me look up the tasks now."));
 }
 
 test "Agent shouldForceActionFollowThrough ignores conclusory english statements" {


### PR DESCRIPTION
## Summary

- Two guardrails in the agent loop were gated on `!is_streaming`:
  1. The empty-response retry (re-prompts the model when it returns blank text).
  2. `shouldForceActionFollowThrough` (detects deferred promises like "Let me list…" with no accompanying tool call and forces a follow-up iteration).
- The A2A protocol always calls `processMessageStreaming`, so `is_streaming = true` for all A2A sessions. Both guardrails silently did nothing, causing the agent to return deferred-promise text as its final answer instead of executing the implied tool call.
- Additionally, `shouldForceActionFollowThrough` only matched ~5 specific verbs (`try`, `check`, `retry`, `attempt`, `do that now`). Common phrases like "Let me list the contents…" or "I'll look into that" were not detected.

## Changes

- Remove `!is_streaming` guard from the empty-response retry block.
- Remove `!is_streaming` guard from the `shouldForceActionFollowThrough` block (with an explanatory comment that the follow-up iteration streams its own chunks independently).
- Expand `shouldForceActionFollowThrough` from ~5 to ~25 action verbs: `look`, `see`, `verify`, `fetch`, `get`, `retrieve`, `list`, `show`, `find`, `search`, `read`, `open`, `load`, `run`, `execute`, `call`, `use` (plus originals). Each verb is matched only in specific `i'll <verb>` / `i will <verb>` / `let me <verb>` phrases to prevent false-positives on conclusory statements like "Let me know if…" or "I'll note that…".

## Validation

```
zig build test --summary all
# 5719/5723 passed, 4 skipped (pre-existing), 0 leaks
```

`zig fmt --check src/agent/root.zig` — clean.

9 new unit tests added:
- 5 positive: `Let me list…`, `I'll look…`, `I will fetch…`, `Let me search…`, `I'll run…`
- 4 negative: `Let me know if…`, `I'll note that…`, `I will summarize…`, `I cannot do that…`

## Notes

- The two guardrail removals are independent of each other but are submitted together because both stem from the same root cause (`!is_streaming` gating).
- No behavioral change for non-streaming (CLI/Mattermost) sessions — both guardrails were already active there.