### PR TITLE
fix(cron): allow agent jobs to omit command field in cron.json

### DIFF
--- a/src/cron.zig
+++ b/src/cron.zig
@@ -1170,14 +1170,11 @@ fn loadJobsWithPolicy(scheduler: *CronScheduler, policy: LoadPolicy) !void {
                 .strict => return error.InvalidCronStoreFormat,
             }
         };
-        const command = blk: {
+        const command_raw: ?[]const u8 = blk: {
             if (obj.get("command")) |v| {
                 if (v == .string and v.string.len > 0) break :blk v.string;
             }
-            switch (policy) {
-                .best_effort => continue,
-                .strict => return error.InvalidCronStoreFormat,
-            }
+            break :blk null;
         };
 
         const next_run_secs: i64 = blk: {
@@ -1231,6 +1228,18 @@ fn loadJobsWithPolicy(scheduler: *CronScheduler, policy: LoadPolicy) !void {
                 if (v == .string and v.string.len > 0) break :blk v.string;
             }
             break :blk null;
+        };
+        // Agent jobs may omit "command" and rely solely on "prompt".
+        // Shell jobs still require a command.
+        const command: []const u8 = blk: {
+            if (command_raw) |c| break :blk c;
+            if (job_type == .agent) {
+                if (prompt) |p| break :blk p;
+            }
+            switch (policy) {
+                .best_effort => continue,
+                .strict => return error.InvalidCronStoreFormat,
+            }
         };
         const model = blk: {
             if (obj.get("model")) |v| {
@@ -2184,6 +2193,28 @@ test "save and load roundtrip" {
     try std.testing.expect(loaded[0].last_status != null);
     try std.testing.expectEqualStrings("ok", loaded[0].last_status.?);
     try std.testing.expect(loaded[1].one_shot);
+}
+
+test "load agent job without command field falls back to prompt" {
+    var scheduler = CronScheduler.init(std.testing.allocator, 10, true);
+    defer scheduler.deinit();
+
+    // Write a cron.json with an agent job that has no "command" field
+    const json =
+        \\[{"id":"ag-1","expression":"0 7 * * 1","job_type":"agent","prompt":"Check traffic","model":"glm-cn/glm-5-turbo","paused":false,"one_shot":false,"enabled":true,"delete_after_run":false,"delivery_mode":"none"}]
+    ;
+    const path = try cronJsonPath(std.testing.allocator);
+    defer std.testing.allocator.free(path);
+    const file = try std.fs.createFileAbsolute(path, .{});
+    defer file.close();
+    try file.writeAll(json);
+
+    try loadJobs(&scheduler);
+
+    const jobs = scheduler.listJobs();
+    try std.testing.expectEqual(@as(usize, 1), jobs.len);
+    try std.testing.expectEqualStrings("Check traffic", jobs[0].command);
+    try std.testing.expectEqualStrings("Check traffic", jobs[0].prompt.?);
 }
 
 test "save and load roundtrip keeps delivery account routing" {

--- a/src/cron.zig
+++ b/src/cron.zig
@@ -1223,10 +1223,17 @@ fn loadJobsWithPolicy(scheduler: *CronScheduler, policy: LoadPolicy) !void {
             }
             break :blk JobType.shell;
         };
-        const prompt = blk: {
+        const prompt_raw: ?[]const u8 = blk: {
             if (obj.get("prompt")) |v| {
                 if (v == .string and v.string.len > 0) break :blk v.string;
             }
+            break :blk null;
+        };
+        // Normalize agent job text so prompt/command stay in sync regardless
+        // of which back-compat field was present in cron.json.
+        const prompt: ?[]const u8 = blk: {
+            if (prompt_raw) |p| break :blk p;
+            if (job_type == .agent) break :blk command_raw;
             break :blk null;
         };
         // Agent jobs may omit "command" and rely solely on "prompt".
@@ -1234,7 +1241,7 @@ fn loadJobsWithPolicy(scheduler: *CronScheduler, policy: LoadPolicy) !void {
         const command: []const u8 = blk: {
             if (command_raw) |c| break :blk c;
             if (job_type == .agent) {
-                if (prompt) |p| break :blk p;
+                if (prompt_raw) |p| break :blk p;
             }
             switch (policy) {
                 .best_effort => continue,
@@ -2209,12 +2216,34 @@ test "load agent job without command field falls back to prompt" {
     defer file.close();
     try file.writeAll(json);
 
-    try loadJobs(&scheduler);
+    try loadJobsStrict(&scheduler);
 
     const jobs = scheduler.listJobs();
     try std.testing.expectEqual(@as(usize, 1), jobs.len);
     try std.testing.expectEqualStrings("Check traffic", jobs[0].command);
     try std.testing.expectEqualStrings("Check traffic", jobs[0].prompt.?);
+}
+
+test "load agent job without prompt field falls back to command" {
+    var scheduler = CronScheduler.init(std.testing.allocator, 10, true);
+    defer scheduler.deinit();
+
+    const json =
+        \\[{"id":"ag-2","expression":"15 9 * * 2","job_type":"agent","command":"Summarize incidents","model":"openrouter/anthropic/claude-sonnet-4","paused":false,"one_shot":false,"enabled":true,"delete_after_run":false,"delivery_mode":"none"}]
+    ;
+    const path = try cronJsonPath(std.testing.allocator);
+    defer std.testing.allocator.free(path);
+    const file = try std.fs.createFileAbsolute(path, .{});
+    defer file.close();
+    try file.writeAll(json);
+
+    try loadJobsStrict(&scheduler);
+
+    const jobs = scheduler.listJobs();
+    try std.testing.expectEqual(@as(usize, 1), jobs.len);
+    try std.testing.expectEqualStrings("Summarize incidents", jobs[0].command);
+    try std.testing.expect(jobs[0].prompt != null);
+    try std.testing.expectEqualStrings("Summarize incidents", jobs[0].prompt.?);
 }
 
 test "save and load roundtrip keeps delivery account routing" {


### PR DESCRIPTION
## Summary
- Agent jobs store their content in `prompt`; `command` was redundant but previously required by the loader
- Jobs with `"command": null` were silently skipped on load, causing all agent cron jobs to disappear after gateway restart
- Now `command` is optional for agent jobs — loader falls back to `prompt` when `command` is absent

## Changes
- `src/cron.zig`: Parse `command` as optional; resolve final value after `job_type` and `prompt` are known; shell jobs still require `command`
- Added test: `load agent job without command field falls back to prompt`

## Test plan
- [ ] `zig build test --summary all` passes with 0 failures
- [ ] Agent cron jobs with no `command` field load correctly after gateway restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)