### PR TITLE
fix(ollama): avoid empty chat responses by default / 修复 Ollama 默认空响应问题

### DIFF
--- a/src/providers/ollama.zig
+++ b/src/providers/ollama.zig
@@ -171,6 +171,7 @@ fn appendOllamaImageValue(
 fn appendThinkField(
     buf: *std.ArrayListUnmanaged(u8),
     allocator: std.mem.Allocator,
+    model: []const u8,
     reasoning_effort: ?[]const u8,
 ) !void {
     const effort = root.normalizeOpenAiReasoningEffort(reasoning_effort) orelse {
@@ -182,7 +183,22 @@ fn appendThinkField(
         return;
     }
     try buf.appendSlice(allocator, ",\"think\":");
-    try root.appendJsonString(buf, allocator, effort);
+    if (ollamaUsesThinkLevels(model)) {
+        try root.appendJsonString(buf, allocator, effort);
+        return;
+    }
+    try buf.appendSlice(allocator, "true");
+}
+
+// GPT-OSS is the documented Ollama exception: it requires string levels rather than booleans.
+fn ollamaUsesThinkLevels(model: []const u8) bool {
+    var lower_buf: [160]u8 = undefined;
+    const lower_len = @min(model.len, lower_buf.len);
+    for (model[0..lower_len], 0..) |c, idx| {
+        lower_buf[idx] = std.ascii.toLower(c);
+    }
+    const lower = lower_buf[0..lower_len];
+    return std.mem.indexOf(u8, lower, "gpt-oss") != null;
 }
 
 /// Ollama LLM provider.
@@ -418,7 +434,7 @@ fn buildChatRequestBody(
     }
 
     try buf.append(allocator, ']');
-    try appendThinkField(&buf, allocator, request.reasoning_effort);
+    try appendThinkField(&buf, allocator, model, request.reasoning_effort);
 
     if (request.tools) |tools| {
         if (tools.len > 0) {
@@ -664,7 +680,7 @@ test "ollama buildChatRequestBody sends think disabled by default" {
     try std.testing.expect(std.mem.indexOf(u8, body, "\"think\":false") != null);
 }
 
-test "ollama buildChatRequestBody maps reasoning_effort to think level" {
+test "ollama buildChatRequestBody enables think for standard thinking models" {
     const alloc = std.testing.allocator;
     var msgs = [_]root.ChatMessage{
         root.ChatMessage.user("Hello"),
@@ -675,7 +691,29 @@ test "ollama buildChatRequestBody maps reasoning_effort to think level" {
         .reasoning_effort = "high",
     }, "qwen3", 0.7);
     defer alloc.free(body);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"think\":\"high\"") != null);
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    const think = parsed.value.object.get("think").?;
+    try std.testing.expect(think == .bool);
+    try std.testing.expect(think.bool);
+}
+
+test "ollama buildChatRequestBody maps reasoning_effort to think level for gpt-oss" {
+    const alloc = std.testing.allocator;
+    var msgs = [_]root.ChatMessage{
+        root.ChatMessage.user("Hello"),
+    };
+    const body = try buildChatRequestBody(alloc, .{
+        .messages = &msgs,
+        .model = "gpt-oss:20b",
+        .reasoning_effort = "xhigh",
+    }, "gpt-oss:20b", 0.7);
+    defer alloc.free(body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    const think = parsed.value.object.get("think").?;
+    try std.testing.expect(think == .string);
+    try std.testing.expectEqualStrings("high", think.string);
 }
 
 test "extractToolNameAndArgs with nested tool_call wrapper" {


### PR DESCRIPTION
## Summary
- Fix `ollama` chat requests to send `"think":false` by default so plain interactive turns do not fall into empty-content responses on models that implicitly enable thinking.
- Map `reasoning_effort` to Ollama's `think` field when reasoning is explicitly requested, keeping reasoning-capable models usable instead of disabling the feature entirely.
- Treat truly empty Ollama chat payloads as `error.NoResponseContent` and add regression tests for the request/response behavior.

## 摘要
- 修复 `ollama` chat 请求：默认发送 `"think":false`，避免某些默认开启思考模式的模型在普通交互轮次里返回空内容。
- 当显式配置 `reasoning_effort` 时，把它映射到 Ollama 的 `think` 字段，既修掉空响应问题，也保留推理模型的可用性。
- 将真正的空 Ollama 响应明确视为 `error.NoResponseContent`，并补上对应的回归测试。

## Validation
- `zig build test --summary all`

## 验证
- `zig build test --summary all`

## Notes
- Closes #665.
- I could not run a live Ollama reproduction in this environment because the `ollama` CLI is not installed here, so the fix is based on the current Ollama API shape plus repository-side regression coverage.
- Risk is limited to `src/providers/ollama.zig`; other providers are unchanged.

## 说明
- 关闭 #665。
- 当前环境没有安装 `ollama` CLI，无法做在线复现；这次修复基于现行 Ollama API 形态和仓库内回归测试完成。
- 风险范围限制在 `src/providers/ollama.zig`，其他 provider 没有改动。
