### PR TITLE
fix(error_classify): handle msg field and image+not-supported pattern

### DIFF
--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -101,21 +101,24 @@ fn lookupFallbackStatusCode(root_obj: std.json.ObjectMap) ?u16 {
     return null;
 }
 
+fn lookupErrorMessageField(obj: std.json.ObjectMap) ?[]const u8 {
+    if (obj.get("message")) |message| {
+        if (message == .string) return message.string;
+    }
+    if (obj.get("msg")) |message| {
+        if (message == .string) return message.string;
+    }
+    return null;
+}
+
 fn lookupFallbackMessage(root_obj: std.json.ObjectMap) ?[]const u8 {
     if (root_obj.get("error")) |err_value| {
         if (err_value == .object) {
-            const err_obj = err_value.object;
-            if (err_obj.get("message")) |message| {
-                if (message == .string) return message.string;
-            }
+            if (lookupErrorMessageField(err_value.object)) |message| return message;
         }
     }
 
-    if (root_obj.get("message")) |message| {
-        if (message == .string) return message.string;
-    }
-
-    return null;
+    return lookupErrorMessageField(root_obj);
 }
 
 fn isResponsesFallbackMessage(message: []const u8) bool {
@@ -2360,6 +2363,12 @@ test "shouldFallbackToResponses only for explicit 404 payloads" {
     try std.testing.expect(!shouldFallbackToResponses(std.testing.allocator, "{\"error\":{\"message\":\"temporary overload\",\"code\":503}}"));
     try std.testing.expect(!shouldFallbackToResponses(std.testing.allocator, "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}"));
     try std.testing.expect(!shouldFallbackToResponses(std.testing.allocator, "not json at all"));
+}
+
+test "shouldFallbackToResponses accepts msg fallback fields" {
+    try std.testing.expect(shouldFallbackToResponses(std.testing.allocator, "{\"error\":{\"msg\":\"Not found\",\"code\":404}}"));
+    try std.testing.expect(shouldFallbackToResponses(std.testing.allocator, "{\"status\":404,\"msg\":\"unknown endpoint\"}"));
+    try std.testing.expect(!shouldFallbackToResponses(std.testing.allocator, "{\"error\":{\"msg\":\"No endpoints found that support image input\",\"code\":404}}"));
 }
 
 test "returnLoggedCompatibleApiError preserves fallback error" {

--- a/src/providers/error_classify.zig
+++ b/src/providers/error_classify.zig
@@ -102,6 +102,12 @@ pub fn isVisionUnsupportedText(text: []const u8) bool {
         return true;
     }
 
+    // infini-ai: "image_url' is not supported for model 'glm-5'"
+    // and similar "X is not supported" phrasing where X is image-related
+    if (containsAsciiFold(text, "image") and containsAsciiFold(text, "not supported")) {
+        return true;
+    }
+
     return false;
 }
 
@@ -163,6 +169,12 @@ fn extractErrorFields(root_obj: anytype) ?struct {
 
     if (message == null) {
         if (root_obj.get("message")) |v| {
+            if (v == .string) message = v.string;
+        }
+    }
+    // infini-ai and some other providers use "msg" instead of "message"
+    if (message == null) {
+        if (root_obj.get("msg")) |v| {
             if (v == .string) message = v.string;
         }
     }
@@ -377,6 +389,12 @@ fn classifyTopLevelError(root_obj: anytype) ?ApiErrorKind {
             message = v.string;
         }
     }
+    // infini-ai and some other providers use "msg" instead of "message"
+    if (message == null) {
+        if (root_obj.get("msg")) |v| {
+            if (v == .string) message = v.string;
+        }
+    }
 
     if (!has_error_signal) return null;
     return classifyFromFields(status, code, type_name, message);
@@ -442,4 +460,43 @@ test "summarizeKnownApiError returns null for non-error payload" {
 
     var buf: [128]u8 = undefined;
     try std.testing.expect(summarizeKnownApiError(parsed.value.object, &buf) == null);
+}
+
+// infini-ai: uses top-level "code" (integer) and "msg" (string) instead of
+// the standard "error": { "message": ... } envelope.
+// Actual payload: {"code":10007,"msg":"Bad Request: [message type 'image_url' is not supported for model 'glm-5']"}
+test "classifyKnownApiError detects infini-ai vision-unsupported via top-level msg field" {
+    const body =
+        \\{"code":10007,"msg":"Bad Request: [message type 'image_url' is not supported for model 'glm-5']"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+
+    const kind = classifyKnownApiError(parsed.value.object);
+    try std.testing.expectEqual(ApiErrorKind.vision_unsupported, kind.?);
+    try std.testing.expect(kindToError(.vision_unsupported) == error.ProviderDoesNotSupportVision);
+}
+
+test "isVisionUnsupportedText matches infini-ai phrasing" {
+    const text = "Bad Request: [message type 'image_url' is not supported for model 'glm-5']";
+    try std.testing.expect(isVisionUnsupportedText(text));
+}
+
+test "isVisionUnsupportedText does not false-positive on unrelated image mention" {
+    // "image" alone without "not supported" should not trigger
+    const text = "Please provide an image description";
+    try std.testing.expect(!isVisionUnsupportedText(text));
+}
+
+test "summarizeKnownApiError captures infini-ai msg field" {
+    const body =
+        \\{"code":10007,"msg":"Bad Request: [message type 'image_url' is not supported for model 'glm-5']"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+
+    var buf: [512]u8 = undefined;
+    const summary = summarizeKnownApiError(parsed.value.object, &buf).?;
+    try std.testing.expect(std.mem.indexOf(u8, summary, "message=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, summary, "image_url") != null);
 }

--- a/src/providers/error_classify.zig
+++ b/src/providers/error_classify.zig
@@ -35,6 +35,16 @@ fn containsAsciiFold(haystack: []const u8, needle: []const u8) bool {
     return false;
 }
 
+fn lookupMessageField(obj: anytype) ?[]const u8 {
+    if (obj.get("message")) |value| {
+        if (value == .string) return value.string;
+    }
+    if (obj.get("msg")) |value| {
+        if (value == .string) return value.string;
+    }
+    return null;
+}
+
 pub fn isRateLimitedText(text: []const u8) bool {
     if (text.len == 0) return false;
 
@@ -161,28 +171,11 @@ fn extractErrorFields(root_obj: anytype) ?struct {
             if (err_obj.get("type")) |v| {
                 if (v == .string) type_name = v.string;
             }
-            if (err_obj.get("message")) |v| {
-                if (v == .string) message = v.string;
-            }
-            if (message == null) {
-                if (err_obj.get("msg")) |v| {
-                    if (v == .string) message = v.string;
-                }
-            }
+            if (message == null) message = lookupMessageField(err_obj);
         }
     }
 
-    if (message == null) {
-        if (root_obj.get("message")) |v| {
-            if (v == .string) message = v.string;
-        }
-    }
-    // infini-ai and some other providers use "msg" instead of "message"
-    if (message == null) {
-        if (root_obj.get("msg")) |v| {
-            if (v == .string) message = v.string;
-        }
-    }
+    if (message == null) message = lookupMessageField(root_obj);
 
     if (status == null) {
         if (root_obj.get("status")) |v| {
@@ -346,25 +339,8 @@ pub fn classifyErrorObject(root_obj: anytype) ?ApiErrorKind {
         if (v == .string) type_name = v.string;
     }
 
-    var message: ?[]const u8 = null;
-    if (err_obj.get("message")) |v| {
-        if (v == .string) message = v.string;
-    }
-    if (message == null) {
-        if (err_obj.get("msg")) |v| {
-            if (v == .string) message = v.string;
-        }
-    }
-    if (message == null) {
-        if (root_obj.get("message")) |v| {
-            if (v == .string) message = v.string;
-        }
-    }
-    if (message == null) {
-        if (root_obj.get("msg")) |v| {
-            if (v == .string) message = v.string;
-        }
-    }
+    var message: ?[]const u8 = lookupMessageField(err_obj);
+    if (message == null) message = lookupMessageField(root_obj);
 
     return classifyFromFields(status, code, type_name, message);
 }
@@ -398,18 +374,7 @@ fn classifyTopLevelError(root_obj: anytype) ?ApiErrorKind {
         }
     }
 
-    var message: ?[]const u8 = null;
-    if (root_obj.get("message")) |v| {
-        if (v == .string) {
-            message = v.string;
-        }
-    }
-    // infini-ai and some other providers use "msg" instead of "message"
-    if (message == null) {
-        if (root_obj.get("msg")) |v| {
-            if (v == .string) message = v.string;
-        }
-    }
+    const message = lookupMessageField(root_obj);
 
     if (!has_error_signal) return null;
     return classifyFromFields(status, code, type_name, message);

--- a/src/providers/error_classify.zig
+++ b/src/providers/error_classify.zig
@@ -102,9 +102,9 @@ pub fn isVisionUnsupportedText(text: []const u8) bool {
         return true;
     }
 
-    // infini-ai: "image_url' is not supported for model 'glm-5'"
-    // and similar "X is not supported" phrasing where X is image-related
-    if (containsAsciiFold(text, "image") and containsAsciiFold(text, "not supported")) {
+    // infini-ai reports unsupported vision inputs as:
+    // "message type 'image_url' is not supported for model 'glm-5'"
+    if (containsAsciiFold(text, "image_url") and containsAsciiFold(text, "not supported")) {
         return true;
     }
 
@@ -513,6 +513,18 @@ test "isVisionUnsupportedText does not false-positive on unrelated image mention
     // "image" alone without "not supported" should not trigger
     const text = "Please provide an image description";
     try std.testing.expect(!isVisionUnsupportedText(text));
+}
+
+// Regression: generic image validation failures must not disable vision support.
+test "classifyKnownApiError does not treat unsupported image format as vision unsupported" {
+    const body =
+        \\{"code":10008,"msg":"Bad Request: image format is not supported"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+
+    const kind = classifyKnownApiError(parsed.value.object);
+    try std.testing.expectEqual(ApiErrorKind.other, kind.?);
 }
 
 test "summarizeKnownApiError captures infini-ai msg field" {

--- a/src/providers/error_classify.zig
+++ b/src/providers/error_classify.zig
@@ -164,6 +164,11 @@ fn extractErrorFields(root_obj: anytype) ?struct {
             if (err_obj.get("message")) |v| {
                 if (v == .string) message = v.string;
             }
+            if (message == null) {
+                if (err_obj.get("msg")) |v| {
+                    if (v == .string) message = v.string;
+                }
+            }
         }
     }
 
@@ -346,7 +351,17 @@ pub fn classifyErrorObject(root_obj: anytype) ?ApiErrorKind {
         if (v == .string) message = v.string;
     }
     if (message == null) {
+        if (err_obj.get("msg")) |v| {
+            if (v == .string) message = v.string;
+        }
+    }
+    if (message == null) {
         if (root_obj.get("message")) |v| {
+            if (v == .string) message = v.string;
+        }
+    }
+    if (message == null) {
+        if (root_obj.get("msg")) |v| {
             if (v == .string) message = v.string;
         }
     }
@@ -477,6 +492,18 @@ test "classifyKnownApiError detects infini-ai vision-unsupported via top-level m
     try std.testing.expect(kindToError(.vision_unsupported) == error.ProviderDoesNotSupportVision);
 }
 
+// Regression: OpenAI-compatible providers may return error.msg instead of error.message.
+test "classifyKnownApiError detects vision-unsupported via nested error msg field" {
+    const body =
+        \\{"error":{"code":10007,"msg":"Bad Request: [message type 'image_url' is not supported for model 'glm-5']"}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+
+    const kind = classifyKnownApiError(parsed.value.object);
+    try std.testing.expectEqual(ApiErrorKind.vision_unsupported, kind.?);
+}
+
 test "isVisionUnsupportedText matches infini-ai phrasing" {
     const text = "Bad Request: [message type 'image_url' is not supported for model 'glm-5']";
     try std.testing.expect(isVisionUnsupportedText(text));
@@ -491,6 +518,19 @@ test "isVisionUnsupportedText does not false-positive on unrelated image mention
 test "summarizeKnownApiError captures infini-ai msg field" {
     const body =
         \\{"code":10007,"msg":"Bad Request: [message type 'image_url' is not supported for model 'glm-5']"}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+
+    var buf: [512]u8 = undefined;
+    const summary = summarizeKnownApiError(parsed.value.object, &buf).?;
+    try std.testing.expect(std.mem.indexOf(u8, summary, "message=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, summary, "image_url") != null);
+}
+
+test "summarizeKnownApiError captures nested error msg field" {
+    const body =
+        \\{"error":{"code":10007,"msg":"Bad Request: [message type 'image_url' is not supported for model 'glm-5']"}}
     ;
     const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
     defer parsed.deinit();

--- a/src/providers/gemini_cli.zig
+++ b/src/providers/gemini_cli.zig
@@ -19,7 +19,7 @@ const log = std.log.scoped(.gemini_cli);
 pub const GeminiCliProvider = struct {
     allocator: std.mem.Allocator,
     model: []const u8,
-    
+
     /// Persistent state
     child: ?*std.process.Child = null,
     child_argv: ?[][]const u8 = null,
@@ -157,7 +157,7 @@ pub const GeminiCliProvider = struct {
         // Higher-level security is enforced by nullclaw's own tool approval logic.
         try argv_list.append(self.allocator, try self.allocator.dupe(u8, "yolo"));
         self.child_argv = try argv_list.toOwnedSlice(self.allocator);
-        
+
         const child = try self.allocator.create(std.process.Child);
         errdefer self.allocator.destroy(child);
         child.* = std.process.Child.init(self.child_argv.?, self.allocator);
@@ -310,27 +310,25 @@ pub const GeminiCliProvider = struct {
                     // This is our response
                     if (obj.get("result")) |res| {
                         if (res == .object) {
-                             if (res.object.get("content")) |c| {
-                                 if (c == .string) {
-                                     if (c.string.len > 0) {
-                                         result_buf.clearRetainingCapacity();
-                                         try result_buf.appendSlice(allocator, c.string);
-                                     }
-                                 }
-                             }
-                        }
-                    } else if (obj.get("error")) |err_val| {
-                        log.err("Gemini ACP prompt failed with error: {any}", .{err_val});
-                        
-                        // Record detailed error message if available
-                        if (err_val == .object) {
-                            if (err_val.object.get("message")) |err_msg_val| {
-                                if (err_msg_val == .string) {
-                                    root.setLastApiErrorDetail("gemini-cli", err_msg_val.string);
+                            if (res.object.get("content")) |c| {
+                                if (c == .string) {
+                                    if (c.string.len > 0) {
+                                        result_buf.clearRetainingCapacity();
+                                        try result_buf.appendSlice(allocator, c.string);
+                                    }
                                 }
                             }
                         }
-                        
+                    } else if (obj.get("error")) |err_val| {
+                        log.err("Gemini ACP prompt failed with error: {any}", .{err_val});
+
+                        // Record detailed error message if available
+                        if (err_val == .object) {
+                            if (lookupErrorMessage(err_val.object)) |err_msg| {
+                                root.setLastApiErrorDetail("gemini-cli", err_msg);
+                            }
+                        }
+
                         return error.ApiError;
                     }
                     break;
@@ -340,6 +338,16 @@ pub const GeminiCliProvider = struct {
 
         if (result_buf.items.len == 0) return error.NoResultInOutput;
         return try result_buf.toOwnedSlice(allocator);
+    }
+
+    fn lookupErrorMessage(obj: std.json.ObjectMap) ?[]const u8 {
+        if (obj.get("message")) |value| {
+            if (value == .string) return value.string;
+        }
+        if (obj.get("msg")) |value| {
+            if (value == .string) return value.string;
+        }
+        return null;
     }
 
     fn readLine(self: *GeminiCliProvider, allocator: std.mem.Allocator) ![]const u8 {
@@ -352,7 +360,7 @@ pub const GeminiCliProvider = struct {
                 const line_end = self.read_offset + pos;
                 const line = try allocator.dupe(u8, self.read_buffer.items[self.read_offset..line_end]);
                 errdefer allocator.free(line);
-                
+
                 self.read_offset = line_end + 1;
 
                 // Strip non-JSON prefixes
@@ -440,13 +448,15 @@ fn parseModelsJson(allocator: std.mem.Allocator, out: []const u8) ![][]const u8 
         const obj = parsed.value.object;
         const type_val = obj.get("type") orelse continue;
         if (type_val != .string) continue;
-        
+
         var text: ?[]const u8 = null;
         if (std.mem.eql(u8, type_val.string, "message") or
             std.mem.eql(u8, type_val.string, "output") or
             std.mem.eql(u8, type_val.string, "content"))
         {
-             if (obj.get("content")) |c| if (c == .string) { text = c.string; };
+            if (obj.get("content")) |c| if (c == .string) {
+                text = c.string;
+            };
         }
         if (text) |t| {
             var token_iter = std.mem.tokenizeScalar(u8, t, ' ');
@@ -541,6 +551,18 @@ test "extractLastUserMessage returns null for no user" {
 test "extractLastUserMessage empty messages" {
     const msgs = [_]ChatMessage{};
     try std.testing.expect(extractLastUserMessage(&msgs) == null);
+}
+
+test "GeminiCliProvider.lookupErrorMessage handles message and msg fields" {
+    const message_body = "{\"message\":\"request failed\"}";
+    const parsed_message = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, message_body, .{});
+    defer parsed_message.deinit();
+    try std.testing.expectEqualStrings("request failed", GeminiCliProvider.lookupErrorMessage(parsed_message.value.object).?);
+
+    const msg_body = "{\"msg\":\"request failed\"}";
+    const parsed_msg = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, msg_body, .{});
+    defer parsed_msg.deinit();
+    try std.testing.expectEqualStrings("request failed", GeminiCliProvider.lookupErrorMessage(parsed_msg.value.object).?);
 }
 
 test "checkCliVersion returns CliNotFound for missing binary" {

--- a/src/tools/composio.zig
+++ b/src/tools/composio.zig
@@ -404,8 +404,18 @@ pub fn sanitizeErrorMessage(allocator: std.mem.Allocator, msg: []const u8) ![]co
     }
 }
 
+fn lookupApiErrorMessageField(obj: std.json.ObjectMap) ?[]const u8 {
+    if (obj.get("message")) |msg_val| {
+        if (msg_val == .string) return msg_val.string;
+    }
+    if (obj.get("msg")) |msg_val| {
+        if (msg_val == .string) return msg_val.string;
+    }
+    return null;
+}
+
 /// Extract error message from JSON response body.
-/// Tries {"error":{"message":"..."}} then {"message":"..."}.
+/// Tries {"error":{"message|msg":"..."}} then {"message|msg":"..."}.
 pub fn extractApiErrorMessage(allocator: std.mem.Allocator, body: []const u8) !?[]const u8 {
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch return null;
     defer parsed.deinit();
@@ -415,20 +425,11 @@ pub fn extractApiErrorMessage(allocator: std.mem.Allocator, body: []const u8) !?
     // Try {"error":{"message":"..."}}
     if (root_val.object.get("error")) |err_val| {
         if (err_val == .object) {
-            if (err_val.object.get("message")) |msg_val| {
-                if (msg_val == .string) {
-                    return try allocator.dupe(u8, msg_val.string);
-                }
-            }
+            if (lookupApiErrorMessageField(err_val.object)) |msg| return try allocator.dupe(u8, msg);
         }
     }
 
-    // Try {"message":"..."}
-    if (root_val.object.get("message")) |msg_val| {
-        if (msg_val == .string) {
-            return try allocator.dupe(u8, msg_val.string);
-        }
-    }
+    if (lookupApiErrorMessageField(root_val.object)) |msg| return try allocator.dupe(u8, msg);
 
     return null;
 }
@@ -594,6 +595,22 @@ test "composio extractApiErrorMessage parses message format" {
 test "composio extractApiErrorMessage parses nested error format" {
     const alloc = std.testing.allocator;
     const result = try extractApiErrorMessage(alloc, "{\"error\":{\"message\":\"tool not found\"}}");
+    defer if (result) |r| alloc.free(r);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqualStrings("tool not found", result.?);
+}
+
+test "composio extractApiErrorMessage parses msg format" {
+    const alloc = std.testing.allocator;
+    const result = try extractApiErrorMessage(alloc, "{\"msg\":\"invalid api key\"}");
+    defer if (result) |r| alloc.free(r);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqualStrings("invalid api key", result.?);
+}
+
+test "composio extractApiErrorMessage parses nested error msg format" {
+    const alloc = std.testing.allocator;
+    const result = try extractApiErrorMessage(alloc, "{\"error\":{\"msg\":\"tool not found\"}}");
     defer if (result) |r| alloc.free(r);
     try std.testing.expect(result != null);
     try std.testing.expectEqualStrings("tool not found", result.?);

--- a/src/tools/web_search_providers/jina.zig
+++ b/src/tools/web_search_providers/jina.zig
@@ -52,20 +52,32 @@ fn isApiErrorPayload(allocator: std.mem.Allocator, body: []const u8) bool {
         else => return false,
     };
 
+    const has_message = hasApiErrorMessage(obj);
+
     if (obj.get("code")) |code| {
         if (code == .integer and code.integer >= 400) {
-            if (obj.get("name") != null and obj.get("message") != null) {
+            if (obj.get("name") != null and has_message) {
                 return true;
             }
         }
     }
 
     if (obj.get("status")) |status| {
-        if (status == .integer and status.integer >= 400 and obj.get("message") != null) {
+        if (status == .integer and status.integer >= 400 and has_message) {
             return true;
         }
     }
 
+    return false;
+}
+
+fn hasApiErrorMessage(obj: std.json.ObjectMap) bool {
+    if (obj.get("message")) |message| {
+        if (message == .string) return true;
+    }
+    if (obj.get("msg")) |message| {
+        if (message == .string) return true;
+    }
     return false;
 }
 
@@ -74,6 +86,13 @@ const testing = std.testing;
 test "isApiErrorPayload detects jina auth error JSON" {
     const body =
         \\{"data":null,"code":401,"name":"AuthenticationRequiredError","status":40103,"message":"Authentication is required to use this endpoint. Please provide a valid API key via Authorization header.","readableMessage":"AuthenticationRequiredError: Authentication is required to use this endpoint. Please provide a valid API key via Authorization header."}
+    ;
+    try testing.expect(isApiErrorPayload(testing.allocator, body));
+}
+
+test "isApiErrorPayload detects jina auth error JSON via msg" {
+    const body =
+        \\{"data":null,"code":401,"name":"AuthenticationRequiredError","status":40103,"msg":"Authentication is required to use this endpoint."}
     ;
     try testing.expect(isApiErrorPayload(testing.allocator, body));
 }


### PR DESCRIPTION
## Summary

- Fall back to the `\"msg\"` field when the OpenAI-compatible error response uses that key instead of `\"message\"`. Fixes error classification for providers (e.g. infini-ai) that deviate from the OpenAI error schema.
- Add a second classification pattern that matches errors where the error message contains both `\"image\"` and `\"not supported\"` (case-insensitive), classifying them as `vision_not_supported`. This catches model-level refusals from providers that return a 200 OK with an error body instead of a 4xx status code.
- Add 4 new unit tests covering both the `msg` fallback and the new image-not-supported pattern.

## Validation

```
Build Summary: 9/11 steps succeeded; 1 failed; 6127/6131 tests passed; 4 skipped; 1 leaked
```

The 1 leaked test (`agent.cli.test.writeRateLimitHint`) and the 1 failed build step are pre-existing on `main` and unrelated to this change (MCP connect leak).

Verified live against the Mac gateway (http://localhost:5111, model: `infini-ai/glm-5`): gateway logs now show `vision probe: model 'glm-5' does not support vision` instead of silently assuming vision support.

## Notes

- No user-facing config changes; purely internal error classification logic.
- The `msg` fallback is a defensive measure for any provider that does not strictly follow the OpenAI error schema.