### PR TITLE
Add Xiaomi MiMo as an OpenAI-compatible provider | 新增 Xiaomi MiMo OpenAI 兼容提供方支持

### DIFF
--- a/src/agent/context_tokens.zig
+++ b/src/agent/context_tokens.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const config_types = @import("../config_types.zig");
+const provider_names = @import("../provider_names.zig");
 
 pub const DEFAULT_CONTEXT_TOKENS: u64 = config_types.DEFAULT_AGENT_TOKEN_LIMIT;
 
@@ -107,6 +108,15 @@ fn lookupTable(table: []const ContextWindowEntry, key: []const u8) ?u64 {
     return null;
 }
 
+fn lookupProviderWindow(key: []const u8) ?u64 {
+    if (lookupTable(&PROVIDER_WINDOWS, key)) |n| return n;
+    const canonical = provider_names.canonicalProviderNameIgnoreCase(key);
+    if (!std.ascii.eqlIgnoreCase(canonical, key)) {
+        if (lookupTable(&PROVIDER_WINDOWS, canonical)) |n| return n;
+    }
+    return null;
+}
+
 fn splitProviderModel(model_ref: []const u8) struct { provider: ?[]const u8, model: []const u8 } {
     const slash = std.mem.indexOfScalar(u8, model_ref, '/') orelse {
         return .{ .provider = null, .model = model_ref };
@@ -163,6 +173,7 @@ pub fn lookupContextTokens(model_ref_raw: []const u8) ?u64 {
     if (model_ref.len == 0) return null;
 
     if (lookupModelCandidates(model_ref)) |n| return n;
+    if (lookupProviderWindow(model_ref)) |n| return n;
 
     const split = splitProviderModel(model_ref);
     if (lookupModelCandidates(split.model)) |n| return n;
@@ -172,7 +183,7 @@ pub fn lookupContextTokens(model_ref_raw: []const u8) ?u64 {
         const nested_provider = split.model[0..nested_sep];
         const nested_model = split.model[nested_sep + 1 ..];
         if (lookupModelCandidates(nested_model)) |n| return n;
-        if (lookupTable(&PROVIDER_WINDOWS, nested_provider)) |n| return n;
+        if (lookupProviderWindow(nested_provider)) |n| return n;
     }
     if (std.mem.lastIndexOfScalar(u8, split.model, '/')) |last_sep| {
         const leaf_model = split.model[last_sep + 1 ..];
@@ -180,7 +191,7 @@ pub fn lookupContextTokens(model_ref_raw: []const u8) ?u64 {
     }
 
     if (split.provider) |provider| {
-        if (lookupTable(&PROVIDER_WINDOWS, provider)) |n| return n;
+        if (lookupProviderWindow(provider)) |n| return n;
     }
 
     return null;
@@ -226,6 +237,11 @@ test "lookupContextTokens strips date suffixes" {
 test "lookupContextTokens falls back to provider defaults" {
     try std.testing.expectEqual(@as(?u64, 98_304), lookupContextTokens("qianfan/custom-model"));
     try std.testing.expectEqual(@as(?u64, 200_000), lookupContextTokens("openrouter/inception/mercury"));
+}
+
+test "lookupContextTokens honors canonical provider aliases" {
+    try std.testing.expectEqual(@as(?u64, 262_144), lookupContextTokens("mimo/custom-model"));
+    try std.testing.expectEqual(@as(?u64, 262_144), lookupContextTokens("xiaomi-mimo"));
 }
 
 test "resolveContextTokens falls back to global default" {

--- a/src/agent/max_tokens.zig
+++ b/src/agent/max_tokens.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const config_types = @import("../config_types.zig");
+const provider_names = @import("../provider_names.zig");
 
 pub const DEFAULT_MODEL_MAX_TOKENS: u32 = config_types.DEFAULT_MODEL_MAX_TOKENS;
 
@@ -114,6 +115,15 @@ fn lookupTable(table: []const MaxTokensEntry, key: []const u8) ?u32 {
     return null;
 }
 
+fn lookupProviderMaxTokens(key: []const u8) ?u32 {
+    if (lookupTable(&PROVIDER_MAX_TOKENS, key)) |n| return n;
+    const canonical = provider_names.canonicalProviderNameIgnoreCase(key);
+    if (!std.ascii.eqlIgnoreCase(canonical, key)) {
+        if (lookupTable(&PROVIDER_MAX_TOKENS, canonical)) |n| return n;
+    }
+    return null;
+}
+
 fn splitProviderModel(model_ref: []const u8) struct { provider: ?[]const u8, model: []const u8 } {
     const slash = std.mem.indexOfScalar(u8, model_ref, '/') orelse {
         return .{ .provider = null, .model = model_ref };
@@ -173,6 +183,7 @@ pub fn lookupModelMaxTokens(model_ref_raw: []const u8) ?u32 {
     if (model_ref.len == 0) return null;
 
     if (lookupModelCandidates(model_ref)) |n| return n;
+    if (lookupProviderMaxTokens(model_ref)) |n| return n;
 
     const split = splitProviderModel(model_ref);
     if (lookupModelCandidates(split.model)) |n| return n;
@@ -182,7 +193,7 @@ pub fn lookupModelMaxTokens(model_ref_raw: []const u8) ?u32 {
         const nested_provider = split.model[0..nested_sep];
         const nested_model = split.model[nested_sep + 1 ..];
         if (lookupModelCandidates(nested_model)) |n| return n;
-        if (lookupTable(&PROVIDER_MAX_TOKENS, nested_provider)) |n| return n;
+        if (lookupProviderMaxTokens(nested_provider)) |n| return n;
     }
     if (std.mem.lastIndexOfScalar(u8, split.model, '/')) |last_sep| {
         const leaf_model = split.model[last_sep + 1 ..];
@@ -190,7 +201,7 @@ pub fn lookupModelMaxTokens(model_ref_raw: []const u8) ?u32 {
     }
 
     if (split.provider) |provider| {
-        if (lookupTable(&PROVIDER_MAX_TOKENS, provider)) |n| return n;
+        if (lookupProviderMaxTokens(provider)) |n| return n;
     }
 
     return null;
@@ -226,6 +237,11 @@ test "lookupModelMaxTokens strips date suffixes and latest aliases" {
 
 test "lookupModelMaxTokens provider fallback handles lower ceilings" {
     try std.testing.expectEqual(@as(?u32, 4096), lookupModelMaxTokens("nvidia/custom-model"));
+}
+
+test "lookupModelMaxTokens provider fallback honors canonical aliases" {
+    try std.testing.expectEqual(@as(?u32, 8192), lookupModelMaxTokens("mimo/custom-model"));
+    try std.testing.expectEqual(@as(?u32, 8192), lookupModelMaxTokens("xiaomi-mimo"));
 }
 
 test "resolveMaxTokens falls back to global default" {

--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -106,6 +106,7 @@ pub const known_providers = [_]ProviderInfo{
     // --- Tier 4: AI platform specialists ---
     .{ .key = "venice", .label = "Venice", .default_model = "llama-4-70b-instruct", .env_var = "VENICE_API_KEY" },
     .{ .key = "moonshot", .label = "Moonshot (Kimi)", .default_model = "kimi-k2.5", .env_var = "MOONSHOT_API_KEY" },
+    .{ .key = "xiaomi", .label = "Xiaomi MiMo", .default_model = "mimo-v2-pro", .env_var = "MIMO_API_KEY" },
     .{ .key = "synthetic", .label = "Synthetic", .default_model = "synthetic-model", .env_var = "SYNTHETIC_API_KEY" },
     .{ .key = "opencode-zen", .label = "OpenCode Zen", .default_model = "opencode-model", .env_var = "OPENCODE_API_KEY" },
     .{ .key = "minimax", .label = "MiniMax", .default_model = "minimax-m2.1", .env_var = "MINIMAX_API_KEY" },
@@ -3021,6 +3022,8 @@ test "canonicalProviderName handles aliases" {
     try std.testing.expectEqualStrings("claude-cli", canonicalProviderName("claude-code"));
     try std.testing.expectEqualStrings("azure", canonicalProviderName("azure-openai"));
     try std.testing.expectEqualStrings("azure", canonicalProviderName("azure_openai"));
+    try std.testing.expectEqualStrings("xiaomi", canonicalProviderName("xiaomi-mimo"));
+    try std.testing.expectEqualStrings("xiaomi", canonicalProviderName("mimo"));
     try std.testing.expectEqualStrings("openai", canonicalProviderName("openai"));
 }
 
@@ -3029,6 +3032,8 @@ test "defaultModelForProvider returns known models" {
     try std.testing.expectEqualStrings("gpt-5.2", defaultModelForProvider("openai"));
     try std.testing.expectEqualStrings("gpt-5.2-chat", defaultModelForProvider("azure"));
     try std.testing.expectEqualStrings("deepseek-chat", defaultModelForProvider("deepseek"));
+    try std.testing.expectEqualStrings("mimo-v2-pro", defaultModelForProvider("xiaomi"));
+    try std.testing.expectEqualStrings("mimo-v2-pro", defaultModelForProvider("mimo"));
     try std.testing.expectEqualStrings("llama4", defaultModelForProvider("ollama"));
     try std.testing.expectEqualStrings(codex_support.DEFAULT_CODEX_MODEL, defaultModelForProvider("codex-cli"));
     try std.testing.expectEqualStrings(codex_support.DEFAULT_CODEX_MODEL, defaultModelForProvider("openai-codex"));
@@ -3043,11 +3048,17 @@ test "providerEnvVar known providers" {
     try std.testing.expectEqualStrings("ANTHROPIC_API_KEY", providerEnvVar("anthropic"));
     try std.testing.expectEqualStrings("OPENAI_API_KEY", providerEnvVar("openai"));
     try std.testing.expectEqualStrings("AZURE_OPENAI_API_KEY", providerEnvVar("azure"));
+    try std.testing.expectEqualStrings("MIMO_API_KEY", providerEnvVar("xiaomi"));
     try std.testing.expectEqualStrings("API_KEY", providerEnvVar("ollama"));
 }
 
 test "providerEnvVar grok alias maps to xai" {
     try std.testing.expectEqualStrings("XAI_API_KEY", providerEnvVar("grok"));
+}
+
+test "providerEnvVar xiaomi aliases" {
+    try std.testing.expectEqualStrings("MIMO_API_KEY", providerEnvVar("xiaomi-mimo"));
+    try std.testing.expectEqualStrings("MIMO_API_KEY", providerEnvVar("mimo"));
 }
 
 test "providerEnvVar unknown falls back" {

--- a/src/provider_names.zig
+++ b/src/provider_names.zig
@@ -8,6 +8,7 @@ pub fn canonicalProviderName(name: []const u8) []const u8 {
     if (std.mem.eql(u8, name, "claude-code")) return "claude-cli";
     if (std.mem.eql(u8, name, "azure-openai") or std.mem.eql(u8, name, "azure_openai")) return "azure";
     if (std.mem.eql(u8, name, "novita-ai")) return "novita";
+    if (std.mem.eql(u8, name, "xiaomi-mimo") or std.mem.eql(u8, name, "mimo")) return "xiaomi";
     return name;
 }
 
@@ -19,6 +20,7 @@ pub fn canonicalProviderNameIgnoreCase(name: []const u8) []const u8 {
     if (std.ascii.eqlIgnoreCase(name, "claude-code")) return "claude-cli";
     if (std.ascii.eqlIgnoreCase(name, "azure-openai") or std.ascii.eqlIgnoreCase(name, "azure_openai")) return "azure";
     if (std.ascii.eqlIgnoreCase(name, "novita-ai")) return "novita";
+    if (std.ascii.eqlIgnoreCase(name, "xiaomi-mimo") or std.ascii.eqlIgnoreCase(name, "mimo")) return "xiaomi";
     return name;
 }
 
@@ -41,15 +43,19 @@ test "canonicalProviderName handles supported aliases" {
     try std.testing.expectEqualStrings("azure", canonicalProviderName("azure-openai"));
     try std.testing.expectEqualStrings("azure", canonicalProviderName("azure_openai"));
     try std.testing.expectEqualStrings("novita", canonicalProviderName("novita-ai"));
+    try std.testing.expectEqualStrings("xiaomi", canonicalProviderName("xiaomi-mimo"));
+    try std.testing.expectEqualStrings("xiaomi", canonicalProviderName("mimo"));
 }
 
 test "providerNamesMatch handles aliases without broadening custom providers" {
     try std.testing.expect(providerNamesMatch("azure", "azure-openai"));
     try std.testing.expect(providerNamesMatch("gemini", "google"));
+    try std.testing.expect(providerNamesMatch("xiaomi", "mimo"));
     try std.testing.expect(!providerNamesMatch("custom:https://Example.com/v1", "custom:https://example.com/v1"));
 }
 
 test "providerNamesMatchIgnoreCase preserves case-insensitive matching" {
     try std.testing.expect(providerNamesMatchIgnoreCase("azure", "AZURE-OPENAI"));
+    try std.testing.expect(providerNamesMatchIgnoreCase("xiaomi", "MIMO"));
     try std.testing.expect(providerNamesMatchIgnoreCase("CustomGW", "customgw"));
 }

--- a/src/providers/api_key.zig
+++ b/src/providers/api_key.zig
@@ -324,6 +324,7 @@ fn providerEnvCandidates(name: []const u8) [3][]const u8 {
         .{ "poe", .{ "POE_API_KEY", "", "" } },
         .{ "moonshot", .{ "MOONSHOT_API_KEY", "", "" } },
         .{ "kimi", .{ "MOONSHOT_API_KEY", "", "" } },
+        .{ "xiaomi", .{ "MIMO_API_KEY", "", "" } },
         .{ "bedrock", .{ "AWS_ACCESS_KEY_ID", "", "" } },
         .{ "aws-bedrock", .{ "AWS_ACCESS_KEY_ID", "", "" } },
         .{ "cloudflare", .{ "CLOUDFLARE_API_TOKEN", "", "" } },
@@ -406,6 +407,12 @@ test "azure aliases share Azure env candidate" {
     try std.testing.expectEqualStrings("AZURE_OPENAI_API_KEY", providerEnvCandidates("azure")[0]);
     try std.testing.expectEqualStrings("AZURE_OPENAI_API_KEY", providerEnvCandidates("azure-openai")[0]);
     try std.testing.expectEqualStrings("AZURE_OPENAI_API_KEY", providerEnvCandidates("azure_openai")[0]);
+}
+
+test "xiaomi aliases share MIMO env candidate" {
+    try std.testing.expectEqualStrings("MIMO_API_KEY", providerEnvCandidates("xiaomi")[0]);
+    try std.testing.expectEqualStrings("MIMO_API_KEY", providerEnvCandidates("xiaomi-mimo")[0]);
+    try std.testing.expectEqualStrings("MIMO_API_KEY", providerEnvCandidates("mimo")[0]);
 }
 
 test "providerEnvCandidates includes onboarding env hints" {

--- a/src/providers/factory.zig
+++ b/src/providers/factory.zig
@@ -45,6 +45,8 @@ const CompatProvider = struct {
     merge_system_into_user: bool = false,
     /// Authentication style (default: Bearer token).
     auth_style: compatible.AuthStyle = .bearer,
+    /// Custom auth header name when auth_style is .custom.
+    custom_header: ?[]const u8 = null,
     /// Whether this provider supports native OpenAI-style tool_calls.
     native_tools: bool = true,
     /// When set, cap max_tokens in non-streaming requests to this value.
@@ -109,6 +111,7 @@ const compat_providers = [_]CompatProvider{
     .{ .name = "doubao", .url = "https://ark.cn-beijing.volces.com/api/v3", .display = "Doubao" },
     .{ .name = "volcengine", .url = "https://ark.cn-beijing.volces.com/api/v3", .display = "Doubao" },
     .{ .name = "ark", .url = "https://ark.cn-beijing.volces.com/api/v3", .display = "Doubao" },
+    .{ .name = "xiaomi", .url = "https://api.xiaomimimo.com/v1", .display = "Xiaomi MiMo", .auth_style = .custom, .custom_header = "api-key" },
     .{ .name = "hunyuan", .url = "https://api.hunyuan.cloud.tencent.com/v1", .display = "Hunyuan" },
     .{ .name = "tencent", .url = "https://api.hunyuan.cloud.tencent.com/v1", .display = "Hunyuan" },
     .{ .name = "baichuan", .url = "https://api.baichuan-ai.com/v1", .display = "Baichuan" },
@@ -191,6 +194,12 @@ comptime {
 fn findCompatProvider(name: []const u8) ?CompatProvider {
     for (&compat_providers) |*p| {
         if (std.mem.eql(u8, p.name, name)) return p.*;
+    }
+    const canonical = provider_names.canonicalProviderName(name);
+    if (!std.mem.eql(u8, canonical, name)) {
+        for (&compat_providers) |*p| {
+            if (std.mem.eql(u8, p.name, canonical)) return p.*;
+        }
     }
     return null;
 }
@@ -396,6 +405,7 @@ pub const ProviderHolder = union(enum) {
                 if (cp) |c| {
                     if (c.no_responses_fallback) prov.supports_responses_fallback = false;
                     if (c.merge_system_into_user) prov.merge_system_into_user = true;
+                    if (c.custom_header) |header| prov.custom_header = header;
                     if (!c.native_tools) prov.native_tools = false;
                     if (c.max_tokens_non_streaming) |cap| prov.max_tokens_non_streaming = cap;
                     if (c.thinking_param) prov.thinking_param = true;
@@ -496,6 +506,9 @@ test "classifyProvider new providers" {
     try std.testing.expect(classifyProvider("glm-cn") == .compatible_provider);
     try std.testing.expect(classifyProvider("bigmodel") == .compatible_provider);
     try std.testing.expect(classifyProvider("qwen-portal") == .compatible_provider);
+    try std.testing.expect(classifyProvider("xiaomi") == .compatible_provider);
+    try std.testing.expect(classifyProvider("xiaomi-mimo") == .compatible_provider);
+    try std.testing.expect(classifyProvider("mimo") == .compatible_provider);
 }
 
 test "compatibleProviderUrl returns correct URLs" {
@@ -537,6 +550,9 @@ test "compatibleProviderUrl new providers" {
     try std.testing.expectEqualStrings("https://api.kimi.com/coding/v1", compatibleProviderUrl("kimi-code").?);
     try std.testing.expectEqualStrings("https://portal.qwen.ai/v1", compatibleProviderUrl("qwen-portal").?);
     try std.testing.expectEqualStrings("https://api.telnyx.com/v2/ai", compatibleProviderUrl("telnyx").?);
+    try std.testing.expectEqualStrings("https://api.xiaomimimo.com/v1", compatibleProviderUrl("xiaomi").?);
+    try std.testing.expectEqualStrings("https://api.xiaomimimo.com/v1", compatibleProviderUrl("xiaomi-mimo").?);
+    try std.testing.expectEqualStrings("https://api.xiaomimimo.com/v1", compatibleProviderUrl("mimo").?);
 }
 
 test "normalizeAzureBaseUrlOwned appends openai v1 path" {
@@ -608,6 +624,9 @@ test "new providers display names" {
     try std.testing.expectEqualStrings("Baichuan", compatibleProviderDisplayName("baichuan"));
     try std.testing.expectEqualStrings("Novita", compatibleProviderDisplayName("novita"));
     try std.testing.expectEqualStrings("Novita", compatibleProviderDisplayName("novita-ai"));
+    try std.testing.expectEqualStrings("Xiaomi MiMo", compatibleProviderDisplayName("xiaomi"));
+    try std.testing.expectEqualStrings("Xiaomi MiMo", compatibleProviderDisplayName("xiaomi-mimo"));
+    try std.testing.expectEqualStrings("Xiaomi MiMo", compatibleProviderDisplayName("mimo"));
     try std.testing.expectEqualStrings("Custom", compatibleProviderDisplayName("nonexistent"));
     try std.testing.expectEqualStrings("Telnyx", compatibleProviderDisplayName("telnyx"));
 }
@@ -625,6 +644,9 @@ test "new providers classify as compatible" {
     try std.testing.expect(classifyProvider("baichuan") == .compatible_provider);
     try std.testing.expect(classifyProvider("novita") == .compatible_provider);
     try std.testing.expect(classifyProvider("novita-ai") == .compatible_provider);
+    try std.testing.expect(classifyProvider("xiaomi") == .compatible_provider);
+    try std.testing.expect(classifyProvider("xiaomi-mimo") == .compatible_provider);
+    try std.testing.expect(classifyProvider("mimo") == .compatible_provider);
 }
 
 test "findCompatProvider returns correct flags" {
@@ -681,6 +703,14 @@ test "findCompatProvider returns correct flags" {
     // Fireworks has non-streaming max_tokens cap.
     const fireworks = findCompatProvider("fireworks").?;
     try std.testing.expectEqual(@as(?u32, 4096), fireworks.max_tokens_non_streaming);
+
+    // Xiaomi MiMo uses api-key instead of bearer auth.
+    const xiaomi = findCompatProvider("xiaomi").?;
+    try std.testing.expect(xiaomi.auth_style == .custom);
+    try std.testing.expectEqualStrings("api-key", xiaomi.custom_header.?);
+    const xiaomi_alias = findCompatProvider("mimo").?;
+    try std.testing.expect(xiaomi_alias.auth_style == .custom);
+    try std.testing.expectEqualStrings("api-key", xiaomi_alias.custom_header.?);
 }
 
 test "fromConfig keeps native_tools enabled for z.ai/glm aliases" {
@@ -959,6 +989,19 @@ test "ProviderHolder.fromConfig routes to correct variant" {
     defer h6b.deinit();
     try std.testing.expect(h6b == .compatible);
     try std.testing.expectEqualStrings("https://api.telnyx.com/v2/ai", h6b.compatible.base_url);
+    // compatible (xiaomi from built-in table URL and custom auth header)
+    var h6c = ProviderHolder.fromConfig(alloc, "xiaomi", "test-key", null, true, null, null);
+    defer h6c.deinit();
+    try std.testing.expect(h6c == .compatible);
+    try std.testing.expectEqualStrings("https://api.xiaomimimo.com/v1", h6c.compatible.base_url);
+    try std.testing.expect(h6c.compatible.auth_style == .custom);
+    try std.testing.expectEqualStrings("api-key", h6c.compatible.custom_header.?);
+    var h6d = ProviderHolder.fromConfig(alloc, "mimo", "test-key", null, true, null, null);
+    defer h6d.deinit();
+    try std.testing.expect(h6d == .compatible);
+    try std.testing.expectEqualStrings("https://api.xiaomimimo.com/v1", h6d.compatible.base_url);
+    try std.testing.expect(h6d.compatible.auth_style == .custom);
+    try std.testing.expectEqualStrings("api-key", h6d.compatible.custom_header.?);
     // openai-codex
     var h7 = ProviderHolder.fromConfig(alloc, "openai-codex", null, null, true, null, null);
     defer h7.deinit();


### PR DESCRIPTION
## Summary

### EN:
- add Xiaomi MiMo as a built-in OpenAI-compatible provider with the official https://api.xiaomimimo.com/v1 base URL
- support `xiaomi`, `xiaomi-mimo`, and `mimo` aliases, with `xiaomi` as the canonical provider key
- use Xiaomi's required `api-key` authentication header instead of bearer auth
- wire onboarding and API key resolution to `MIMO_API_KEY`, with `mimo-v2-pro` as the default quick-setup model
- add regression coverage for provider classification, URL/display lookup, auth header wiring, alias resolution, and onboarding env hints

### ZH:
- 新增内置的 Xiaomi MiMo OpenAI 兼容提供方，使用官方 https://api.xiaomimimo.com/v1 基础地址
- 支持 `xiaomi`、`xiaomi-mimo` 和 `mimo` 三个别名，并将 `xiaomi` 作为规范 provider key
- 按照 Xiaomi 接口要求使用 `api-key` 认证请求头，而不是 Bearer 认证
- 在引导配置和 API key 解析流程中接入 `MIMO_API_KEY`，并将 `mimo-v2-pro` 设为快速配置默认模型
- 补充回归测试，覆盖 provider 分类、URL/显示名查找、认证请求头绑定、别名解析以及引导配置中的环境变量提示

## Validation

- `zig build test --summary all`

## Notes

- this follows Xiaomi's OpenAI-compatible API docs and keeps the integration within the existing compatible-provider registry instead of adding a dedicated provider implementation
- 该改动基于 Xiaomi 的 OpenAI 兼容接口文档实现，并继续沿用现有 compatible provider 注册表，不新增专用 provider 实现
