### PR TITLE
docs: clarify that config values do not support environment variable interpolation | 文档: 澄清配置值不支持环境变量插值

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Config: `~/.nullclaw/config.json` (created by `onboard`)
       "url": "https://mcp.example.com/rpc",
       "timeout_ms": 10000,
       "headers": {
-        "Authorization": "Bearer <YOUR_MCP_TOKEN>"
+        "Authorization": "Bearer example-token"
       }
     }
   },
@@ -479,6 +479,10 @@ Config: `~/.nullclaw/config.json` (created by `onboard`)
   }
 }
 ```
+
+Config values are literal. NullClaw does not expand `${VAR}` inside `config.json`
+strings, including custom header values. If you need environment-based secrets,
+render `config.json` ahead of time with your own deployment tooling.
 
 Telegram forum topics:
 


### PR DESCRIPTION
## Summary

###  EN:
   - Resolves #697.
   - Updated the `README.md` example to replace `${MCP_TOKEN}` with `<YOUR_MCP_TOKEN>` to avoid giving the false impression that NullClaw dynamically interpolates environment variables inside `config.json` strings.
   - Config values do not currently support `${VAR}` expansion natively, and users should provide absolute values (or use GitOps tools/templates to generate the config file beforehand).

###  ZH:
   - 解决了 #697。
   - 更新了 `README.md` 中的示例，将 `${MCP_TOKEN}` 替换为 `<YOUR_MCP_TOKEN>`，以避免给用户造成 NullClaw 会在 `config.json` 字符串中动态插值环境变量的错误印象。
   - 当前配置值原生不支持 `${VAR}` 展开，用户应提供绝对值（或事先使用 GitOps 工具/模板生成配置文件）。

##  Validation
   - Manual review of the documentation changes.