### PR TITLE
fix(config): encrypt persisted api keys in config.json

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const platform = @import("platform.zig");
 const provider_names = @import("provider_names.zig");
+const secrets = @import("security/secrets.zig");
 pub const config_types = @import("config_types.zig");
 pub const config_parse = @import("config_parse.zig");
 /// Write a JSON-escaped string (with enclosing quotes) to any writer.
@@ -110,6 +111,15 @@ const SerializedNamedAgentConfig = struct {
     api_key: ?[]const u8 = null,
     temperature: ?f64 = null,
     max_depth: u32 = 3,
+};
+
+const SerializedModelRouteConfig = struct {
+    hint: []const u8,
+    provider: []const u8,
+    model: []const u8,
+    api_key: ?[]const u8 = null,
+    cost_class: config_types.ModelRouteCostClass = .standard,
+    quota_class: config_types.ModelRouteQuotaClass = .normal,
 };
 
 fn freeNamedAgentSlice(allocator: std.mem.Allocator, agents: []const NamedAgentConfig) void {
@@ -412,6 +422,39 @@ pub const Config = struct {
         }
     }
 
+    fn secretStore(self: *const Config) secrets.SecretStore {
+        const config_dir = std.fs.path.dirname(self.config_path) orelse ".";
+        return secrets.SecretStore.init(config_dir, self.secrets.encrypt);
+    }
+
+    fn encryptConfigSecret(
+        self: *const Config,
+        store: *const secrets.SecretStore,
+        value: ?[]const u8,
+    ) !?[]u8 {
+        const secret = value orelse return null;
+        return try store.encryptSecret(self.allocator, secret);
+    }
+
+    fn encryptConfigSecretArray(
+        self: *const Config,
+        store: *const secrets.SecretStore,
+        values: []const []const u8,
+    ) ![][]const u8 {
+        var encrypted = try self.allocator.alloc([]const u8, values.len);
+        var count: usize = 0;
+        errdefer {
+            for (encrypted[0..count]) |value| self.allocator.free(value);
+            self.allocator.free(encrypted);
+        }
+
+        for (values, 0..) |value, i| {
+            encrypted[i] = try store.encryptSecret(self.allocator, value);
+            count += 1;
+        }
+        return encrypted;
+    }
+
     fn writeIndentedMultilineJson(w: *std.Io.Writer, json: []const u8, continuation_indent: []const u8) !void {
         var start: usize = 0;
         while (start < json.len) {
@@ -616,7 +659,7 @@ pub const Config = struct {
         try w.print("]", .{});
     }
 
-    fn writeReliabilitySection(self: *const Config, w: *std.Io.Writer) !void {
+    fn writeReliabilitySection(self: *const Config, w: *std.Io.Writer, store: *const secrets.SecretStore) !void {
         try w.print("  \"reliability\": {{\n", .{});
         try w.print("    \"provider_retries\": {d},\n", .{self.reliability.provider_retries});
         try w.print("    \"provider_backoff_ms\": {d},\n", .{self.reliability.provider_backoff_ms});
@@ -630,7 +673,12 @@ pub const Config = struct {
         try w.print(",\n", .{});
 
         try w.print("    \"api_keys\": ", .{});
-        try writeStringArray(w, self.reliability.api_keys);
+        const encrypted_api_keys = try self.encryptConfigSecretArray(store, self.reliability.api_keys);
+        defer {
+            for (encrypted_api_keys) |value| self.allocator.free(value);
+            self.allocator.free(encrypted_api_keys);
+        }
+        try writeStringArray(w, encrypted_api_keys);
         try w.print(",\n", .{});
 
         try w.print("    \"model_fallbacks\": [", .{});
@@ -757,6 +805,7 @@ pub const Config = struct {
     /// Save config as JSON to the config_path.
     pub fn save(self: *const Config) !void {
         const dir = std.fs.path.dirname(self.config_path) orelse return error.InvalidConfigPath;
+        const store = self.secretStore();
 
         // Ensure parent directory exists
         std.fs.makeDirAbsolute(dir) catch |err| switch (err) {
@@ -796,8 +845,10 @@ pub const Config = struct {
                 try w.print("      \"{s}\": {{", .{entry.name});
                 var has_field = false;
                 if (entry.api_key) |key| {
+                    const encrypted_key = try self.encryptConfigSecret(&store, key);
+                    defer if (encrypted_key) |value| self.allocator.free(value);
                     try w.print("\"api_key\": ", .{});
-                    try writePrettyJsonInline(self.allocator, w, key, "");
+                    try writePrettyJsonInline(self.allocator, w, encrypted_key.?, "");
                     has_field = true;
                 }
                 if (entry.base_url) |base| {
@@ -829,7 +880,32 @@ pub const Config = struct {
         }
 
         if (self.model_routes.len > 0) {
-            try w.print("  \"model_routes\": {f},\n", .{std.json.fmt(self.model_routes, .{})});
+            const serialized_routes = try self.allocator.alloc(SerializedModelRouteConfig, self.model_routes.len);
+            defer self.allocator.free(serialized_routes);
+            var route_count: usize = 0;
+            errdefer {
+                for (serialized_routes[0..route_count]) |route| {
+                    if (route.api_key) |value| self.allocator.free(value);
+                }
+            }
+            for (self.model_routes, 0..) |route, i| {
+                const encrypted_key = try self.encryptConfigSecret(&store, route.api_key);
+                serialized_routes[i] = .{
+                    .hint = route.hint,
+                    .provider = route.provider,
+                    .model = route.model,
+                    .api_key = encrypted_key,
+                    .cost_class = route.cost_class,
+                    .quota_class = route.quota_class,
+                };
+                route_count += 1;
+            }
+            defer {
+                for (serialized_routes) |route| {
+                    if (route.api_key) |value| self.allocator.free(value);
+                }
+            }
+            try w.print("  \"model_routes\": {f},\n", .{std.json.fmt(serialized_routes, .{})});
         }
 
         // agents.defaults (model + heartbeat) + agents.list
@@ -869,17 +945,30 @@ pub const Config = struct {
                 if (has_agents) {
                     const serialized_agents = try self.allocator.alloc(SerializedNamedAgentConfig, self.agents.len);
                     defer self.allocator.free(serialized_agents);
+                    var agent_count: usize = 0;
+                    errdefer {
+                        for (serialized_agents[0..agent_count]) |agent_cfg| {
+                            if (agent_cfg.api_key) |value| self.allocator.free(value);
+                        }
+                    }
                     for (self.agents, 0..) |agent_cfg, i| {
+                        const encrypted_key = try self.encryptConfigSecret(&store, agent_cfg.api_key);
                         serialized_agents[i] = .{
                             .name = agent_cfg.name,
                             .provider = agent_cfg.provider,
                             .model = agent_cfg.model,
                             .system_prompt = agent_cfg.system_prompt_path orelse agent_cfg.system_prompt,
                             .workspace_path = agent_cfg.workspace_path,
-                            .api_key = agent_cfg.api_key,
+                            .api_key = encrypted_key,
                             .temperature = agent_cfg.temperature,
                             .max_depth = agent_cfg.max_depth,
                         };
+                        agent_count += 1;
+                    }
+                    defer {
+                        for (serialized_agents) |agent_cfg| {
+                            if (agent_cfg.api_key) |value| self.allocator.free(value);
+                        }
                     }
                     if (wrote_agent_field) {
                         try w.print(",\n", .{});
@@ -953,7 +1042,7 @@ pub const Config = struct {
         }, .{})});
 
         // Reliability
-        try self.writeReliabilitySection(w);
+        try self.writeReliabilitySection(w, &store);
         try w.print("  \"scheduler\": {f},\n", .{std.json.fmt(self.scheduler, .{})});
         try w.print("  \"agent\": {f},\n", .{std.json.fmt(.{
             .compact_context = self.agent.compact_context,
@@ -974,11 +1063,33 @@ pub const Config = struct {
         // Channels
         try self.writeChannelsSection(w);
 
-        try w.print("  \"memory\": {f},\n", .{std.json.fmt(self.memory, .{})});
+        var serialized_memory = self.memory;
+        if (serialized_memory.search.store.qdrant_api_key.len > 0) {
+            serialized_memory.search.store.qdrant_api_key = try store.encryptSecret(self.allocator, serialized_memory.search.store.qdrant_api_key);
+        }
+        defer if (serialized_memory.search.store.qdrant_api_key.ptr != self.memory.search.store.qdrant_api_key.ptr) {
+            self.allocator.free(serialized_memory.search.store.qdrant_api_key);
+        };
+        if (serialized_memory.api.api_key.len > 0) {
+            serialized_memory.api.api_key = try store.encryptSecret(self.allocator, serialized_memory.api.api_key);
+        }
+        defer if (serialized_memory.api.api_key.ptr != self.memory.api.api_key.ptr) {
+            self.allocator.free(serialized_memory.api.api_key);
+        };
+        try w.print("  \"memory\": {f},\n", .{std.json.fmt(serialized_memory, .{})});
         try w.print("  \"gateway\": {f},\n", .{std.json.fmt(self.gateway, .{})});
         try w.print("  \"a2a\": {f},\n", .{std.json.fmt(self.a2a, .{})});
         try w.print("  \"tunnel\": {f},\n", .{std.json.fmt(self.tunnel, .{})});
-        try w.print("  \"composio\": {f},\n", .{std.json.fmt(self.composio, .{})});
+        var serialized_composio = self.composio;
+        if (serialized_composio.api_key) |api_key| {
+            serialized_composio.api_key = try store.encryptSecret(self.allocator, api_key);
+        }
+        defer if (serialized_composio.api_key) |api_key| {
+            if (self.composio.api_key == null or api_key.ptr != self.composio.api_key.?.ptr) {
+                self.allocator.free(api_key);
+            }
+        };
+        try w.print("  \"composio\": {f},\n", .{std.json.fmt(serialized_composio, .{})});
         try w.print("  \"secrets\": {f},\n", .{std.json.fmt(self.secrets, .{})});
         try w.print("  \"browser\": {f},\n", .{std.json.fmt(.{
             .enabled = self.browser.enabled,
@@ -4345,6 +4456,7 @@ test "save escapes provider string fields" {
         .config_path = config_path,
         .allocator = allocator,
     };
+    cfg.secrets.encrypt = false;
     cfg.providers = &.{
         .{
             .name = "openai",
@@ -4371,6 +4483,89 @@ test "save escapes provider string fields" {
     try std.testing.expectEqualStrings("sk-\"quoted\"", openai.get("api_key").?.string);
     try std.testing.expectEqualStrings("https://api.example.com/v1/\"quoted\"", openai.get("base_url").?.string);
     try std.testing.expectEqualStrings("nullclaw \"agent\"", openai.get("user_agent").?.string);
+}
+
+test "save encrypts persisted api keys and parse decrypts them" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.json", .{base});
+    defer allocator.free(config_path);
+
+    var cfg = Config{
+        .workspace_dir = base,
+        .config_path = config_path,
+        .allocator = allocator,
+    };
+    cfg.providers = &.{
+        .{
+            .name = "openrouter",
+            .api_key = "sk-or-secret",
+        },
+    };
+    cfg.reliability.api_keys = &.{ "rel-key-a", "rel-key-b" };
+    cfg.model_routes = &.{
+        .{
+            .hint = "fast",
+            .provider = "groq",
+            .model = "llama-3.3-70b",
+            .api_key = "gsk-secret",
+        },
+    };
+    cfg.agents = &.{
+        .{
+            .name = "helper",
+            .provider = "openrouter",
+            .model = "openai/gpt-4o-mini",
+            .api_key = "agent-secret",
+        },
+    };
+    cfg.memory.search.store.qdrant_api_key = "qdrant-secret";
+    cfg.memory.api.api_key = "memory-secret";
+    cfg.composio.api_key = "comp-secret";
+
+    try cfg.save();
+
+    const file = try std.fs.openFileAbsolute(config_path, .{});
+    defer file.close();
+    const content = try file.readToEndAlloc(allocator, 128 * 1024);
+    defer allocator.free(content);
+
+    const secret_values = [_][]const u8{
+        "sk-or-secret",
+        "rel-key-a",
+        "rel-key-b",
+        "gsk-secret",
+        "agent-secret",
+        "qdrant-secret",
+        "memory-secret",
+        "comp-secret",
+    };
+    for (secret_values) |secret| {
+        try std.testing.expect(std.mem.indexOf(u8, content, secret) == null);
+    }
+    try std.testing.expect(std.mem.indexOf(u8, content, "\"api_key\": \"enc2:") != null);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var loaded = Config{
+        .workspace_dir = base,
+        .config_path = config_path,
+        .allocator = arena.allocator(),
+    };
+    try loaded.parseJson(content);
+
+    try std.testing.expectEqualStrings("sk-or-secret", loaded.getProviderKey("openrouter").?);
+    try std.testing.expectEqualStrings("rel-key-a", loaded.reliability.api_keys[0]);
+    try std.testing.expectEqualStrings("rel-key-b", loaded.reliability.api_keys[1]);
+    try std.testing.expectEqualStrings("gsk-secret", loaded.model_routes[0].api_key.?);
+    try std.testing.expectEqualStrings("agent-secret", loaded.agents[0].api_key.?);
+    try std.testing.expectEqualStrings("qdrant-secret", loaded.memory.search.store.qdrant_api_key);
+    try std.testing.expectEqualStrings("memory-secret", loaded.memory.api.api_key);
+    try std.testing.expectEqualStrings("comp-secret", loaded.composio.api_key.?);
 }
 
 test "json parse tools.media.audio section" {

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("config_types.zig");
 const agent_routing = @import("agent_routing.zig");
+const secrets = @import("security/secrets.zig");
 
 const log = std.log.scoped(.config);
 
@@ -22,10 +23,36 @@ pub fn parseStringArray(allocator: std.mem.Allocator, arr: std.json.Array) ![]co
     return try list.toOwnedSlice(allocator);
 }
 
-fn parseApiKeyField(allocator: std.mem.Allocator, value: std.json.Value) !?[]const u8 {
+fn decryptSecretField(allocator: std.mem.Allocator, config_path: []const u8, value: []const u8) ![]u8 {
+    const config_dir = std.fs.path.dirname(config_path) orelse ".";
+    const store = secrets.SecretStore.init(config_dir, true);
+    return try store.decryptSecret(allocator, value);
+}
+
+fn decryptSecretArray(
+    allocator: std.mem.Allocator,
+    config_path: []const u8,
+    arr: std.json.Array,
+) ![]const []const u8 {
+    var list: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try list.ensureTotalCapacity(allocator, @intCast(arr.items.len));
+    for (arr.items) |item| {
+        if (item == .string) {
+            try list.append(allocator, try decryptSecretField(allocator, config_path, item.string));
+        }
+    }
+    return try list.toOwnedSlice(allocator);
+}
+
+fn parseApiKeyField(cfg: *const Config, value: std.json.Value) !?[]const u8 {
     return switch (value) {
-        .string => |s| try allocator.dupe(u8, s),
-        .object, .array => try std.json.Stringify.valueAlloc(allocator, value, .{}),
+        .string => |s| try decryptSecretField(cfg.allocator, cfg.config_path, s),
+        .object, .array => try std.json.Stringify.valueAlloc(cfg.allocator, value, .{}),
         else => null,
     };
 }
@@ -86,6 +113,7 @@ fn splitPrimaryModelRef(primary: []const u8) ?PrimaryModelRef {
 
 fn parseNamedAgentObject(
     allocator: std.mem.Allocator,
+    config_path: []const u8,
     agent_name: []const u8,
     item: std.json.Value,
 ) !?types.NamedAgentConfig {
@@ -167,7 +195,7 @@ fn parseNamedAgentObject(
         }
     }
     if (item.object.get("api_key")) |ak| {
-        if (ak == .string) agent_cfg.api_key = try allocator.dupe(u8, ak.string);
+        if (ak == .string) agent_cfg.api_key = try decryptSecretField(allocator, config_path, ak.string);
     }
     if (item.object.get("workspace_path")) |wp| {
         if (wp == .string) agent_cfg.workspace_path = try allocator.dupe(u8, wp.string);
@@ -678,7 +706,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                         errdefer if (route.api_key) |api_key| self.allocator.free(api_key);
 
                         if (item.object.get("api_key")) |ak| {
-                            if (ak == .string) route.api_key = try self.allocator.dupe(u8, ak.string);
+                            if (ak == .string) route.api_key = try decryptSecretField(self.allocator, self.config_path, ak.string);
                         }
                         if (item.object.get("cost_class")) |cost_class| {
                             if (cost_class == .string) {
@@ -778,7 +806,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                         if (item == .object) {
                             const name_val = item.object.get("id") orelse item.object.get("name") orelse continue;
                             if (name_val != .string) continue;
-                            var agent_cfg = try parseNamedAgentObject(self.allocator, name_val.string, item) orelse continue;
+                            var agent_cfg = try parseNamedAgentObject(self.allocator, self.config_path, name_val.string, item) orelse continue;
                             errdefer freeNamedAgentConfig(self.allocator, &agent_cfg);
                             try list.append(self.allocator, agent_cfg);
                         }
@@ -799,7 +827,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                 while (it.next()) |entry| {
                     const key = entry.key_ptr.*;
                     if (std.mem.eql(u8, key, "defaults") or std.mem.eql(u8, key, "list")) continue;
-                    var agent_cfg = try parseNamedAgentObject(self.allocator, key, entry.value_ptr.*) orelse continue;
+                    var agent_cfg = try parseNamedAgentObject(self.allocator, self.config_path, key, entry.value_ptr.*) orelse continue;
                     errdefer freeNamedAgentConfig(self.allocator, &agent_cfg);
                     try named_agent_list.append(self.allocator, agent_cfg);
                 }
@@ -1054,7 +1082,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                 if (v == .array) self.reliability.fallback_providers = try parseStringArray(self.allocator, v.array);
             }
             if (rel.object.get("api_keys")) |v| {
-                if (v == .array) self.reliability.api_keys = try parseStringArray(self.allocator, v.array);
+                if (v == .array) self.reliability.api_keys = try decryptSecretArray(self.allocator, self.config_path, v.array);
             }
             if (rel.object.get("model_fallbacks")) |v| {
                 if (v == .array) {
@@ -1336,7 +1364,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                                 self.memory.search.store.qdrant_collection = try self.allocator.dupe(u8, v.string);
                             };
                             if (store.get("qdrant_api_key")) |v| if (v == .string) {
-                                self.memory.search.store.qdrant_api_key = try self.allocator.dupe(u8, v.string);
+                                self.memory.search.store.qdrant_api_key = try decryptSecretField(self.allocator, self.config_path, v.string);
                             };
                             if (store.get("pgvector_table")) |v| if (v == .string) {
                                 self.memory.search.store.pgvector_table = try self.allocator.dupe(u8, v.string);
@@ -1726,7 +1754,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                         self.memory.api.url = try self.allocator.dupe(u8, v.string);
                     };
                     if (api.get("api_key")) |v| if (v == .string) {
-                        self.memory.api.api_key = try self.allocator.dupe(u8, v.string);
+                        self.memory.api.api_key = try decryptSecretField(self.allocator, self.config_path, v.string);
                     };
                     if (api.get("timeout_ms")) |v| if (v == .integer) {
                         self.memory.api.timeout_ms = @intCast(v.integer);
@@ -1886,7 +1914,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                 if (v == .bool) self.composio.enabled = v.bool;
             }
             if (comp.object.get("api_key")) |v| {
-                if (v == .string) self.composio.api_key = try self.allocator.dupe(u8, v.string);
+                if (v == .string) self.composio.api_key = try decryptSecretField(self.allocator, self.config_path, v.string);
             }
             if (comp.object.get("entity_id")) |v| {
                 if (v == .string) self.composio.entity_id = try self.allocator.dupe(u8, v.string);
@@ -2153,7 +2181,7 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                             .name = try self.allocator.dupe(u8, prov_name),
                         };
                         if (val.object.get("api_key")) |ak| {
-                            pe.api_key = try parseApiKeyField(self.allocator, ak);
+                            pe.api_key = try parseApiKeyField(self, ak);
                         }
                         if (val.object.get("base_url")) |ab| {
                             if (ab == .string) pe.base_url = try self.allocator.dupe(u8, ab.string);


### PR DESCRIPTION
## Summary
- encrypt persisted `api_key` values when `Config.save()` writes `config.json`
- decrypt those `api_key` values during config parsing so runtime behavior stays unchanged
- add regression coverage for encrypted save/load round-trips across providers, reliability fallbacks, model routes, named agents, memory API/Qdrant, and Composio

## Why
A reviewer on #537 correctly pointed out that `secrets.encrypt=true` only enforced plaintext-secret rejection and Nostr key encryption, while regular `api_key` entries were still written to `config.json` in plaintext.

## Validation
- `zig build test --summary all`

Refs: https://github.com/nullclaw/nullclaw/pull/537#issuecomment-4075513735 (thanks again, [ats-bcon](https://github.com/ats-bcon))
