### PR TITLE
providers(openrouter): preserve reasoning traces in stream | 修复(providers/openrouter): 保留流式 reasoning 轨迹

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -1799,6 +1799,7 @@ pub const Agent = struct {
             const timer_start = std.time.milliTimestamp();
             const is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
             const native_tools_enabled = !is_streaming and self.provider.supportsNativeTools();
+            const include_reasoning = self.reasoning_mode != .off;
 
             // Filter tool specs for this turn (arena-owned; may be self.tool_specs directly if no groups).
             const turn_tool_specs = try self.filterToolSpecsForTurn(arena, effective_user_message);
@@ -1827,6 +1828,7 @@ pub const Agent = struct {
                         .tools = null,
                         .timeout_secs = self.message_timeout_secs,
                         .reasoning_effort = self.reasoning_effort,
+                        .include_reasoning = include_reasoning,
                     },
                     turn_model_name,
                     self.temperature,
@@ -1863,6 +1865,7 @@ pub const Agent = struct {
                                 .tools = null,
                                 .timeout_secs = self.message_timeout_secs,
                                 .reasoning_effort = self.reasoning_effort,
+                                .include_reasoning = include_reasoning,
                             },
                             turn_model_name,
                             self.temperature,
@@ -1881,6 +1884,7 @@ pub const Agent = struct {
                 };
                 response = ChatResponse{
                     .content = stream_result.content,
+                    .reasoning_content = stream_result.reasoning_content,
                     .tool_calls = &.{},
                     .usage = stream_result.usage,
                     .model = stream_result.model,
@@ -1899,6 +1903,7 @@ pub const Agent = struct {
                         .tools = if (native_tools_enabled) turn_tool_specs else null,
                         .timeout_secs = self.message_timeout_secs,
                         .reasoning_effort = self.reasoning_effort,
+                        .include_reasoning = include_reasoning,
                     },
                     turn_model_name,
                     self.temperature,
@@ -1934,6 +1939,7 @@ pub const Agent = struct {
                                 .tools = if (native_tools_enabled) turn_tool_specs else null,
                                 .timeout_secs = self.message_timeout_secs,
                                 .reasoning_effort = self.reasoning_effort,
+                                .include_reasoning = include_reasoning,
                             },
                             turn_model_name,
                             self.temperature,
@@ -1972,6 +1978,7 @@ pub const Agent = struct {
                                 .tools = if (native_tools_enabled) turn_tool_specs else null,
                                 .timeout_secs = self.message_timeout_secs,
                                 .reasoning_effort = self.reasoning_effort,
+                                .include_reasoning = include_reasoning,
                             },
                             turn_model_name,
                             self.temperature,
@@ -2004,6 +2011,7 @@ pub const Agent = struct {
                             .tools = if (native_tools_enabled) turn_tool_specs else null,
                             .timeout_secs = self.message_timeout_secs,
                             .reasoning_effort = self.reasoning_effort,
+                            .include_reasoning = include_reasoning,
                         },
                         turn_model_name,
                         self.temperature,
@@ -2033,6 +2041,7 @@ pub const Agent = struct {
                                     .tools = if (native_tools_enabled) turn_tool_specs else null,
                                     .timeout_secs = self.message_timeout_secs,
                                     .reasoning_effort = self.reasoning_effort,
+                                    .include_reasoning = include_reasoning,
                                 },
                                 turn_model_name,
                                 self.temperature,
@@ -2949,8 +2958,10 @@ pub const Agent = struct {
         const session_hash: u64 = if (self.memory_session_id) |sid| std.hash.Wyhash.hash(0, sid) else 0;
         const content = response.contentOrEmpty();
         const preview = llmLogPreview(content);
+        const reasoning_returned = response.reasoning_content != null and response.reasoning_content.?.len > 0;
+        const reasoning_requested = self.reasoning_mode != .off;
         log.info(
-            "llm response session=0x{x} iter={d} attempt={d} provider={s} model={s} bytes={d} tool_calls={d} usage={f} content={f}{s}",
+            "llm response session=0x{x} iter={d} attempt={d} provider={s} model={s} bytes={d} tool_calls={d} reasoning_mode={s} reasoning_effort={s} reasoning_requested={} reasoning_returned={} usage={f} content={f}{s}",
             .{
                 session_hash,
                 iteration,
@@ -2959,11 +2970,32 @@ pub const Agent = struct {
                 self.effectiveModel(response),
                 content.len,
                 response.tool_calls.len,
+                self.reasoning_mode.toSlice(),
+                self.reasoning_effort orelse "off",
+                reasoning_requested,
+                reasoning_returned,
                 std.json.fmt(response.usage, .{}),
                 std.json.fmt(preview.slice, .{}),
                 if (preview.truncated) " [log preview truncated]" else "",
             },
         );
+
+        // NOTE: Logging-only path. No direct unit test added because verifying structured
+        // log emission here would require a log sink harness for Agent runtime logging.
+        if (reasoning_requested and !reasoning_returned) {
+            log.info(
+                "llm response reasoning missing session=0x{x} iter={d} attempt={d} provider={s} model={s} reasoning_mode={s} reasoning_effort={s}",
+                .{
+                    session_hash,
+                    iteration,
+                    attempt,
+                    self.effectiveProvider(response),
+                    self.effectiveModel(response),
+                    self.reasoning_mode.toSlice(),
+                    self.reasoning_effort orelse "off",
+                },
+            );
+        }
 
         if (response.reasoning_content) |reasoning| {
             const r_preview = llmLogPreview(reasoning);

--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -1116,6 +1116,11 @@ pub const OpenAiCompatibleProvider = struct {
                             reasoning_content = try allocator.dupe(u8, rc.string);
                     }
                 }
+                if (reasoning_content == null) {
+                    if (msg_obj.get("reasoning_details")) |details| {
+                        reasoning_content = try root.extractReasoningTextFromDetails(allocator, details);
+                    }
+                }
 
                 var tool_calls_list: std.ArrayListUnmanaged(ToolCall) = .empty;
                 errdefer {
@@ -1278,16 +1283,8 @@ pub const OpenAiCompatibleProvider = struct {
                 "{s} streaming skipped for large request ({d} bytes >= {d}); using non-streaming",
                 .{ self.name, request_text_bytes, self.max_streaming_prompt_bytes.? },
             );
-            const fallback = try chatImpl(ptr, allocator, request, model, temperature);
-            if (fallback.content) |text| {
-                callback(callback_ctx, root.StreamChunk.textDelta(text));
-            }
-            callback(callback_ctx, root.StreamChunk.finalChunk());
-            return .{
-                .content = fallback.content,
-                .usage = fallback.usage,
-                .model = fallback.model,
-            };
+            var fallback = try chatImpl(ptr, allocator, request, model, temperature);
+            return root.emitChatResponseAsStream(allocator, &fallback, callback, callback_ctx);
         }
 
         const url = try self.chatCompletionsUrl(allocator);
@@ -1916,6 +1913,26 @@ test "parseNativeResponse reads native reasoning field (Groq/Cerebras parsed for
     try std.testing.expectEqualStrings("Final answer", result.content.?);
     try std.testing.expect(result.reasoning_content != null);
     try std.testing.expectEqualStrings("parsed reasoning trace", result.reasoning_content.?);
+}
+
+test "parseNativeResponse reads reasoning_details field" {
+    const body =
+        \\{"choices":[{"message":{"content":"Visible answer","reasoning_details":[{"type":"reasoning.summary","summary":"plan"},{"type":"reasoning.text","text":"step by step"}]}}],"model":"openrouter/auto"}
+    ;
+    const result = try OpenAiCompatibleProvider.parseNativeResponse(std.testing.allocator, body);
+    defer {
+        if (result.content) |c| if (c.len > 0) std.testing.allocator.free(c);
+        for (result.tool_calls) |tc| {
+            if (tc.id.len > 0) std.testing.allocator.free(tc.id);
+            if (tc.name.len > 0) std.testing.allocator.free(tc.name);
+            if (tc.arguments.len > 0) std.testing.allocator.free(tc.arguments);
+        }
+        if (result.tool_calls.len > 0) std.testing.allocator.free(result.tool_calls);
+        if (result.model.len > 0) std.testing.allocator.free(result.model);
+        if (result.reasoning_content) |rc| if (rc.len > 0) std.testing.allocator.free(rc);
+    }
+    try std.testing.expectEqualStrings("Visible answer", result.content.?);
+    try std.testing.expectEqualStrings("plan\nstep by step", result.reasoning_content.?);
 }
 
 test "parseNativeResponse supports content array text parts" {

--- a/src/providers/helpers.zig
+++ b/src/providers/helpers.zig
@@ -91,6 +91,50 @@ pub fn stripThinkBlocks(allocator: std.mem.Allocator, text: []const u8) ![]const
     return allocator.dupe(u8, trimmed);
 }
 
+fn appendReasoningDetailText(
+    out: *std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+    detail: std.json.Value,
+) !void {
+    if (detail != .object) return;
+    const obj = detail.object;
+
+    if (obj.get("type")) |type_val| {
+        if (type_val == .string and std.mem.eql(u8, type_val.string, "reasoning.encrypted")) return;
+    }
+
+    const text = blk: {
+        if (obj.get("text")) |value| {
+            if (value == .string and value.string.len > 0) break :blk value.string;
+        }
+        if (obj.get("summary")) |value| {
+            if (value == .string and value.string.len > 0) break :blk value.string;
+        }
+        break :blk null;
+    } orelse return;
+
+    if (out.items.len > 0) try out.append(allocator, '\n');
+    try out.appendSlice(allocator, text);
+}
+
+/// Extract plain-text reasoning from OpenRouter/OpenAI-style `reasoning_details`.
+/// Encrypted detail variants are intentionally ignored.
+pub fn extractReasoningTextFromDetails(allocator: std.mem.Allocator, details: std.json.Value) !?[]const u8 {
+    if (details != .array) return null;
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(allocator);
+
+    for (details.array.items) |detail| {
+        try appendReasoningDetailText(&out, allocator, detail);
+    }
+
+    const trimmed = std.mem.trim(u8, out.items, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    const owned = try allocator.dupe(u8, trimmed);
+    return owned;
+}
+
 /// Extract api_key from a config-like struct (supports both Config.defaultProviderKey() and plain .api_key field).
 fn resolveApiKeyFromCfg(cfg: anytype) ?[]const u8 {
     const T = @TypeOf(cfg);

--- a/src/providers/openrouter.zig
+++ b/src/providers/openrouter.zig
@@ -121,6 +121,8 @@ pub const OpenRouterProvider = struct {
 
                 var content: ?[]const u8 = null;
                 var reasoning_content: ?[]const u8 = null;
+                errdefer if (content) |c| if (c.len > 0) allocator.free(c);
+                errdefer if (reasoning_content) |rc| if (rc.len > 0) allocator.free(rc);
                 if (msg_obj.get("content")) |c| {
                     if (c == .string) {
                         const split = try root.splitThinkContent(allocator, c.string);
@@ -144,8 +146,21 @@ pub const OpenRouterProvider = struct {
                             reasoning_content = try allocator.dupe(u8, rc.string);
                     }
                 }
+                if (reasoning_content == null) {
+                    if (msg_obj.get("reasoning_details")) |details| {
+                        reasoning_content = try root.extractReasoningTextFromDetails(allocator, details);
+                    }
+                }
 
                 var tool_calls_list: std.ArrayListUnmanaged(ToolCall) = .empty;
+                errdefer {
+                    for (tool_calls_list.items) |tc| {
+                        if (tc.id.len > 0) allocator.free(tc.id);
+                        if (tc.name.len > 0) allocator.free(tc.name);
+                        if (tc.arguments.len > 0) allocator.free(tc.arguments);
+                    }
+                    tool_calls_list.deinit(allocator);
+                }
 
                 if (msg_obj.get("tool_calls")) |tc_arr| {
                     for (tc_arr.array.items) |tc| {
@@ -931,6 +946,22 @@ test "parseNativeResponse reads native reasoning_content field" {
     }
     try std.testing.expectEqualStrings("The answer is 42", response.content.?);
     try std.testing.expectEqualStrings("I computed this", response.reasoning_content.?);
+}
+
+test "parseNativeResponse reads reasoning_details field" {
+    const body =
+        \\{"choices":[{"message":{"content":"Visible answer","reasoning_details":[{"type":"reasoning.summary","summary":"plan"},{"type":"reasoning.text","text":"step by step"}]}}],"model":"moonshotai/kimi-k2.5","usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}
+    ;
+    const alloc = std.testing.allocator;
+    const response = try OpenRouterProvider.parseNativeResponse(alloc, body);
+    defer {
+        if (response.content) |c| alloc.free(c);
+        if (response.reasoning_content) |rc| alloc.free(rc);
+        alloc.free(response.tool_calls);
+        alloc.free(response.model);
+    }
+    try std.testing.expectEqualStrings("Visible answer", response.content.?);
+    try std.testing.expectEqualStrings("plan\nstep by step", response.reasoning_content.?);
 }
 
 test "parseNativeResponse no think tags leaves reasoning_content null" {

--- a/src/providers/openrouter.zig
+++ b/src/providers/openrouter.zig
@@ -457,6 +457,7 @@ pub const OpenRouterProvider = struct {
         }
 
         try buf.append(allocator, ']');
+        try appendOpenRouterRequestFields(&buf, allocator, request);
         try root.appendGenerationFields(&buf, allocator, model, temperature, request.max_tokens, request.reasoning_effort);
         try appendOpenRouterReasoning(&buf, allocator, request.reasoning_effort);
 
@@ -500,6 +501,7 @@ pub const OpenRouterProvider = struct {
         }
 
         try buf.append(allocator, ']');
+        try appendOpenRouterRequestFields(&buf, allocator, request);
         try root.appendGenerationFields(&buf, allocator, model, temperature, request.max_tokens, request.reasoning_effort);
         try appendOpenRouterReasoning(&buf, allocator, request.reasoning_effort);
 
@@ -530,6 +532,21 @@ fn appendOpenRouterReasoning(
     try buf.appendSlice(allocator, ",\"reasoning\":{\"effort\":");
     try root.appendJsonString(buf, allocator, effort);
     try buf.append(allocator, '}');
+}
+
+fn appendOpenRouterRequestFields(
+    buf: *std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+    request: ChatRequest,
+) !void {
+    if (request.session_id) |session_id| {
+        try buf.appendSlice(allocator, ",\"session_id\":");
+        try root.appendJsonString(buf, allocator, session_id);
+    }
+    if (request.include_reasoning) |include_reasoning| {
+        try buf.appendSlice(allocator, ",\"include_reasoning\":");
+        try buf.appendSlice(allocator, if (include_reasoning) "true" else "false");
+    }
 }
 
 /// HTTP GET via curl subprocess with auth header.
@@ -772,6 +789,25 @@ test "buildChatRequestBody escapes OpenRouter reasoning effort value" {
     try std.testing.expect(parsed.value.object.get("pwned") == null);
 }
 
+test "buildChatRequestBody includes session_id and include_reasoning" {
+    const msgs = [_]ChatMessage{
+        .{ .role = .user, .content = "hello" },
+    };
+    const req = ChatRequest{
+        .messages = &msgs,
+        .model = "moonshotai/kimi-k2.5",
+        .session_id = "telegram:chat123",
+        .include_reasoning = true,
+    };
+    const body = try OpenRouterProvider.buildChatRequestBody(std.testing.allocator, req, "moonshotai/kimi-k2.5", 0.7);
+    defer std.testing.allocator.free(body);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("telegram:chat123", parsed.value.object.get("session_id").?.string);
+    try std.testing.expect(parsed.value.object.get("include_reasoning").?.bool);
+}
+
 test "chatWithHistory fails without key" {
     var p = OpenRouterProvider.init(std.testing.allocator, null);
     const messages = &[_]ChatMessage{
@@ -818,6 +854,25 @@ test "buildStreamingChatRequestBody escapes tool_call_id" {
     defer parsed.deinit();
     const msg = parsed.value.object.get("messages").?.array.items[0].object;
     try std.testing.expectEqualStrings("call_\"x\\y", msg.get("tool_call_id").?.string);
+}
+
+test "buildStreamingChatRequestBody includes session_id and include_reasoning" {
+    const msgs = [_]ChatMessage{
+        .{ .role = .user, .content = "hello" },
+    };
+    const req = ChatRequest{
+        .messages = &msgs,
+        .model = "moonshotai/kimi-k2.5",
+        .session_id = "discord:dm42",
+        .include_reasoning = true,
+    };
+    const body = try OpenRouterProvider.buildStreamingChatRequestBody(std.testing.allocator, req, "moonshotai/kimi-k2.5", 0.7);
+    defer std.testing.allocator.free(body);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("discord:dm42", parsed.value.object.get("session_id").?.string);
+    try std.testing.expect(parsed.value.object.get("include_reasoning").?.bool);
 }
 
 test "streamChatImpl fails without key" {

--- a/src/providers/root.zig
+++ b/src/providers/root.zig
@@ -251,6 +251,7 @@ pub const StreamCallback = *const fn (ctx: *anyopaque, chunk: StreamChunk) void;
 /// Result of a streaming chat call (accumulated after stream completes).
 pub const StreamChatResult = struct {
     content: ?[]const u8 = null,
+    reasoning_content: ?[]const u8 = null,
     usage: TokenUsage = .{},
     model: []const u8 = "",
 };
@@ -317,6 +318,8 @@ pub const ChatRequest = struct {
     timeout_secs: u64 = 0,
     /// Reasoning effort for reasoning models (o1, o3, gpt-5*). null = don't send.
     reasoning_effort: ?[]const u8 = null,
+    /// Provider hint for surfacing reasoning traces when supported.
+    include_reasoning: ?bool = null,
 };
 
 /// A single tool result message in a conversation.

--- a/src/providers/root.zig
+++ b/src/providers/root.zig
@@ -67,6 +67,7 @@ pub const extractContent = helpers.extractContent;
 pub const SplitThinkContent = helpers.SplitThinkContent;
 pub const splitThinkContent = helpers.splitThinkContent;
 pub const stripThinkBlocks = helpers.stripThinkBlocks;
+pub const extractReasoningTextFromDetails = helpers.extractReasoningTextFromDetails;
 pub const normalizeOpenAiReasoningEffort = helpers.normalizeOpenAiReasoningEffort;
 
 // Direct re-exports from utility modules
@@ -282,6 +283,8 @@ pub fn emitChatResponseAsStream(
     callback: StreamCallback,
     callback_ctx: *anyopaque,
 ) StreamChatResult {
+    const reasoning_content = response.reasoning_content;
+    response.reasoning_content = null;
     if (response.content) |content| {
         if (content.len > 0) {
             callback(callback_ctx, StreamChunk.textDelta(content));
@@ -291,6 +294,7 @@ pub fn emitChatResponseAsStream(
     freeStreamUnusedChatResponseFields(allocator, response);
     return .{
         .content = response.content,
+        .reasoning_content = reasoning_content,
         .usage = response.usage,
         .model = response.model,
     };
@@ -850,6 +854,7 @@ test "emitChatResponseAsStream frees unused chat response fields" {
     var ctx = CallbackCtx{};
     const result = emitChatResponseAsStream(allocator, &response, CallbackCtx.onChunk, @ptrCast(&ctx));
     defer if (result.content) |content| allocator.free(content);
+    defer if (result.reasoning_content) |reasoning| allocator.free(reasoning);
     defer if (result.model.len > 0) allocator.free(result.model);
 
     try std.testing.expectEqual(@as(usize, 1), ctx.text_count);
@@ -858,6 +863,7 @@ test "emitChatResponseAsStream frees unused chat response fields" {
     try std.testing.expectEqualStrings("", response.provider);
     try std.testing.expect(response.reasoning_content == null);
     try std.testing.expectEqualStrings("hello", result.content.?);
+    try std.testing.expectEqualStrings("private reasoning", result.reasoning_content.?);
     try std.testing.expectEqualStrings("test-model", result.model);
 }
 

--- a/src/providers/sse.zig
+++ b/src/providers/sse.zig
@@ -263,9 +263,10 @@ fn extractStreamUsage(json_str: []const u8) ?root.TokenUsage {
 }
 
 /// Extract visible streaming text from an SSE JSON payload.
-/// Falls back to `delta.reasoning` or `delta.reasoning_content` when providers stream their
-/// thinking trace separately and wraps it in think tags so higher layers can
-/// suppress it from user-visible output.
+/// Falls back to `delta.reasoning`, `delta.reasoning_content`, or
+/// `delta.reasoning_details` when providers stream their thinking trace
+/// separately and wraps it in think tags so higher layers can suppress it
+/// from user-visible output.
 /// Returns owned slice or null if no content found.
 pub fn extractDeltaContent(allocator: std.mem.Allocator, json_str: []const u8) !?[]const u8 {
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch
@@ -298,6 +299,13 @@ pub fn extractDeltaContent(allocator: std.mem.Allocator, json_str: []const u8) !
         if (reasoning_content == .string and reasoning_content.string.len > 0) {
             const wrapped = try std.fmt.allocPrint(allocator, "<think>{s}</think>", .{reasoning_content.string});
             return wrapped;
+        }
+    }
+
+    if (delta.object.get("reasoning_details")) |reasoning_details| {
+        if (try root.extractReasoningTextFromDetails(allocator, reasoning_details)) |reasoning_text| {
+            defer allocator.free(reasoning_text);
+            return try std.fmt.allocPrint(allocator, "<think>{s}</think>", .{reasoning_text});
         }
     }
 
@@ -1017,6 +1025,17 @@ test "extractDeltaContent falls back to reasoning_content when content missing" 
     const result = (try extractDeltaContent(allocator, "{\"choices\":[{\"delta\":{\"reasoning_content\":\"step by step\"}}]}")).?;
     defer allocator.free(result);
     try std.testing.expectEqualStrings("<think>step by step</think>", result);
+}
+
+// Regression: OpenRouter's current normalized streaming shape uses reasoning_details.
+test "extractDeltaContent falls back to reasoning_details when content missing" {
+    const allocator = std.testing.allocator;
+    const result = (try extractDeltaContent(
+        allocator,
+        "{\"choices\":[{\"delta\":{\"reasoning_details\":[{\"type\":\"reasoning.summary\",\"summary\":\"plan\"},{\"type\":\"reasoning.text\",\"text\":\"step by step\"}]}}]}",
+    )).?;
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("<think>plan\nstep by step</think>", result);
 }
 
 test "extractDeltaContent prefers visible content over reasoning_content" {

--- a/src/providers/sse.zig
+++ b/src/providers/sse.zig
@@ -8,6 +8,10 @@ const error_classify = @import("error_classify.zig");
 const verbose = @import("../verbose.zig");
 const log = std.log.scoped(.provider_sse);
 
+// Keep large request bodies out of argv. On Linux, a single oversized `-d`
+// argument can hit execve limits long before the total ARG_MAX budget.
+const MAX_INLINE_CURL_BODY_BYTES: usize = 64 * 1024;
+
 var curl_fail_fast_arg_mutex: std.Thread.Mutex = .{};
 var curl_fail_with_body_supported_cache: ?bool = null;
 const stream_stall_detection_args = [_][]const u8{
@@ -22,10 +26,13 @@ fn finalizeStreamResult(
     accumulated: []const u8,
     stream_usage: ?root.TokenUsage,
 ) !root.StreamChatResult {
-    const content = if (accumulated.len > 0)
-        try allocator.dupe(u8, accumulated)
-    else
-        null;
+    var content: ?[]const u8 = null;
+    var reasoning_content: ?[]const u8 = null;
+    if (accumulated.len > 0) {
+        const split = try root.splitThinkContent(allocator, accumulated);
+        content = split.visible;
+        reasoning_content = split.reasoning;
+    }
 
     var usage = stream_usage orelse root.TokenUsage{};
     if (usage.completion_tokens == 0) {
@@ -34,6 +41,7 @@ fn finalizeStreamResult(
 
     return .{
         .content = content,
+        .reasoning_content = reasoning_content,
         .usage = usage,
         .model = "",
     };
@@ -125,7 +133,8 @@ fn prepareCurlBodyArg(
     body: []const u8,
     log_enabled: bool,
 ) !CurlBodyArg {
-    if (builtin.os.tag != .windows) {
+    const should_use_temp_file = builtin.os.tag == .windows or body.len > MAX_INLINE_CURL_BODY_BYTES;
+    if (!should_use_temp_file) {
         return .{ .arg = body };
     }
 
@@ -254,7 +263,7 @@ fn extractStreamUsage(json_str: []const u8) ?root.TokenUsage {
 }
 
 /// Extract visible streaming text from an SSE JSON payload.
-/// Falls back to `delta.reasoning_content` when providers stream their
+/// Falls back to `delta.reasoning` or `delta.reasoning_content` when providers stream their
 /// thinking trace separately and wraps it in think tags so higher layers can
 /// suppress it from user-visible output.
 /// Returns owned slice or null if no content found.
@@ -276,6 +285,12 @@ pub fn extractDeltaContent(allocator: std.mem.Allocator, json_str: []const u8) !
     if (delta.object.get("content")) |content| {
         if (content == .string and content.string.len > 0) {
             return try allocator.dupe(u8, content.string);
+        }
+    }
+
+    if (delta.object.get("reasoning")) |reasoning| {
+        if (reasoning == .string and reasoning.string.len > 0) {
+            return try std.fmt.allocPrint(allocator, "<think>{s}</think>", .{reasoning.string});
         }
     }
 
@@ -874,7 +889,7 @@ test "parseSseLine valid delta without optional space" {
     }
 }
 
-test "prepareCurlBodyArg uses temp file only on Windows" {
+test "prepareCurlBodyArg keeps small bodies inline except on Windows" {
     const allocator = std.testing.allocator;
     const body = [_]u8{'x'} ** 4096;
     var prepared = try prepareCurlBodyArg(allocator, body[0..], false);
@@ -887,6 +902,16 @@ test "prepareCurlBodyArg uses temp file only on Windows" {
         try std.testing.expect(!prepared.uses_temp_file);
         try std.testing.expectEqualStrings(body[0..], prepared.arg);
     }
+}
+
+test "prepareCurlBodyArg spills large bodies to temp file" {
+    const allocator = std.testing.allocator;
+    const body = [_]u8{'x'} ** (MAX_INLINE_CURL_BODY_BYTES + 1);
+    var prepared = try prepareCurlBodyArg(allocator, body[0..], false);
+    defer prepared.deinit(allocator);
+
+    try std.testing.expect(prepared.uses_temp_file);
+    try std.testing.expect(std.mem.startsWith(u8, prepared.arg, "@"));
 }
 
 test "appendCurlStallDetectionArgs appends curl speed flags in order" {
@@ -975,6 +1000,14 @@ test "extractDeltaContent empty content" {
 test "extractDeltaContent falls back to reasoning_content when content empty" {
     const allocator = std.testing.allocator;
     const result = (try extractDeltaContent(allocator, "{\"choices\":[{\"delta\":{\"content\":\"\",\"reasoning_content\":\"step by step\"}}]}")).?;
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("<think>step by step</think>", result);
+}
+
+// Regression: OpenRouter's documented chat stream uses delta.reasoning.
+test "extractDeltaContent falls back to reasoning when content missing" {
+    const allocator = std.testing.allocator;
+    const result = (try extractDeltaContent(allocator, "{\"choices\":[{\"delta\":{\"reasoning\":\"step by step\"}}]}")).?;
     defer allocator.free(result);
     try std.testing.expectEqualStrings("<think>step by step</think>", result);
 }
@@ -1102,6 +1135,21 @@ test "extractStreamUsage returns null for chunk without usage" {
 
 test "extractStreamUsage returns null for invalid JSON" {
     try std.testing.expect(extractStreamUsage("not-json{{{") == null);
+}
+
+test "finalizeStreamResult separates think blocks into reasoning content" {
+    const result = try finalizeStreamResult(
+        std.testing.allocator,
+        "<think>private trace</think>Visible answer",
+        .{ .completion_tokens = 4, .total_tokens = 4 },
+    );
+    defer {
+        if (result.content) |content| std.testing.allocator.free(content);
+        if (result.reasoning_content) |reasoning| std.testing.allocator.free(reasoning);
+    }
+
+    try std.testing.expectEqualStrings("Visible answer", result.content.?);
+    try std.testing.expectEqualStrings("private trace", result.reasoning_content.?);
 }
 
 test "parseSseLine extracts usage from final chunk" {

--- a/src/streaming.zig
+++ b/src/streaming.zig
@@ -74,6 +74,7 @@ pub const TagFilter = struct {
         "<tool_result_begin",
         "<|tool_call_begin|",
         "<|tool_result_begin|",
+        "<think",
     };
 
     // Closing tags (fixed match).
@@ -84,6 +85,7 @@ pub const TagFilter = struct {
         "<tool_result_end>",
         "<|tool_call_end|>",
         "<|tool_result_end|>",
+        "</think>",
     };
 
     // Standalone control tokens that should be stripped, but do not wrap body text.
@@ -446,4 +448,16 @@ test "TagFilter strips section wrapper with mixed pipe-delimited close tag" {
     s.emitFinal();
     var buf: [96]u8 = undefined;
     try std.testing.expectEqualStrings("AB", col.joined(&buf));
+}
+
+test "TagFilter strips think blocks split across chunks" {
+    var col = collectChunks(16){};
+    var filter = TagFilter.init(col.sink());
+    const s = filter.sink();
+    s.emitChunk("Before <th");
+    s.emitChunk("ink>private");
+    s.emitChunk("</think> after");
+    s.emitFinal();
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("Before  after", col.joined(&buf));
 }


### PR DESCRIPTION
## Summary

### EN:
   - Extended the provider contract so requests can explicitly ask for reasoning traces and streaming results can return reasoning separately from visible content.
   - Updated the agent to pass the reasoning hint through provider requests, preserve streamed reasoning in the final response, and log whether reasoning was requested versus actually returned.
   - Updated the OpenRouter request builder to send both `session_id` and `include_reasoning`, matching the documented API surface.
   - Fixed SSE handling for OpenRouter-style reasoning streams by accepting `delta.reasoning`, separating `<think>` traces from visible output at stream finalization, and spilling oversized curl request bodies to temp files when inline `-d` would exceed safe argv limits.

### ZH:
   - 扩展了 provider contract，使请求可以显式要求返回 reasoning trace，并让流式结果把 reasoning 与可见内容分开返回。
   - 更新 agent，将 reasoning hint 透传到 provider 请求中，在最终响应里保留流式 reasoning，并记录 reasoning 是否被请求以及是否真的返回。
   - 更新 OpenRouter 请求构造逻辑，发送 `session_id` 与 `include_reasoning`，与其文档化 API 能力保持一致。
   - 修复 OpenRouter 风格 SSE reasoning 流处理：支持 `delta.reasoning`、在流结束时把 `<think>` 轨迹与可见内容分离，并在内联 `-d` 可能超过安全 argv 限制时把大请求体落到临时文件。

## Validation
   - zig build test --summary all

## Notes
   - Risk: Medium. The change touches shared provider request/streaming contracts, but the behavior is covered with regression tests for request serialization, SSE parsing, streamed reasoning extraction, and curl body handling.
