### PR TITLE
fix: respect NULLCLAW_HOME in cron.zig config directory resolution

### DIFF
--- a/src/agent/prompt.zig
+++ b/src/agent/prompt.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const config_paths = @import("../config_paths.zig");
 const config_types = @import("../config_types.zig");
 const fs_compat = @import("../fs_compat.zig");
 const identity_mod = @import("../identity.zig");
-const platform = @import("../platform.zig");
 const memory_root = @import("../memory/root.zig");
 const tools_mod = @import("../tools/root.zig");
 const path_prefix = @import("../path_prefix.zig");
@@ -844,13 +844,8 @@ fn appendSkillsSection(
     w: anytype,
     workspace_dir: []const u8,
 ) !void {
-    // Two-source loading: workspace skills + ~/.nullclaw/skills/
-    const home_dir = platform.getHomeDir(allocator) catch null;
-    defer if (home_dir) |h| allocator.free(h);
-    const community_base = if (home_dir) |h|
-        std.fs.path.join(allocator, &.{ h, ".nullclaw" }) catch null
-    else
-        null;
+    // Two-source loading: workspace skills + config directory skills/
+    const community_base = config_paths.defaultConfigDir(allocator) catch null;
     defer if (community_base) |cb| allocator.free(cb);
 
     // listSkillsMerged already calls checkRequirements on each skill.

--- a/src/auth.zig
+++ b/src/auth.zig
@@ -2,12 +2,12 @@
 //!
 //! Provides reusable OAuth primitives for all providers:
 //! - PKCE challenge generation (RFC 7636)
-//! - Token storage with filesystem-based credential store (~/.nullclaw/auth.json)
+//! - Token storage with filesystem-based credential store (auth.json in the config directory)
 //! - Device Authorization Grant flow (RFC 8628)
 
 const std = @import("std");
+const config_paths = @import("config_paths.zig");
 const fs_compat = @import("fs_compat.zig");
-const platform = @import("platform.zig");
 const json_util = @import("json_util.zig");
 
 // ── PKCE (RFC 7636) ────────────────────────────────────────────────────
@@ -81,8 +81,17 @@ pub const OAuthToken = struct {
 
 // ── Credential Store ───────────────────────────────────────────────────
 
-const CRED_DIR = ".nullclaw";
 const CRED_FILE = "auth.json";
+
+fn credentialFilePathFromConfigDir(allocator: std.mem.Allocator, config_dir: []const u8) ![]u8 {
+    return config_paths.pathFromConfigDir(allocator, config_dir, CRED_FILE);
+}
+
+fn credentialFilePath(allocator: std.mem.Allocator) ![]u8 {
+    const config_dir = try config_paths.defaultConfigDir(allocator);
+    defer allocator.free(config_dir);
+    return credentialFilePathFromConfigDir(allocator, config_dir);
+}
 
 fn writeCredentialsFileAtomic(allocator: std.mem.Allocator, file_path: []const u8, contents: []const u8) !void {
     const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{file_path});
@@ -106,21 +115,19 @@ fn writeCredentialsFileAtomic(allocator: std.mem.Allocator, file_path: []const u
     };
 }
 
-/// Save a credential for the given provider to ~/.nullclaw/auth.json.
+/// Save a credential for the given provider to auth.json in the config directory.
 /// Merges with existing credentials (other providers are preserved).
 /// File permissions are set to 0o600.
 pub fn saveCredential(allocator: std.mem.Allocator, provider: []const u8, token: OAuthToken) !void {
-    const home = platform.getHomeDir(allocator) catch return error.HomeNotSet;
-    defer allocator.free(home);
-
-    const dir_path = try std.fs.path.join(allocator, &.{ home, CRED_DIR });
-    defer allocator.free(dir_path);
+    const file_path = credentialFilePath(allocator) catch |err| switch (err) {
+        error.HomeDirNotFound => return error.HomeNotSet,
+        else => return err,
+    };
+    defer allocator.free(file_path);
 
     // Ensure directory exists
+    const dir_path = std.fs.path.dirname(file_path) orelse return error.CredentialWriteFailed;
     fs_compat.makePath(dir_path) catch return error.CredentialWriteFailed;
-
-    const file_path = try std.fs.path.join(allocator, &.{ dir_path, CRED_FILE });
-    defer allocator.free(file_path);
 
     // Read existing credentials (if any)
     var existing = loadAllCredentials(allocator, file_path) orelse std.StringArrayHashMap(StoredToken).init(allocator);
@@ -190,14 +197,11 @@ pub fn saveCredential(allocator: std.mem.Allocator, provider: []const u8, token:
     try writeCredentialsFileAtomic(allocator, file_path, buf.items);
 }
 
-/// Load a credential for the given provider from ~/.nullclaw/auth.json.
+/// Load a credential for the given provider from auth.json in the config directory.
 /// Returns null if the file is missing, the provider is not found, or the token
 /// is expired and cannot be refreshed.
 pub fn loadCredential(allocator: std.mem.Allocator, provider: []const u8) !?OAuthToken {
-    const home = platform.getHomeDir(allocator) catch return null;
-    defer allocator.free(home);
-
-    const file_path = try std.fs.path.join(allocator, &.{ home, CRED_DIR, CRED_FILE });
+    const file_path = credentialFilePath(allocator) catch return null;
     defer allocator.free(file_path);
 
     const file = std.fs.cwd().openFile(file_path, .{}) catch return null;
@@ -400,13 +404,13 @@ pub fn refreshAccessToken(
 
 // ── Credential Deletion ───────────────────────────────────────────────
 
-/// Delete a credential for the given provider from ~/.nullclaw/auth.json.
+/// Delete a credential for the given provider from auth.json in the config directory.
 /// Returns true if the credential was found and removed.
 pub fn deleteCredential(allocator: std.mem.Allocator, provider: []const u8) !bool {
-    const home = platform.getHomeDir(allocator) catch return error.HomeNotSet;
-    defer allocator.free(home);
-
-    const file_path = try std.fs.path.join(allocator, &.{ home, CRED_DIR, CRED_FILE });
+    const file_path = credentialFilePath(allocator) catch |err| switch (err) {
+        error.HomeDirNotFound => return error.HomeNotSet,
+        else => return err,
+    };
     defer allocator.free(file_path);
 
     var existing = loadAllCredentials(allocator, file_path) orelse return false;
@@ -912,4 +916,14 @@ test "Allocating writer deinit frees full buffer — no invalid free on sub-slic
     // If we reach here without panic, DebugAllocator confirmed:
     // 1. No invalid free (sub-slice length mismatch)
     // 2. No memory leak (all allocations freed)
+}
+
+test "credentialFilePathFromConfigDir appends auth.json" {
+    const path = try credentialFilePathFromConfigDir(std.testing.allocator, "/tmp/nullclaw-home");
+    defer std.testing.allocator.free(path);
+
+    const expected = try std.fs.path.join(std.testing.allocator, &.{ "/tmp/nullclaw-home", "auth.json" });
+    defer std.testing.allocator.free(expected);
+
+    try std.testing.expectEqualStrings(expected, path);
 }

--- a/src/channel_loop.zig
+++ b/src/channel_loop.zig
@@ -1298,7 +1298,7 @@ pub fn runTelegramLoop(
     var evict_counter: u32 = 0;
 
     const model = config.default_model orelse {
-        log.err("No default model configured. Set agents.defaults.model.primary in ~/.nullclaw/config.json or run `nullclaw onboard`.", .{});
+        log.err("No default model configured. Set agents.defaults.model.primary in config.json in your nullclaw config directory or run `nullclaw onboard`.", .{});
         return;
     };
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
+const config_paths = @import("config_paths.zig");
 const fs_compat = @import("fs_compat.zig");
-const platform = @import("platform.zig");
 const provider_names = @import("provider_names.zig");
 const secrets = @import("security/secrets.zig");
 pub const config_types = @import("config_types.zig");
@@ -362,15 +362,11 @@ pub const Config = struct {
         }
         const allocator = arena_ptr.allocator();
 
-        // NULLCLAW_HOME overrides the default config directory (~/.nullclaw/).
-        const config_dir = std.process.getEnvVarOwned(allocator, "NULLCLAW_HOME") catch |err| switch (err) {
-            error.EnvironmentVariableNotFound => blk: {
-                const home = platform.getHomeDir(allocator) catch return error.NoHomeDir;
-                break :blk try std.fs.path.join(allocator, &.{ home, ".nullclaw" });
-            },
+        const config_dir = config_paths.defaultConfigDir(allocator) catch |err| switch (err) {
+            error.HomeDirNotFound => return error.NoHomeDir,
             else => return err,
         };
-        const config_path = try std.fs.path.join(allocator, &.{ config_dir, "config.json" });
+        const config_path = try config_paths.pathFromConfigDir(allocator, config_dir, "config.json");
         const default_workspace_dir = try std.fs.path.join(allocator, &.{ config_dir, "workspace" });
 
         var cfg = Config{
@@ -1417,7 +1413,7 @@ pub const Config = struct {
                 .{},
             ),
             ValidationError.NoDefaultModel => std.debug.print(
-                "No default model configured. Set agents.defaults.model.primary in ~/.nullclaw/config.json or run `nullclaw onboard`.\n",
+                "No default model configured. Set agents.defaults.model.primary in config.json in your nullclaw config directory or run `nullclaw onboard`.\n",
                 .{},
             ),
             ValidationError.TemperatureOutOfRange => std.debug.print("Config error: temperature must be between 0.0 and 2.0.\n", .{}),

--- a/src/config_mutator.zig
+++ b/src/config_mutator.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const config_mod = @import("config.zig");
+const config_paths = @import("config_paths.zig");
 const platform = @import("platform.zig");
 
 pub const MutationAction = enum {
@@ -64,17 +65,13 @@ pub fn freeMutationResult(allocator: std.mem.Allocator, result: *MutationResult)
 }
 
 fn defaultConfigDir(allocator: std.mem.Allocator, nullclaw_home_override: ?[]const u8) ![]u8 {
-    if (nullclaw_home_override) |config_dir| {
-        return allocator.dupe(u8, config_dir);
-    }
-
     const home = try platform.getHomeDir(allocator);
     defer allocator.free(home);
-    return try std.fs.path.join(allocator, &.{ home, ".nullclaw" });
+    return config_paths.defaultConfigDirFromInputs(allocator, nullclaw_home_override, home);
 }
 
 fn defaultConfigPathFromDir(allocator: std.mem.Allocator, config_dir: []const u8) ![]u8 {
-    return try std.fs.path.join(allocator, &.{ config_dir, "config.json" });
+    return config_paths.pathFromConfigDir(allocator, config_dir, "config.json");
 }
 
 pub fn defaultConfigPath(allocator: std.mem.Allocator) ![]u8 {

--- a/src/config_paths.zig
+++ b/src/config_paths.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const platform = @import("platform.zig");
+
+pub fn defaultConfigDirFromInputs(
+    allocator: std.mem.Allocator,
+    nullclaw_home: ?[]const u8,
+    home_dir: ?[]const u8,
+) ![]u8 {
+    if (nullclaw_home) |config_dir| return allocator.dupe(u8, config_dir);
+    const home = home_dir orelse return error.HomeDirNotFound;
+    return std.fs.path.join(allocator, &.{ home, ".nullclaw" });
+}
+
+pub fn defaultConfigDir(allocator: std.mem.Allocator) ![]u8 {
+    const nullclaw_home = std.process.getEnvVarOwned(allocator, "NULLCLAW_HOME") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    if (nullclaw_home) |config_dir| return config_dir;
+
+    const home_dir = try platform.getHomeDir(allocator);
+    defer allocator.free(home_dir);
+    return defaultConfigDirFromInputs(allocator, null, home_dir);
+}
+
+pub fn pathFromConfigDir(
+    allocator: std.mem.Allocator,
+    config_dir: []const u8,
+    leaf_name: []const u8,
+) ![]u8 {
+    return std.fs.path.join(allocator, &.{ config_dir, leaf_name });
+}
+
+test "defaultConfigDirFromInputs prefers NULLCLAW_HOME override" {
+    const config_dir = try defaultConfigDirFromInputs(std.testing.allocator, "/tmp/nullclaw-home", "/home/ignored");
+    defer std.testing.allocator.free(config_dir);
+
+    try std.testing.expectEqualStrings("/tmp/nullclaw-home", config_dir);
+}
+
+test "defaultConfigDirFromInputs falls back to HOME/.nullclaw" {
+    const config_dir = try defaultConfigDirFromInputs(std.testing.allocator, null, "/home/alice");
+    defer std.testing.allocator.free(config_dir);
+
+    const expected = try std.fs.path.join(std.testing.allocator, &.{ "/home/alice", ".nullclaw" });
+    defer std.testing.allocator.free(expected);
+
+    try std.testing.expectEqualStrings(expected, config_dir);
+}
+
+test "defaultConfigDirFromInputs reports missing home" {
+    try std.testing.expectError(error.HomeDirNotFound, defaultConfigDirFromInputs(std.testing.allocator, null, null));
+}
+
+test "pathFromConfigDir appends a leaf name" {
+    const path = try pathFromConfigDir(std.testing.allocator, "/tmp/nullclaw-home", "config.json");
+    defer std.testing.allocator.free(path);
+
+    const expected = try std.fs.path.join(std.testing.allocator, &.{ "/tmp/nullclaw-home", "config.json" });
+    defer std.testing.allocator.free(expected);
+
+    try std.testing.expectEqualStrings(expected, path);
+}

--- a/src/cron.zig
+++ b/src/cron.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const config_paths = @import("config_paths.zig");
 const platform = @import("platform.zig");
 const bus = @import("bus.zig");
 const fs_compat = @import("fs_compat.zig");
@@ -1651,43 +1652,20 @@ const JsonCronJob = struct {
     delivery_to: ?[]const u8 = null,
 };
 
-/// Shared by runtime code and regression tests so NULLCLAW_HOME precedence
-/// stays deterministic without relying on process-global environment state.
-fn resolveConfigDirFromInputs(
-    allocator: std.mem.Allocator,
-    nullclaw_home: ?[]const u8,
-    home_dir: ?[]const u8,
-) ![]const u8 {
-    if (nullclaw_home) |dir| return allocator.dupe(u8, dir);
-    const home = home_dir orelse return error.HomeDirNotFound;
-    return std.fs.path.join(allocator, &.{ home, ".nullclaw" });
-}
-
-/// Resolve the NullClaw config directory.
-/// Checks NULLCLAW_HOME first, falls back to ~/.nullclaw/.
-/// Mirrors the logic in Config.load() (src/config.zig).
-/// Caller owns the returned slice.
-fn resolveConfigDir(allocator: std.mem.Allocator) ![]const u8 {
-    if (platform.getEnvOrNull(allocator, "NULLCLAW_HOME")) |dir| return dir;
-    const home_dir = try platform.getHomeDir(allocator);
-    defer allocator.free(home_dir);
-    return resolveConfigDirFromInputs(allocator, null, home_dir);
-}
-
 fn cronJsonPathFromDir(allocator: std.mem.Allocator, config_dir: []const u8) ![]const u8 {
-    return std.fs.path.join(allocator, &.{ config_dir, "cron.json" });
+    return config_paths.pathFromConfigDir(allocator, config_dir, "cron.json");
 }
 
 /// Get the cron.json path inside the config directory.
 fn cronJsonPath(allocator: std.mem.Allocator) ![]const u8 {
-    const dir = try resolveConfigDir(allocator);
+    const dir = try config_paths.defaultConfigDir(allocator);
     defer allocator.free(dir);
     return cronJsonPathFromDir(allocator, dir);
 }
 
 /// Ensure the config directory exists.
 fn ensureCronDir(allocator: std.mem.Allocator) !void {
-    const dir = try resolveConfigDir(allocator);
+    const dir = try config_paths.defaultConfigDir(allocator);
     defer allocator.free(dir);
     std.fs.makeDirAbsolute(dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
@@ -1695,7 +1673,7 @@ fn ensureCronDir(allocator: std.mem.Allocator) !void {
     };
 }
 
-/// Save scheduler jobs to ~/.nullclaw/cron.json.
+/// Save scheduler jobs to cron.json in the config directory.
 pub fn saveJobs(scheduler: *const CronScheduler) !void {
     try ensureCronDir(scheduler.allocator);
     const path = try cronJsonPath(scheduler.allocator);
@@ -1817,12 +1795,12 @@ pub fn saveJobs(scheduler: *const CronScheduler) !void {
     try writeFileAtomic(scheduler.allocator, path, buf.items);
 }
 
-/// Load jobs from ~/.nullclaw/cron.json into the scheduler.
+/// Load jobs from cron.json in the config directory into the scheduler.
 pub fn loadJobs(scheduler: *CronScheduler) !void {
     try loadJobsWithPolicy(scheduler, .best_effort);
 }
 
-/// Load jobs from ~/.nullclaw/cron.json; unlike loadJobs, this returns
+/// Load jobs from cron.json in the config directory; unlike loadJobs, this returns
 /// parse/read errors (except missing file/path).
 pub fn loadJobsStrict(scheduler: *CronScheduler) !void {
     try loadJobsWithPolicy(scheduler, .strict);
@@ -1895,9 +1873,9 @@ fn trimOwnedRight(allocator: std.mem.Allocator, raw: []u8) ?[]u8 {
 /// Try to read the gateway URL from daemon_state.json in the config directory.
 /// Returns an allocated string like "http://127.0.0.1:3000" or null.
 fn readGatewayUrl(allocator: std.mem.Allocator) ?[]const u8 {
-    const dir = resolveConfigDir(allocator) catch return null;
+    const dir = config_paths.defaultConfigDir(allocator) catch return null;
     defer allocator.free(dir);
-    const state_path = std.fs.path.join(allocator, &.{ dir, "daemon_state.json" }) catch return null;
+    const state_path = config_paths.pathFromConfigDir(allocator, dir, "daemon_state.json") catch return null;
     defer allocator.free(state_path);
 
     const content = fs_compat.readFileAlloc(std.fs.cwd(), allocator, state_path, 64 * 1024) catch return null;
@@ -1921,9 +1899,9 @@ fn readGatewayUrl(allocator: std.mem.Allocator) ?[]const u8 {
 
 /// Read the paired bearer token from paired_token in the config directory (if present).
 fn readPairedToken(allocator: std.mem.Allocator) ?[]const u8 {
-    const dir = resolveConfigDir(allocator) catch return null;
+    const dir = config_paths.defaultConfigDir(allocator) catch return null;
     defer allocator.free(dir);
-    const token_path = std.fs.path.join(allocator, &.{ dir, "paired_token" }) catch return null;
+    const token_path = config_paths.pathFromConfigDir(allocator, dir, "paired_token") catch return null;
     defer allocator.free(token_path);
     const raw = fs_compat.readFileAlloc(std.fs.cwd(), allocator, token_path, 4096) catch return null;
     return trimOwnedRight(allocator, raw);
@@ -3746,7 +3724,7 @@ test "tick reschedules anchored recurring job using cron expression" {
 // Regression: #691 — NULLCLAW_HOME must override the HOME-based fallback.
 test "resolveConfigDir prefers NULLCLAW_HOME override" {
     const allocator = std.testing.allocator;
-    const dir = try resolveConfigDirFromInputs(allocator, "test-nullclaw-data", "ignored-home");
+    const dir = try config_paths.defaultConfigDirFromInputs(allocator, "test-nullclaw-data", "ignored-home");
     defer allocator.free(dir);
     try std.testing.expectEqualStrings("test-nullclaw-data", dir);
 }
@@ -3754,7 +3732,7 @@ test "resolveConfigDir prefers NULLCLAW_HOME override" {
 // Regression: #691 — without NULLCLAW_HOME, cron.zig must use HOME/.nullclaw.
 test "resolveConfigDir falls back to HOME/.nullclaw when NULLCLAW_HOME unset" {
     const allocator = std.testing.allocator;
-    const dir = try resolveConfigDirFromInputs(allocator, null, "test-home");
+    const dir = try config_paths.defaultConfigDirFromInputs(allocator, null, "test-home");
     defer allocator.free(dir);
 
     const expected = try std.fs.path.join(allocator, &.{ "test-home", ".nullclaw" });
@@ -3776,5 +3754,5 @@ test "cronJsonPath appends cron.json to resolved config dir" {
 }
 
 test "resolveConfigDir reports missing home when no config directory inputs exist" {
-    try std.testing.expectError(error.HomeDirNotFound, resolveConfigDirFromInputs(std.testing.allocator, null, null));
+    try std.testing.expectError(error.HomeDirNotFound, config_paths.defaultConfigDirFromInputs(std.testing.allocator, null, null));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1057,15 +1057,8 @@ const VisibleSkills = struct {
 };
 
 fn loadVisibleSkills(allocator: std.mem.Allocator, workspace_dir: []const u8) !VisibleSkills {
-    const home = yc.platform.getHomeDir(allocator) catch null;
-    defer if (home) |path| allocator.free(path);
-
-    var community_base: ?[]u8 = null;
+    var community_base: ?[]u8 = yc.config_paths.defaultConfigDir(allocator) catch null;
     errdefer if (community_base) |path| allocator.free(path);
-
-    if (home) |path| {
-        community_base = std.fs.path.join(allocator, &.{ path, ".nullclaw" }) catch null;
-    }
 
     if (community_base) |base| {
         if (yc.skills.listSkillsMerged(allocator, base, workspace_dir)) |skills| {
@@ -2703,7 +2696,7 @@ fn runSignalChannel(allocator: std.mem.Allocator, args: []const []const u8, conf
     const provider_kind = yc.providers.classifyProvider(config.default_provider);
     const has_fallback_credentials = hasReliabilityCredentialFallback(allocator, config);
     if (resolved_api_key == null and provider_kind != .openai_codex_provider and !has_fallback_credentials) {
-        std.debug.print("No API key configured. Set env var or add to ~/.nullclaw/config.json:\n", .{});
+        std.debug.print("No API key configured. Set env var or add to config.json in your nullclaw config directory:\n", .{});
         std.debug.print("  \"providers\": {{ \"{s}\": {{ \"api_key\": \"...\" }} }}\n", .{config.default_provider});
         std.process.exit(1);
     }
@@ -3254,7 +3247,7 @@ fn runTelegramChannel(allocator: std.mem.Allocator, args: []const []const u8, co
     const provider_kind = yc.providers.classifyProvider(config.default_provider);
     const has_fallback_credentials = hasReliabilityCredentialFallback(allocator, &config);
     if (resolved_api_key == null and provider_kind != .openai_codex_provider and !has_fallback_credentials) {
-        std.debug.print("No API key configured. Set env var or add to ~/.nullclaw/config.json:\n", .{});
+        std.debug.print("No API key configured. Set env var or add to config.json in your nullclaw config directory:\n", .{});
         std.debug.print("  \"providers\": {{ \"{s}\": {{ \"api_key\": \"...\" }} }}\n", .{config.default_provider});
         std.process.exit(1);
     }
@@ -3596,7 +3589,7 @@ fn runAuth(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
         } else if (yc.codex_support.hasOpenAiCodexCredential(allocator)) {
             std.debug.print("openai-codex: authenticated via Codex CLI\n", .{});
             std.debug.print("  Tokens found in ~/.codex/auth.json\n", .{});
-            std.debug.print("  Run `nullclaw auth login openai-codex --import-codex` to persist them in ~/.nullclaw/auth.json.\n", .{});
+            std.debug.print("  Run `nullclaw auth login openai-codex --import-codex` to persist them in auth.json in your nullclaw config directory.\n", .{});
         } else {
             std.debug.print("openai-codex: not authenticated\n", .{});
             std.debug.print("  Run `nullclaw auth login openai-codex` to authenticate.\n", .{});
@@ -3821,7 +3814,7 @@ fn runAuthImportCodex(
             std.debug.print("  Token: expired (will auto-refresh)\n", .{});
         }
     }
-    std.debug.print("\nTo use: set \"agents.defaults.model.primary\": \"openai-codex/{s}\" in ~/.nullclaw/config.json\n", .{yc.codex_support.DEFAULT_CODEX_MODEL});
+    std.debug.print("\nTo use: set \"agents.defaults.model.primary\": \"openai-codex/{s}\" in config.json in your nullclaw config directory\n", .{yc.codex_support.DEFAULT_CODEX_MODEL});
 }
 
 /// Decode the "exp" claim from a JWT, returning the Unix timestamp or 0 if not decodable.
@@ -3875,7 +3868,7 @@ fn saveAndPrintResult(
     } else {
         std.debug.print("Authenticated successfully.\n", .{});
     }
-    std.debug.print("\nTo use: set \"agents.defaults.model.primary\": \"openai-codex/{s}\" in ~/.nullclaw/config.json\n", .{yc.codex_support.DEFAULT_CODEX_MODEL});
+    std.debug.print("\nTo use: set \"agents.defaults.model.primary\": \"openai-codex/{s}\" in config.json in your nullclaw config directory\n", .{yc.codex_support.DEFAULT_CODEX_MODEL});
 }
 
 fn printUsage() void {

--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -11,8 +11,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
+const config_paths = @import("config_paths.zig");
 const fs_compat = @import("fs_compat.zig");
-const platform = @import("platform.zig");
 const codex_support = @import("codex_support.zig");
 const config_mod = @import("config.zig");
 const net_security = @import("net_security.zig");
@@ -491,7 +491,7 @@ fn dupeFallbackModels(allocator: std.mem.Allocator, provider: []const u8) ![][]c
 
 /// Fetch available model IDs for a provider (with caching, limit, and fallback).
 ///
-/// Uses file-based cache at `~/.nullclaw/state/models_cache.json` with 12h TTL.
+/// Uses file-based cache at `state/models_cache.json` inside the config directory with 12h TTL.
 /// Returns at most 20 model IDs. Caller ALWAYS owns the returned slice and strings.
 /// Free with: for (models) |m| allocator.free(m); allocator.free(models);
 pub fn fetchModels(allocator: std.mem.Allocator, provider: []const u8, api_key: ?[]const u8) ![][]const u8 {
@@ -500,11 +500,11 @@ pub fn fetchModels(allocator: std.mem.Allocator, provider: []const u8, api_key: 
         return codex_support.loadCodexModels(allocator);
     }
 
-    const home = platform.getHomeDir(allocator) catch
+    const config_dir = config_paths.defaultConfigDir(allocator) catch
         return dupeFallbackModels(allocator, provider);
-    defer allocator.free(home);
+    defer allocator.free(config_dir);
 
-    const state_dir = try std.fs.path.join(allocator, &.{ home, ".nullclaw", "state" });
+    const state_dir = try std.fs.path.join(allocator, &.{ config_dir, "state" });
     defer allocator.free(state_dir);
 
     // Ensure state directory exists
@@ -2047,7 +2047,7 @@ pub fn runWizard(allocator: std.mem.Allocator) !void {
     } else {
         try out.writeAll("  Step 2/8: Authentication\n");
         if (std.mem.eql(u8, cfg.default_provider, "openai-codex")) {
-            try out.writeAll("  -> Uses local OAuth tokens from ~/.nullclaw/auth.json or ~/.codex/auth.json\n\n");
+            try out.writeAll("  -> Uses local OAuth tokens from auth.json in your nullclaw config directory or ~/.codex/auth.json\n\n");
         } else if (std.mem.eql(u8, cfg.default_provider, "codex-cli")) {
             try out.writeAll("  -> Uses your local Codex CLI login (`codex login`)\n\n");
         } else if (std.mem.eql(u8, cfg.default_provider, "gemini-cli")) {
@@ -2303,7 +2303,7 @@ const catalog_providers = [_]ModelsCatalogProvider{
 };
 
 /// Refresh the model catalog by fetching available models from known providers.
-/// Saves results to ~/.nullclaw/models_cache.json.
+/// Saves results to models_cache.json in the config directory.
 pub fn runModelsRefresh(allocator: std.mem.Allocator) !void {
     var stdout_buf: [4096]u8 = undefined;
     var bw = std.fs.File.stdout().writer(&stdout_buf);
@@ -2312,16 +2312,15 @@ pub fn runModelsRefresh(allocator: std.mem.Allocator) !void {
     try out.flush();
 
     // Build cache path
-    const home = platform.getHomeDir(allocator) catch {
-        try out.writeAll("Could not determine HOME directory.\n");
+    const config_dir = config_paths.defaultConfigDir(allocator) catch {
+        try out.writeAll("Could not determine config directory.\n");
         try out.flush();
         return;
     };
-    defer allocator.free(home);
-    const cache_path = try std.fs.path.join(allocator, &.{ home, ".nullclaw", "models_cache.json" });
+    defer allocator.free(config_dir);
+    const cache_path = try config_paths.pathFromConfigDir(allocator, config_dir, "models_cache.json");
     defer allocator.free(cache_path);
-    const cache_dir = try std.fs.path.join(allocator, &.{ home, ".nullclaw" });
-    defer allocator.free(cache_dir);
+    const cache_dir = config_dir;
 
     // Ensure directory exists
     std.fs.makeDirAbsolute(cache_dir) catch |err| switch (err) {
@@ -3008,15 +3007,23 @@ pub fn defaultBackendKey() []const u8 {
 // ── Path helpers ─────────────────────────────────────────────────
 
 fn getDefaultWorkspace(allocator: std.mem.Allocator) ![]const u8 {
-    const home = try platform.getHomeDir(allocator);
-    defer allocator.free(home);
-    return std.fs.path.join(allocator, &.{ home, ".nullclaw", "workspace" });
+    const config_dir = try config_paths.defaultConfigDir(allocator);
+    defer allocator.free(config_dir);
+    return defaultWorkspaceFromConfigDir(allocator, config_dir);
 }
 
 fn getDefaultConfigPath(allocator: std.mem.Allocator) ![]const u8 {
-    const home = try platform.getHomeDir(allocator);
-    defer allocator.free(home);
-    return std.fs.path.join(allocator, &.{ home, ".nullclaw", "config.json" });
+    const config_dir = try config_paths.defaultConfigDir(allocator);
+    defer allocator.free(config_dir);
+    return defaultConfigPathFromDir(allocator, config_dir);
+}
+
+fn defaultWorkspaceFromConfigDir(allocator: std.mem.Allocator, config_dir: []const u8) ![]const u8 {
+    return std.fs.path.join(allocator, &.{ config_dir, "workspace" });
+}
+
+fn defaultConfigPathFromDir(allocator: std.mem.Allocator, config_dir: []const u8) ![]const u8 {
+    return config_paths.pathFromConfigDir(allocator, config_dir, "config.json");
 }
 
 // ── Tests ────────────────────────────────────────────────────────
@@ -3146,6 +3153,26 @@ test "isWizardInteractiveChannel includes supported onboarding channels" {
     try std.testing.expect(isWizardInteractiveChannel(.nostr));
     try std.testing.expect(isWizardInteractiveChannel(.max));
     try std.testing.expect(!isWizardInteractiveChannel(.whatsapp));
+}
+
+test "defaultWorkspaceFromConfigDir appends workspace" {
+    const path = try defaultWorkspaceFromConfigDir(std.testing.allocator, "/tmp/nullclaw-home");
+    defer std.testing.allocator.free(path);
+
+    const expected = try std.fs.path.join(std.testing.allocator, &.{ "/tmp/nullclaw-home", "workspace" });
+    defer std.testing.allocator.free(expected);
+
+    try std.testing.expectEqualStrings(expected, path);
+}
+
+test "defaultConfigPathFromDir appends config.json" {
+    const path = try defaultConfigPathFromDir(std.testing.allocator, "/tmp/nullclaw-home");
+    defer std.testing.allocator.free(path);
+
+    const expected = try std.fs.path.join(std.testing.allocator, &.{ "/tmp/nullclaw-home", "config.json" });
+    defer std.testing.allocator.free(expected);
+
+    try std.testing.expectEqualStrings(expected, path);
 }
 
 test "parseWizardJsonConfig normalizes valid object payload" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -14,6 +14,7 @@ pub const websocket = @import("websocket.zig");
 // Phase 1: Core
 pub const bus = @import("bus.zig");
 pub const config = @import("config.zig");
+pub const config_paths = @import("config_paths.zig");
 pub const util = @import("util.zig");
 pub const platform = @import("platform.zig");
 pub const codex_support = @import("codex_support.zig");


### PR DESCRIPTION
Fixes #691

`cron.zig` hardcodes `$HOME/.nullclaw/` for file paths (`cron.json`, `daemon_state.json`, `paired_token`) instead of respecting `NULLCLAW_HOME`. In Docker (uid 65534, `NULLCLAW_HOME=/nullclaw-data`), this causes `AccessDenied` because the fallback path doesn't exist or isn't writable.

**Fix:** Add `resolveConfigDir()` that checks `NULLCLAW_HOME` first, falling back to `$HOME/.nullclaw/` — matching `Config.load()`. Updated `cronJsonPath`, `ensureCronDir`, `readGatewayUrl`, and `readPairedToken` to use it.