### PR TITLE
fix(config): accept flat OTEL diagnostics fields | 修复(config): 兼容平铺式 OTEL diagnostics 配置字段

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -3254,6 +3254,29 @@ test "json parse diagnostics section accepts flat otel fields for compatibility"
     allocator.free(cfg.diagnostics.otel_headers);
 }
 
+test "json parse diagnostics section prefers nested otel fields over flat compatibility aliases" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\{"diagnostics": {"backend": "otel", "otel_endpoint": "http://flat:4318", "otel_service_name": "flat-service", "otel_headers": {"Authorization": "Bearer flat"}, "otel": {"endpoint": "http://nested:4318", "service_name": "nested-service", "headers": {"Authorization": "Bearer nested"}}}}
+    ;
+    var cfg = Config{ .workspace_dir = "/tmp/yc", .config_path = "/tmp/yc/config.json", .allocator = allocator };
+    try cfg.parseJson(json);
+    try std.testing.expectEqualStrings("otel", cfg.diagnostics.backend);
+    try std.testing.expectEqualStrings("http://nested:4318", cfg.diagnostics.otel_endpoint.?);
+    try std.testing.expectEqualStrings("nested-service", cfg.diagnostics.otel_service_name.?);
+    try std.testing.expectEqual(@as(usize, 1), cfg.diagnostics.otel_headers.len);
+    try std.testing.expectEqualStrings("Authorization", cfg.diagnostics.otel_headers[0].key);
+    try std.testing.expectEqualStrings("Bearer nested", cfg.diagnostics.otel_headers[0].value);
+    allocator.free(cfg.diagnostics.backend);
+    allocator.free(cfg.diagnostics.otel_endpoint.?);
+    allocator.free(cfg.diagnostics.otel_service_name.?);
+    for (cfg.diagnostics.otel_headers) |header| {
+        allocator.free(header.key);
+        allocator.free(header.value);
+    }
+    allocator.free(cfg.diagnostics.otel_headers);
+}
+
 test "json parse scheduler section" {
     const allocator = std.testing.allocator;
     const json =

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -111,6 +111,40 @@ fn splitPrimaryModelRef(primary: []const u8) ?PrimaryModelRef {
     };
 }
 
+fn parseDiagnosticsOtelHeaders(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !?[]const types.DiagnosticsConfig.OtelHeaderEntry {
+    if (value != .object) return null;
+
+    var header_list: std.ArrayListUnmanaged(types.DiagnosticsConfig.OtelHeaderEntry) = .empty;
+    errdefer {
+        for (header_list.items) |header| {
+            allocator.free(header.key);
+            allocator.free(header.value);
+        }
+        header_list.deinit(allocator);
+    }
+
+    var hit = value.object.iterator();
+    while (hit.next()) |he| {
+        if (he.value_ptr.* != .string) continue;
+
+        const header_key = try allocator.dupe(u8, he.key_ptr.*);
+        const header_value = try allocator.dupe(u8, he.value_ptr.string);
+        header_list.append(allocator, .{
+            .key = header_key,
+            .value = header_value,
+        }) catch |err| {
+            allocator.free(header_key);
+            allocator.free(header_value);
+            return err;
+        };
+    }
+
+    return try header_list.toOwnedSlice(allocator);
+}
+
 fn parseNamedAgentObject(
     allocator: std.mem.Allocator,
     config_path: []const u8,
@@ -977,49 +1011,46 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                     self.diagnostics.token_usage_ledger_max_lines = @intCast(v.integer);
                 }
             }
-            if (diag.object.get("otel_endpoint")) |v| {
-                if (v == .string) self.diagnostics.otel_endpoint = try self.allocator.dupe(u8, v.string);
-            }
-            if (diag.object.get("otel_service_name")) |v| {
-                if (v == .string) self.diagnostics.otel_service_name = try self.allocator.dupe(u8, v.string);
-            }
-            if (diag.object.get("otel_headers")) |h| {
-                if (h == .object) {
-                    var header_list: std.ArrayListUnmanaged(types.DiagnosticsConfig.OtelHeaderEntry) = .empty;
-                    var hit = h.object.iterator();
-                    while (hit.next()) |he| {
-                        if (he.value_ptr.* == .string) {
-                            try header_list.append(self.allocator, .{
-                                .key = try self.allocator.dupe(u8, he.key_ptr.*),
-                                .value = try self.allocator.dupe(u8, he.value_ptr.string),
-                            });
-                        }
-                    }
-                    self.diagnostics.otel_headers = try header_list.toOwnedSlice(self.allocator);
-                }
-            }
+            var has_nested_otel_endpoint = false;
+            var has_nested_otel_service_name = false;
+            var has_nested_otel_headers = false;
             if (diag.object.get("otel")) |otel| {
                 if (otel == .object) {
                     if (otel.object.get("endpoint")) |v| {
-                        if (v == .string) self.diagnostics.otel_endpoint = try self.allocator.dupe(u8, v.string);
+                        if (v == .string) {
+                            self.diagnostics.otel_endpoint = try self.allocator.dupe(u8, v.string);
+                            has_nested_otel_endpoint = true;
+                        }
                     }
                     if (otel.object.get("service_name")) |v| {
-                        if (v == .string) self.diagnostics.otel_service_name = try self.allocator.dupe(u8, v.string);
+                        if (v == .string) {
+                            self.diagnostics.otel_service_name = try self.allocator.dupe(u8, v.string);
+                            has_nested_otel_service_name = true;
+                        }
                     }
                     if (otel.object.get("headers")) |h| {
-                        if (h == .object) {
-                            var header_list: std.ArrayListUnmanaged(types.DiagnosticsConfig.OtelHeaderEntry) = .empty;
-                            var hit = h.object.iterator();
-                            while (hit.next()) |he| {
-                                if (he.value_ptr.* == .string) {
-                                    try header_list.append(self.allocator, .{
-                                        .key = try self.allocator.dupe(u8, he.key_ptr.*),
-                                        .value = try self.allocator.dupe(u8, he.value_ptr.string),
-                                    });
-                                }
-                            }
-                            self.diagnostics.otel_headers = try header_list.toOwnedSlice(self.allocator);
+                        if (try parseDiagnosticsOtelHeaders(self.allocator, h)) |headers| {
+                            self.diagnostics.otel_headers = headers;
+                            has_nested_otel_headers = true;
                         }
+                    }
+                }
+            }
+            // Accept flat OTEL diagnostics aliases as a fallback for older configs.
+            if (!has_nested_otel_endpoint) {
+                if (diag.object.get("otel_endpoint")) |v| {
+                    if (v == .string) self.diagnostics.otel_endpoint = try self.allocator.dupe(u8, v.string);
+                }
+            }
+            if (!has_nested_otel_service_name) {
+                if (diag.object.get("otel_service_name")) |v| {
+                    if (v == .string) self.diagnostics.otel_service_name = try self.allocator.dupe(u8, v.string);
+                }
+            }
+            if (!has_nested_otel_headers) {
+                if (diag.object.get("otel_headers")) |h| {
+                    if (try parseDiagnosticsOtelHeaders(self.allocator, h)) |headers| {
+                        self.diagnostics.otel_headers = headers;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

### EN:
   - Fixed OTEL diagnostics config parsing so nullclaw now accepts `diagnostics.otel_endpoint`, `diagnostics.otel_service_name`, and `diagnostics.otel_headers` as compatibility aliases.
   - Kept the current nested `diagnostics.otel.{endpoint,service_name,headers}` schema intact while making the parser accept the flat fields used by existing configs and reports.
   - Added a regression test covering the flat OTEL diagnostics fields so the runtime keeps wiring the configured collector endpoint instead of silently falling back to `http://localhost:4318`.

### ZH:
   - 修复了 OTEL diagnostics 配置解析逻辑，nullclaw 现在接受 `diagnostics.otel_endpoint`、`diagnostics.otel_service_name` 和 `diagnostics.otel_headers` 作为兼容别名。
   - 保留当前正式的嵌套结构 `diagnostics.otel.{endpoint,service_name,headers}`，同时让解析器兼容现有配置和 issue 报告中使用的平铺字段。
   - 补充了针对平铺 OTEL diagnostics 字段的回归测试，确保运行时会正确使用已配置的 collector endpoint，而不是悄悄回退到 `http://localhost:4318`。

## Validation
   - `zig build test --summary all`: Passed.

## Notes
   - Closes #638.
