### PR TITLE
docs(a2a): expand protocol doc and examples + add config details and method reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,9 +700,11 @@ Use `channels.web` for browser UI events (WebChannel v1):
 | `/whatsapp` | GET | Query params | Meta webhook verification |
 | `/whatsapp` | POST | None (Meta signature) | WhatsApp incoming message webhook |
 
-### A2A
+### A2A (Agent-to-Agent Protocol v0.3.0)
 
-Enable the gateway binding with:
+NullClaw implements Google's [A2A protocol](https://github.com/google/A2A) v0.3.0, allowing any A2A-compatible agent or client to discover, authenticate, and interact with your instance over JSON-RPC 2.0.
+
+Enable in `~/.nullclaw/config.json`:
 
 ```json
 {
@@ -716,10 +718,32 @@ Enable the gateway binding with:
 }
 ```
 
-- Discover the agent card at `/.well-known/agent-card.json`.
-- Send JSON-RPC requests to `/a2a` using a bearer token obtained from `/pair`.
-- Canonical JSON-RPC methods: `SendMessage`, `SendStreamingMessage`, `GetTask`, `CancelTask`, `ListTasks`, `SubscribeToTask`.
-- Legacy slash aliases remain accepted for compatibility: `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/list`, `tasks/resubscribe`.
+**Endpoints:**
+
+| Endpoint | Auth | Description |
+|----------|------|-------------|
+| `GET /.well-known/agent-card.json` | None | Agent Card discovery (public) |
+| `POST /a2a` | Bearer token | JSON-RPC 2.0 dispatch |
+
+**Supported methods:** `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/list`, `tasks/resubscribe`.
+
+**Quick test:**
+
+```bash
+# 1. Get a bearer token
+TOKEN=$(curl -s -X POST -H "X-Pairing-Code: 123456" http://localhost:3000/pair | jq -r .token)
+
+# 2. Discover the agent
+curl http://localhost:3000/.well-known/agent-card.json
+
+# 3. Send a message
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"messageId":"msg-1","role":"user","parts":[{"kind":"text","text":"Hello"}]}}}' \
+  http://localhost:3000/a2a
+```
+
+See [Gateway API docs](docs/en/gateway-api.md) for full A2A reference including streaming, task lifecycle, and configuration details.
 
 ## Commands
 

--- a/docs/en/gateway-api.md
+++ b/docs/en/gateway-api.md
@@ -32,6 +32,8 @@ Default gateway endpoint: `http://127.0.0.1:3000`
 | `/whatsapp` | GET | Query params | Meta webhook verification |
 | `/whatsapp` | POST | Meta signature | WhatsApp inbound webhook |
 | `/max` | POST | `X-Max-Bot-Api-Secret` when configured | Max inbound webhook delivery |
+| `/.well-known/agent-card.json` | GET | None | A2A Agent Card discovery (public) |
+| `/a2a` | POST | `Authorization: Bearer <token>` | A2A JSON-RPC 2.0 endpoint |
 
 ## Quick Examples
 
@@ -88,6 +90,167 @@ Max webhook notes:
 - `nullclaw` routes `/max` to the configured Max account by `account_id` query first, then by `X-Max-Bot-Api-Secret`.
 - If `channels.max[].webhook_secret` is configured, the header is required and must match exactly.
 - Use HTTPS in the configured Max-side webhook URL.
+
+## A2A (Agent-to-Agent Protocol)
+
+NullClaw implements [Google's A2A protocol v0.3.0](https://github.com/google/A2A) over JSON-RPC 2.0, enabling interoperability with any A2A-compatible agent or client.
+
+### Configuration
+
+Add to `~/.nullclaw/config.json`:
+
+```json
+{
+  "a2a": {
+    "enabled": true,
+    "name": "My Agent",
+    "description": "General-purpose AI assistant",
+    "url": "https://your-public-url.example.com",
+    "version": "0.3.0"
+  }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Enable A2A endpoints |
+| `name` | `"NullClaw"` | Agent name in the Agent Card |
+| `description` | `"AI assistant"` | Agent description |
+| `url` | `""` | Public URL (used in Agent Card and `supportedInterfaces`) |
+| `version` | `"1.0.0"` | Agent version string |
+
+### Agent Card Discovery
+
+```bash
+curl http://127.0.0.1:3000/.well-known/agent-card.json
+```
+
+Returns the Agent Card with capabilities, skills, security schemes, and supported interfaces. No authentication required.
+
+### JSON-RPC Methods
+
+All methods are called via `POST /a2a` with a bearer token from `/pair`.
+
+| Method | Description |
+|--------|-------------|
+| `message/send` | Send a message, receive completed task |
+| `message/stream` | Send a message, receive SSE stream of events |
+| `tasks/get` | Retrieve task by ID (supports `historyLength`) |
+| `tasks/cancel` | Cancel an active task |
+| `tasks/list` | List tasks with optional `state`/`contextId` filters |
+| `tasks/resubscribe` | Resume SSE stream for an existing task |
+
+### Task Lifecycle
+
+```
+submitted → working → completed
+                    → failed
+                    → canceled
+                    → input-required
+                    → auth-required
+                    → rejected
+```
+
+Terminal states: `completed`, `failed`, `canceled`, `rejected`.
+
+### Examples
+
+**Send a message:**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "What is nullclaw?"}]
+      }
+    }
+  }' \
+  http://127.0.0.1:3000/a2a
+```
+
+**Stream a response (SSE):**
+
+```bash
+curl -N -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/stream",
+    "params": {
+      "message": {
+        "messageId": "msg-2",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Explain A2A protocol"}]
+      }
+    }
+  }' \
+  http://127.0.0.1:3000/a2a
+```
+
+**Get a task:**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"id":"task-1"}}' \
+  http://127.0.0.1:3000/a2a
+```
+
+**Cancel a task:**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tasks/cancel","params":{"id":"task-1"}}' \
+  http://127.0.0.1:3000/a2a
+```
+
+### Multi-turn Conversations
+
+Include `contextId` in the message to group tasks into a conversation. All messages with the same `contextId` share session state and conversation history:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "message/send",
+  "params": {
+    "message": {
+      "messageId": "msg-3",
+      "contextId": "my-conversation",
+      "role": "user",
+      "parts": [{"kind": "text", "text": "Follow-up question"}]
+    }
+  }
+}
+```
+
+### Error Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| -32700 | JSONParseError | Invalid JSON payload |
+| -32600 | InvalidRequestError | Request validation error |
+| -32601 | MethodNotFoundError | Unknown method |
+| -32602 | InvalidParamsError | Missing or invalid parameters |
+| -32603 | InternalError | Server-side error |
+| -32001 | TaskNotFoundError | Task ID not found |
+| -32002 | TaskNotCancelableError | Task already in terminal state |
+| -32003 | PushNotificationNotSupportedError | Push notifications not supported |
+| -32005 | ContentTypeNotSupportedError | Incompatible content types |
+| -32007 | AuthenticatedExtendedCardNotConfiguredError | Extended card not available |
 
 ## Security Guidance
 

--- a/docs/zh/gateway-api.md
+++ b/docs/zh/gateway-api.md
@@ -18,6 +18,8 @@
 | `/whatsapp` | GET | Query 参数 | Meta Webhook 验证 |
 | `/whatsapp` | POST | Meta 签名 | WhatsApp 入站消息 |
 | `/max` | POST | `X-Max-Bot-Api-Secret`（配置后必填） | Max 入站 webhook |
+| `/.well-known/agent-card.json` | GET | 无 | A2A Agent Card 发现（公开） |
+| `/a2a` | POST | `Authorization: Bearer <token>` | A2A JSON-RPC 2.0 端点 |
 
 ## 快速示例
 
@@ -74,6 +76,157 @@ Max webhook 说明：
 - `nullclaw` 对 `/max` 路由优先按 `account_id` query 参数匹配，其次按 `X-Max-Bot-Api-Secret` 匹配。
 - 如果 `channels.max[].webhook_secret` 已配置，header 必须存在且完全匹配。
 - Max 侧配置的 webhook URL 必须使用 HTTPS。
+
+## A2A（Agent-to-Agent 协议）
+
+NullClaw 实现了 [Google A2A 协议 v0.3.0](https://github.com/google/A2A)，基于 JSON-RPC 2.0，支持与任何兼容 A2A 的代理或客户端互操作。
+
+### 配置
+
+在 `~/.nullclaw/config.json` 中添加：
+
+```json
+{
+  "a2a": {
+    "enabled": true,
+    "name": "My Agent",
+    "description": "通用 AI 助手",
+    "url": "https://your-public-url.example.com",
+    "version": "0.3.0"
+  }
+}
+```
+
+| 字段 | 默认值 | 说明 |
+|------|--------|------|
+| `enabled` | `false` | 启用 A2A 端点 |
+| `name` | `"NullClaw"` | Agent Card 中显示的名称 |
+| `description` | `"AI assistant"` | 代理描述 |
+| `url` | `""` | 公开 URL（用于 Agent Card 和 `supportedInterfaces`） |
+| `version` | `"1.0.0"` | 代理版本号 |
+
+### Agent Card 发现
+
+```bash
+curl http://127.0.0.1:3000/.well-known/agent-card.json
+```
+
+返回 Agent Card，包含能力声明、技能列表、安全机制和支持的接口。无需鉴权。
+
+### JSON-RPC 方法
+
+所有方法通过 `POST /a2a` 调用，需要从 `/pair` 获取的 bearer token。
+
+| 方法 | 说明 |
+|------|------|
+| `message/send` | 发送消息，返回完成的任务 |
+| `message/stream` | 发送消息，返回 SSE 事件流 |
+| `tasks/get` | 按 ID 查询任务（支持 `historyLength`） |
+| `tasks/cancel` | 取消进行中的任务 |
+| `tasks/list` | 列出任务，支持 `state`/`contextId` 过滤 |
+| `tasks/resubscribe` | 恢复已有任务的 SSE 流 |
+
+### 任务生命周期
+
+```
+submitted → working → completed
+                    → failed
+                    → canceled
+                    → input-required
+                    → auth-required
+                    → rejected
+```
+
+终态：`completed`、`failed`、`canceled`、`rejected`。
+
+### 示例
+
+**发送消息：**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "什么是 nullclaw？"}]
+      }
+    }
+  }' \
+  http://127.0.0.1:3000/a2a
+```
+
+**流式响应（SSE）：**
+
+```bash
+curl -N -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/stream",
+    "params": {
+      "message": {
+        "messageId": "msg-2",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "解释 A2A 协议"}]
+      }
+    }
+  }' \
+  http://127.0.0.1:3000/a2a
+```
+
+**查询任务：**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"id":"task-1"}}' \
+  http://127.0.0.1:3000/a2a
+```
+
+### 多轮对话
+
+在消息中包含 `contextId` 将任务归入同一对话。相同 `contextId` 的消息共享会话状态和对话历史：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "message/send",
+  "params": {
+    "message": {
+      "messageId": "msg-3",
+      "contextId": "my-conversation",
+      "role": "user",
+      "parts": [{"kind": "text", "text": "后续问题"}]
+    }
+  }
+}
+```
+
+### 错误码
+
+| 错误码 | 名称 | 说明 |
+|--------|------|------|
+| -32700 | JSONParseError | JSON 格式无效 |
+| -32600 | InvalidRequestError | 请求校验失败 |
+| -32601 | MethodNotFoundError | 未知方法 |
+| -32602 | InvalidParamsError | 缺少或无效参数 |
+| -32603 | InternalError | 服务端错误 |
+| -32001 | TaskNotFoundError | 任务 ID 不存在 |
+| -32002 | TaskNotCancelableError | 任务已处于终态 |
+| -32003 | PushNotificationNotSupportedError | 不支持推送通知 |
+| -32005 | ContentTypeNotSupportedError | 内容类型不兼容 |
+| -32007 | AuthenticatedExtendedCardNotConfiguredError | 未配置扩展卡片 |
 
 ## 鉴权与安全建议
 


### PR DESCRIPTION
**Summary**
- Add comprehensive A2A protocol documentation to README and gateway API docs (EN + ZH)
- Update README A2A section with v0.3.0 protocol version, endpoint table, method list, and copy-paste quick test example
- Add full A2A reference to docs/en/gateway-api.md: configuration table, Agent Card discovery, JSON-RPC methods, task lifecycle diagram, curl examples (send, stream, get, cancel),
  multi-turn conversations via contextId, and error code table
- Add A2A endpoints to the endpoint summary tables in both language docs

**Validation**
- All links and referenced endpoints match src/a2a.zig and src/config_types.zig
- curl examples use correct v0.3.0 message format (including required messageId)

**Notes**
- No code changes — docs only
- Syncs EN and ZH gateway API pages as required by CONTRIBUTING.md