### PR TITLE
Surface provider API details in channel-loop errors | 在 channel-loop 错误中展示 provider API 细节

### DIFF
--- a/src/channel_loop.zig
+++ b/src/channel_loop.zig
@@ -107,6 +107,15 @@ fn defaultAgentErrorMessage(err: anyerror) []const u8 {
     };
 }
 
+fn compactAgentErrorMessage(err: anyerror) []const u8 {
+    return switch (err) {
+        error.ProviderDoesNotSupportVision => "The current provider does not support image input.",
+        error.NoResponseContent => "Model returned an empty response. Please try again.",
+        error.CurlFailed, error.CurlReadError, error.CurlWaitError, error.CurlWriteError, error.CurlDnsError, error.CurlConnectError, error.CurlTimeout, error.CurlTlsError, error.AllProvidersFailed, error.OutOfMemory => defaultAgentErrorMessage(err),
+        else => "An error occurred. Try again.",
+    };
+}
+
 const TelegramSessionTarget = struct {
     base_chat_id: []const u8,
     thread_id: ?i64,
@@ -1634,15 +1643,10 @@ pub fn runSignalLoop(
             });
 
             const reply = runtime.session_mgr.processMessage(session_key, msg.content, conversation_context) catch |err| {
-                log.err("Signal agent error: {}", .{err});
-                const err_msg: []const u8 = switch (err) {
-                    error.CurlFailed, error.CurlReadError, error.CurlWaitError, error.CurlWriteError, error.CurlDnsError, error.CurlConnectError, error.CurlTimeout, error.CurlTlsError => "Network error contacting provider. Check base_url, DNS, proxy, and TLS certificates, then try again.",
-                    error.ProviderDoesNotSupportVision => "The current provider does not support image input.",
-                    error.NoResponseContent => "Model returned an empty response. Please try again.",
-                    error.AllProvidersFailed => "All configured providers failed for this request. Check model/provider compatibility and credentials.",
-                    error.OutOfMemory => "Out of memory.",
-                    else => "An error occurred. Try again.",
-                };
+                logAgentProcessingError(allocator, "Signal agent error", err);
+                const owned_err_msg = detailedProviderErrorForDisplay(allocator, err) catch null;
+                defer if (owned_err_msg) |owned_msg| allocator.free(owned_msg);
+                const err_msg = owned_err_msg orelse compactAgentErrorMessage(err);
                 if (msg.reply_target) |target| {
                     sg_ptr.sendMessage(target, err_msg, &.{}) catch |send_err| log.err("failed to send signal error reply: {}", .{send_err});
                 }
@@ -1868,15 +1872,10 @@ pub fn runMatrixLoop(
             });
 
             const reply = runtime.session_mgr.processMessage(session_key, msg.content, conversation_context) catch |err| {
-                log.err("Matrix agent error: {}", .{err});
-                const err_msg: []const u8 = switch (err) {
-                    error.CurlFailed, error.CurlReadError, error.CurlWaitError, error.CurlWriteError, error.CurlDnsError, error.CurlConnectError, error.CurlTimeout, error.CurlTlsError => "Network error contacting provider. Check base_url, DNS, proxy, and TLS certificates, then try again.",
-                    error.ProviderDoesNotSupportVision => "The current provider does not support image input.",
-                    error.NoResponseContent => "Model returned an empty response. Please try again.",
-                    error.AllProvidersFailed => "All configured providers failed for this request. Check model/provider compatibility and credentials.",
-                    error.OutOfMemory => "Out of memory.",
-                    else => "An error occurred. Try again.",
-                };
+                logAgentProcessingError(allocator, "Matrix agent error", err);
+                const owned_err_msg = detailedProviderErrorForDisplay(allocator, err) catch null;
+                defer if (owned_err_msg) |owned_msg| allocator.free(owned_msg);
+                const err_msg = owned_err_msg orelse compactAgentErrorMessage(err);
                 mx_ptr.sendMessage(typing_target, err_msg) catch |send_err| log.err("failed to send matrix error reply: {}", .{send_err});
                 continue;
             };
@@ -2018,11 +2017,7 @@ pub fn runMaxLoop(
                 logAgentProcessingError(allocator, "Max agent error", err);
                 const owned_err_msg = detailedProviderErrorForDisplay(allocator, err) catch null;
                 defer if (owned_err_msg) |owned_msg| allocator.free(owned_msg);
-                const err_msg = owned_err_msg orelse switch (err) {
-                    error.ProviderDoesNotSupportVision => "The current provider does not support image input.",
-                    error.NoResponseContent => "Model returned an empty response. Please try again.",
-                    else => defaultAgentErrorMessage(err),
-                };
+                const err_msg = owned_err_msg orelse compactAgentErrorMessage(err);
                 mx_ptr.sendMessage(reply_target, err_msg) catch |send_err| log.err("failed to send max error reply: {}", .{send_err});
                 continue;
             };
@@ -2453,6 +2448,11 @@ test "detailedProviderErrorForDisplay ignores non-provider errors" {
 
     providers.setLastApiErrorDetail("compatible", "status=429 message=Rate limit exceeded");
     try std.testing.expect((try detailedProviderErrorForDisplay(allocator, error.OutOfMemory)) == null);
+}
+
+test "compactAgentErrorMessage keeps non-telegram fallback concise" {
+    // Regression: Signal/Matrix/Max should not inherit Telegram's `/new` guidance for generic failures.
+    try std.testing.expectEqualStrings("An error occurred. Try again.", compactAgentErrorMessage(error.Unexpected));
 }
 
 test "telegram update offset store returns null for mismatched bot id" {


### PR DESCRIPTION
## Summary

### EN:
- enrich channel-loop provider failures with the existing sanitized provider API error detail when available
- improve user-facing fallback messages for `ApiError`, `ProviderError`, and `AllProvidersFailed` instead of only logging the bare error enum
- keep the change local to `channel_loop` by reusing the provider error detail infrastructure that already exists

### ZH:
- 在可用时，将现有的已脱敏 provider API 错误详情带入 channel loop 的失败日志
- 针对 `ApiError`、`ProviderError` 和 `AllProvidersFailed` 改进用户侧兜底报错，不再只暴露裸错误枚举
- 该改动仅限于 `channel_loop`，复用项目中已有的 provider 错误详情机制，不新增额外错误框架

## Validation

- `zig build test --summary all`

## Notes

- this addresses #619 by making daemon/channel error reporting more actionable for operators without broadening sensitive logging
- 该改动对应 #619，使 daemon/channel 层的错误信息更便于排查，同时不放宽敏感信息日志边界
