### PR TITLE
docs: clarify workspace_path and system_prompt behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ Named agent profiles are configured separately from bindings. Bindings only choo
 
 If a named agent should run from its own workspace, set `agents.list[].workspace_path`.
 Relative paths are resolved from the directory that contains `config.json`, the workspace is scaffolded on first use, and the agent gets a durable memory namespace `agent:<agent-id>`.
+Setting `workspace_path` does not disable `system_prompt`: when both are configured, the named profile prompt is still applied and the workspace bootstrap files are loaded from that dedicated workspace.
 This applies to `nullclaw agent --agent <id>`, `/subagents spawn --agent <id>`, and routed sessions resolved through `bindings`.
 
 Minimal end-to-end example:

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -231,6 +231,7 @@ Behavior:
 - Relative paths are resolved relative to the directory that contains `config.json`.
 - Absolute paths are used as-is.
 - Both `/` and `\` are accepted in config; the runtime normalizes separators for the current OS.
+- `workspace_path` does not disable `system_prompt`. If both are set, nullclaw keeps the named profile prompt and also loads bootstrap context from that dedicated workspace.
 - On first use, nullclaw scaffolds the workspace if missing and creates:
   - `AGENTS.md`
   - `SOUL.md`

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -172,6 +172,7 @@ nullclaw onboard --interactive
 - 相对路径会相对于 `config.json` 所在目录解析。
 - 绝对路径会原样使用。
 - 配置中可以写 `/` 或 `\`，运行时会按当前操作系统规范化路径分隔符。
+- `workspace_path` 不会禁用 `system_prompt`。如果两者同时设置，nullclaw 仍会应用命名 agent 的 profile prompt，并从该独立工作区加载 bootstrap 上下文。
 - 首次使用时，如果工作区不存在，nullclaw 会自动创建并初始化：
   - `AGENTS.md`
   - `SOUL.md`

--- a/src/session.zig
+++ b/src/session.zig
@@ -1921,6 +1921,58 @@ const MockProvider = struct {
     fn mockDeinit(_: *anyopaque) void {}
 };
 
+const CapturePromptProvider = struct {
+    response: []const u8 = "ok",
+    captured_system: ?[]const u8 = null,
+
+    const vtable = Provider.VTable{
+        .chatWithSystem = chatWithSystem,
+        .chat = chat,
+        .supportsNativeTools = supportsNativeTools,
+        .getName = getName,
+        .deinit = deinitFn,
+    };
+
+    fn provider(self: *CapturePromptProvider) Provider {
+        return .{ .ptr = @ptrCast(self), .vtable = &vtable };
+    }
+
+    fn chatWithSystem(
+        _: *anyopaque,
+        allocator: Allocator,
+        _: ?[]const u8,
+        _: []const u8,
+        _: []const u8,
+        _: f64,
+    ) anyerror![]const u8 {
+        return allocator.dupe(u8, "");
+    }
+
+    fn chat(
+        ptr: *anyopaque,
+        allocator: Allocator,
+        request: providers.ChatRequest,
+        _: []const u8,
+        _: f64,
+    ) anyerror!providers.ChatResponse {
+        const self: *CapturePromptProvider = @ptrCast(@alignCast(ptr));
+        if (request.messages.len > 0 and request.messages[0].role == .system) {
+            self.captured_system = request.messages[0].content;
+        }
+        return .{ .content = try allocator.dupe(u8, self.response) };
+    }
+
+    fn supportsNativeTools(_: *anyopaque) bool {
+        return false;
+    }
+
+    fn getName(_: *anyopaque) []const u8 {
+        return "capture_prompt";
+    }
+
+    fn deinitFn(_: *anyopaque) void {}
+};
+
 const MockStreamingProvider = struct {
     response: []const u8,
 
@@ -2547,6 +2599,50 @@ test "getOrCreate uses named agent workspace namespace when workspace_path is se
     try testing.expect(session.owned_memory_session_id != null);
     try testing.expectEqualStrings("agent:coder-agent", session.agent.memory_session_id.?);
     try testing.expectEqualStrings(expected_workspace, session.agent.workspace_dir);
+}
+
+test "getOrCreate preserves named agent system prompt when workspace_path is set" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(base);
+    const config_path = try std.fs.path.join(testing.allocator, &.{ base, "config.json" });
+    defer testing.allocator.free(config_path);
+
+    const expected_prompt = "Focus on implementation and tests.";
+
+    var mock = MockProvider{ .response = "ok" };
+    var cfg = testConfig();
+    cfg.workspace_dir = base;
+    cfg.config_path = config_path;
+    cfg.agents = &.{
+        .{
+            .name = "Coder Agent",
+            .provider = "ollama",
+            .model = "qwen2.5-coder:14b",
+            .system_prompt = expected_prompt,
+            .workspace_path = "agents/coder-agent",
+        },
+    };
+
+    var sm = testSessionManager(testing.allocator, &mock, &cfg);
+    defer sm.deinit();
+
+    const session = try sm.getOrCreate("agent:coder-agent:telegram:group:-100123");
+    try testing.expectEqualStrings(expected_prompt, session.agent.profile_system_prompt.?);
+    try expectPathEndsWith(session.agent.workspace_dir, "/agents/coder-agent");
+
+    var capture = CapturePromptProvider{};
+    session.agent.provider = capture.provider();
+
+    const response = try session.agent.turn("hello");
+    defer testing.allocator.free(response);
+
+    try testing.expectEqualStrings("ok", response);
+    try testing.expect(capture.captured_system != null);
+    try testing.expect(std.mem.indexOf(u8, capture.captured_system.?, expected_prompt) != null);
+    try testing.expect(std.mem.indexOf(u8, capture.captured_system.?, "Profile: Coder Agent") != null);
 }
 
 test "getOrCreate auto-provisioned peer uses dedicated runtime workspace" {

--- a/src/subagent.zig
+++ b/src/subagent.zig
@@ -487,6 +487,14 @@ fn testTaskRunnerWorkspace(allocator: Allocator, request: TaskRunRequest) ![]con
     return allocator.dupe(u8, request.workspace_dir);
 }
 
+fn testTaskRunnerWorkspaceAndPrompt(allocator: Allocator, request: TaskRunRequest) ![]const u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "workspace={s}\nprompt={s}",
+        .{ request.workspace_dir, request.system_prompt },
+    );
+}
+
 fn testTaskRunnerHttpTimeout(allocator: Allocator, request: TaskRunRequest) ![]const u8 {
     return std.fmt.allocPrint(allocator, "{d}", .{request.http_timeout_secs});
 }
@@ -724,6 +732,44 @@ test "SubagentManager uses named agent workspace_path for task runner" {
     const status = try waitTaskTerminalStatus(&mgr, task_id);
     try std.testing.expectEqual(TaskStatus.completed, status);
     try std.testing.expectEqualStrings(expected_workspace, mgr.getTaskResult(task_id).?);
+}
+
+test "SubagentManager preserves named agent system_prompt when workspace_path is set" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(base);
+    const config_path = try std.fs.path.join(std.testing.allocator, &.{ base, "config.json" });
+    defer std.testing.allocator.free(config_path);
+    const expected_workspace = try std.fs.path.join(std.testing.allocator, &.{ base, "agents", "researcher" });
+    defer std.testing.allocator.free(expected_workspace);
+    const expected_prompt = "Focus on implementation and tests.";
+
+    const agents = [_]config_mod.NamedAgentConfig{.{
+        .name = "researcher",
+        .provider = "openrouter",
+        .model = "anthropic/claude-sonnet-4",
+        .system_prompt = expected_prompt,
+        .workspace_path = "agents/researcher",
+    }};
+    const cfg = config_mod.Config{
+        .workspace_dir = base,
+        .config_path = config_path,
+        .allocator = std.testing.allocator,
+        .agents = &agents,
+    };
+    var mgr = SubagentManager.init(std.testing.allocator, &cfg, null, .{});
+    mgr.task_runner = testTaskRunnerWorkspaceAndPrompt;
+    defer mgr.deinit();
+
+    const task_id = try mgr.spawnWithAgent("quick task", "workspace-prompt-check", "agent", "session:42", "researcher");
+    const status = try waitTaskTerminalStatus(&mgr, task_id);
+    try std.testing.expectEqual(TaskStatus.completed, status);
+
+    const result = mgr.getTaskResult(task_id).?;
+    try std.testing.expect(std.mem.indexOf(u8, result, expected_workspace) != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, expected_prompt) != null);
 }
 
 test "SubagentManager uses task runner callback result" {


### PR DESCRIPTION
## Summary

Follow-up to the discussion in #500 about whether `workspace_path` suppresses a named agent's `system_prompt`.

This PR does not change the runtime behavior. It makes the current behavior explicit and adds regression coverage for it.

## What changed

- add a regression test proving routed/named-agent sessions keep the profile `system_prompt` when `workspace_path` is set
- add a regression test proving `/subagents spawn --agent <id>` keeps the profile `system_prompt` when `workspace_path` is set
- document that `workspace_path` and `system_prompt` are combined, not mutually exclusive

## Why

The current runtime already applies both:
- dedicated workspace bootstrap context comes from the agent workspace
- the named profile prompt is still prepended to the system prompt

That behavior was not stated clearly enough in the docs, which made the `#500` thread look like a possible regression.

## Validation

- [x] `zig build test --summary all` -> `5857 passed`, `11 skipped`, `0 failures`
