### PR TITLE
feat(channels): retry transient final outbound sends | 功能(channels): 为最终出站消息增加瞬时失败重试

### DIFF
--- a/src/channels/dispatch.zig
+++ b/src/channels/dispatch.zig
@@ -5,6 +5,7 @@ const bus = @import("../bus.zig");
 const outbound = @import("../outbound.zig");
 const Atomic = @import("../portable_atomic.zig").Atomic;
 const thread_stacks = @import("../thread_stacks.zig");
+const builtin = @import("builtin");
 
 /// Message dispatch — routes incoming ChannelMessages to the agent,
 /// routes agent responses back to the originating channel.
@@ -198,7 +199,7 @@ pub fn runOutboundDispatcher(
             registry.findByName(msg.channel);
 
         if (channel_opt) |channel| {
-            dispatchOutboundMessage(allocator, channel, msg, &draft_messages) catch {
+            dispatchOutboundMessageWithRetry(allocator, channel, msg, &draft_messages) catch {
                 _ = stats.errors.fetchAdd(1, .monotonic);
                 continue;
             };
@@ -206,6 +207,51 @@ pub fn runOutboundDispatcher(
         } else {
             _ = stats.channel_not_found.fetchAdd(1, .monotonic);
         }
+    }
+}
+
+const DeliveryFailureClass = enum {
+    transient,
+    permanent,
+};
+
+const MAX_FINAL_SEND_ATTEMPTS: usize = 3;
+const FINAL_SEND_RETRY_BACKOFF_MS = if (builtin.is_test)
+    [_]u64{ 0, 0 }
+else
+    [_]u64{ 250, 1000 };
+
+fn classifyOutboundFailure(err: anyerror) DeliveryFailureClass {
+    return switch (err) {
+        error.NotSupported,
+        error.InvalidTarget,
+        error.InvalidMessageRef,
+        => .permanent,
+        else => .transient,
+    };
+}
+
+fn shouldRetryOutboundMessage(msg: bus.OutboundMessage, err: anyerror) bool {
+    return msg.stage == .final and classifyOutboundFailure(err) == .transient;
+}
+
+fn dispatchOutboundMessageWithRetry(
+    allocator: Allocator,
+    channel: root.Channel,
+    msg: bus.OutboundMessage,
+    draft_messages: *DraftMessageMap,
+) !void {
+    var attempt: usize = 1;
+    while (true) {
+        dispatchOutboundMessage(allocator, channel, msg, draft_messages) catch |err| {
+            if (!shouldRetryOutboundMessage(msg, err) or attempt >= MAX_FINAL_SEND_ATTEMPTS) return err;
+            const backoff_idx = @min(attempt - 1, FINAL_SEND_RETRY_BACKOFF_MS.len - 1);
+            const backoff_ms = FINAL_SEND_RETRY_BACKOFF_MS[backoff_idx];
+            if (backoff_ms > 0) std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
+            attempt += 1;
+            continue;
+        };
+        return;
     }
 }
 
@@ -531,6 +577,8 @@ const MockChannel = struct {
     sent_count: Atomic(u64) = Atomic(u64).init(0),
     chunk_count: Atomic(u64) = Atomic(u64).init(0),
     should_fail: bool = false,
+    fail_first_final: bool = false,
+    final_attempts: Atomic(u64) = Atomic(u64).init(0),
 
     const vtable = root.Channel.VTable{
         .start = mockStart,
@@ -550,6 +598,8 @@ const MockChannel = struct {
     fn mockSend(ctx: *anyopaque, _: []const u8, _: []const u8, _: []const []const u8) anyerror!void {
         const self: *MockChannel = @ptrCast(@alignCast(ctx));
         if (self.should_fail) return error.SendFailed;
+        const attempt = self.final_attempts.fetchAdd(1, .monotonic) + 1;
+        if (self.fail_first_final and attempt == 1) return error.SendFailed;
         _ = self.sent_count.fetchAdd(1, .monotonic);
     }
     fn mockSendEvent(
@@ -563,7 +613,11 @@ const MockChannel = struct {
         if (self.should_fail) return error.SendFailed;
         switch (stage) {
             .chunk => _ = self.chunk_count.fetchAdd(1, .monotonic),
-            .final => _ = self.sent_count.fetchAdd(1, .monotonic),
+            .final => {
+                const attempt = self.final_attempts.fetchAdd(1, .monotonic) + 1;
+                if (self.fail_first_final and attempt == 1) return error.SendFailed;
+                _ = self.sent_count.fetchAdd(1, .monotonic);
+            },
         }
     }
     fn mockName(ctx: *anyopaque) []const u8 {
@@ -1196,6 +1250,37 @@ test "dispatcher increments errors on channel.send failure" {
     try std.testing.expectEqual(@as(u64, 0), stats.getDispatched());
     try std.testing.expectEqual(@as(u64, 1), stats.getErrors());
     try std.testing.expectEqual(@as(u64, 0), stats.getChannelNotFound());
+}
+
+// Regression: transient final-send failures must not drop the reply permanently.
+test "dispatcher retries transient final send once" {
+    const allocator = std.testing.allocator;
+
+    var mock_retry = MockChannel{ .name_str = "qq", .fail_first_final = true };
+    var reg = ChannelRegistry.init(allocator);
+    defer reg.deinit();
+    try reg.register(mock_retry.channel());
+
+    var event_bus = bus.Bus.init();
+    var stats = DispatchStats{};
+
+    const msg = try bus.makeOutbound(allocator, "qq", "c1", "hello");
+    try event_bus.publishOutbound(msg);
+    event_bus.close();
+
+    runOutboundDispatcher(allocator, &event_bus, &reg, &stats);
+
+    try std.testing.expectEqual(@as(u64, 1), stats.getDispatched());
+    try std.testing.expectEqual(@as(u64, 0), stats.getErrors());
+    try std.testing.expectEqual(@as(u64, 1), mock_retry.sent_count.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 2), mock_retry.final_attempts.load(.monotonic));
+}
+
+test "dispatcher classifies permanent and transient outbound failures" {
+    try std.testing.expectEqual(DeliveryFailureClass.permanent, classifyOutboundFailure(error.InvalidTarget));
+    try std.testing.expectEqual(DeliveryFailureClass.permanent, classifyOutboundFailure(error.NotSupported));
+    try std.testing.expectEqual(DeliveryFailureClass.transient, classifyOutboundFailure(error.QQApiError));
+    try std.testing.expectEqual(DeliveryFailureClass.transient, classifyOutboundFailure(error.SendFailed));
 }
 
 test "dispatcher handles multiple messages" {

--- a/src/channels/dispatch.zig
+++ b/src/channels/dispatch.zig
@@ -231,8 +231,10 @@ fn classifyOutboundFailure(err: anyerror) DeliveryFailureClass {
     };
 }
 
-fn shouldRetryOutboundMessage(msg: bus.OutboundMessage, err: anyerror) bool {
-    return msg.stage == .final and classifyOutboundFailure(err) == .transient;
+fn shouldRetryOutboundMessage(channel: root.Channel, msg: bus.OutboundMessage, err: anyerror) bool {
+    return msg.stage == .final and
+        !shouldUseTrackedDraftDispatch(channel, msg) and
+        classifyOutboundFailure(err) == .transient;
 }
 
 fn dispatchOutboundMessageWithRetry(
@@ -244,7 +246,7 @@ fn dispatchOutboundMessageWithRetry(
     var attempt: usize = 1;
     while (true) {
         dispatchOutboundMessage(allocator, channel, msg, draft_messages) catch |err| {
-            if (!shouldRetryOutboundMessage(msg, err) or attempt >= MAX_FINAL_SEND_ATTEMPTS) return err;
+            if (!shouldRetryOutboundMessage(channel, msg, err) or attempt >= MAX_FINAL_SEND_ATTEMPTS) return err;
             const backoff_idx = @min(attempt - 1, FINAL_SEND_RETRY_BACKOFF_MS.len - 1);
             const backoff_ms = FINAL_SEND_RETRY_BACKOFF_MS[backoff_idx];
             if (backoff_ms > 0) std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
@@ -259,6 +261,12 @@ fn deinitDraftMessages(allocator: Allocator, draft_messages: *DraftMessageMap) v
     var it = draft_messages.valueIterator();
     while (it.next()) |state| state.deinit(allocator);
     draft_messages.deinit(allocator);
+}
+
+fn shouldUseTrackedDraftDispatch(channel: root.Channel, msg: bus.OutboundMessage) bool {
+    return msg.draft_id != 0 and
+        !channel.supportsStreamingOutbound() and
+        supportsDraftStreaming(channel);
 }
 
 fn draftMessageKey(allocator: Allocator, msg: bus.OutboundMessage) ![]u8 {
@@ -305,10 +313,7 @@ fn dispatchOutboundMessage(
     msg: bus.OutboundMessage,
     draft_messages: *DraftMessageMap,
 ) !void {
-    if (msg.draft_id != 0 and
-        !channel.supportsStreamingOutbound() and
-        supportsDraftStreaming(channel))
-    {
+    if (shouldUseTrackedDraftDispatch(channel, msg)) {
         switch (msg.stage) {
             .chunk => return dispatchDraftChunk(allocator, channel, msg, draft_messages),
             .final => {
@@ -670,10 +675,12 @@ const MockDraftChannel = struct {
     allocator: Allocator,
     name_str: []const u8,
     supports_drafts: bool = true,
+    fail_first_delete: bool = false,
     sent_count: Atomic(u64) = Atomic(u64).init(0),
     tracked_count: Atomic(u64) = Atomic(u64).init(0),
     edit_count: Atomic(u64) = Atomic(u64).init(0),
     delete_count: Atomic(u64) = Atomic(u64).init(0),
+    delete_attempts: Atomic(u64) = Atomic(u64).init(0),
     last_tracked_text: ?[]u8 = null,
     last_edit_text: ?[]u8 = null,
 
@@ -726,6 +733,8 @@ const MockDraftChannel = struct {
     }
     fn mockDeleteMessage(ctx: *anyopaque, _: root.Channel.MessageRef) anyerror!void {
         const self: *MockDraftChannel = @ptrCast(@alignCast(ctx));
+        const attempt = self.delete_attempts.fetchAdd(1, .monotonic) + 1;
+        if (self.fail_first_delete and attempt == 1) return error.SendFailed;
         _ = self.delete_count.fetchAdd(1, .monotonic);
     }
     fn mockName(ctx: *anyopaque) []const u8 {
@@ -971,6 +980,43 @@ test "dispatcher deletes tracked draft on empty final" {
     try std.testing.expectEqual(@as(u64, 1), mock_external.tracked_count.load(.monotonic));
     try std.testing.expectEqual(@as(u64, 0), mock_external.edit_count.load(.monotonic));
     try std.testing.expectEqual(@as(u64, 1), mock_external.delete_count.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 0), mock_external.sent_count.load(.monotonic));
+}
+
+// Regression: retry logic must not turn a failed tracked-draft delete into a fresh outbound send.
+test "dispatcher does not retry tracked draft final delete failures" {
+    const allocator = std.testing.allocator;
+
+    var mock_external = MockDraftChannel{
+        .allocator = allocator,
+        .name_str = "external",
+        .fail_first_delete = true,
+    };
+    defer mock_external.deinit();
+
+    var reg = ChannelRegistry.init(allocator);
+    defer reg.deinit();
+    try reg.register(mock_external.channel());
+
+    var event_bus = bus.Bus.init();
+    var stats = DispatchStats{};
+
+    var chunk = try bus.makeOutboundChunk(allocator, "external", "chat1", "Hello");
+    chunk.draft_id = 22;
+    try event_bus.publishOutbound(chunk);
+
+    var final = try bus.makeOutbound(allocator, "external", "chat1", "");
+    final.draft_id = 22;
+    try event_bus.publishOutbound(final);
+    event_bus.close();
+
+    runOutboundDispatcher(allocator, &event_bus, &reg, &stats);
+
+    try std.testing.expectEqual(@as(u64, 1), stats.getDispatched());
+    try std.testing.expectEqual(@as(u64, 1), stats.getErrors());
+    try std.testing.expectEqual(@as(u64, 1), mock_external.tracked_count.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 1), mock_external.delete_attempts.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 0), mock_external.delete_count.load(.monotonic));
     try std.testing.expectEqual(@as(u64, 0), mock_external.sent_count.load(.monotonic));
 }
 


### PR DESCRIPTION
## Summary

### EN:
   - Added bounded retry handling for final outbound sends when a channel returns a transient transport error.
   - Classified outbound failures into transient and permanent classes so invalid targets and unsupported operations fail fast without duplicate retries.
   - Kept retry scope intentionally narrow to final-stage messages, with deterministic backoff behavior in tests and no changes to chunk or draft delivery paths.
   - Added regression coverage proving that a transient final-send failure is retried and eventually delivered instead of being dropped immediately.

### ZH:
   - 为最终阶段的出站消息增加了有界重试机制；当渠道返回瞬时传输错误时，运行时会自动再次投递。
   - 将出站发送失败明确区分为瞬时错误与永久错误，使无效目标、接口不支持等情况能够快速失败，避免无意义的重复发送。
   - 将重试范围刻意限制在 final 消息，测试中的退避行为保持确定性，不影响 chunk 或 draft 的现有投递路径。
   - 增加回归测试，验证最终消息在首次瞬时失败后会被重试并成功送达，而不是被直接丢弃。

## Validation
   - zig build test --summary all

## Notes
   - Risk: Medium. This change modifies shared outbound dispatch behavior, but only for final-message transport failures.