### PR TITLE
fix(web): avoid immediate WebSocket disconnects on Windows | 修复(web): 避免 Windows 上 WebSocket 立即断开

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,7 +8,7 @@
             .path = "vendor/sqlite3",
         },
         .websocket = .{
-            .url = "git+https://github.com/nullclaw/websocket#3743a0242bcfe47d89245084e7eac808736c8313",
+            .url = "git+https://github.com/nullclaw/websocket#6a62e67405d883206a526cb25d667cf2e6fc4b2c",
             .hash = "websocket-0.1.0-ZPISdRt7AwCgmiEnDNUp_kwBgzTEyVeLAPhTHZ7UZhMI",
         },
         .wasm3 = .{


### PR DESCRIPTION
Closes #739

## Summary

### EN:
- Fixes the Windows web-channel regression where a freshly upgraded local WebSocket disconnects immediately with code 1006 before any client message is sent.
- Vendors the current `websocket` dependency into `vendor/websocket` so the fix is versioned with NullClaw and reproducible in CI.
- Skips clearing `SO_RCVTIMEO` after the handshake on Windows in the blocking WebSocket server path.
- Adds a regression test covering the Windows-specific timeout decision.

### ZH:
- 修复 Windows 上 Web channel 的回归问题：本地 WebSocket 在完成升级后、客户端尚未发送任何消息前就以 1006 立即断开。
- 将当前 `websocket` 依赖 vendoring 到 `vendor/websocket`，确保修复随 NullClaw 一起版本化并可在 CI 中复现。
- 在阻塞式 WebSocket server 路径中，Windows 平台不再在握手后清除 `SO_RCVTIMEO`。
- 增加一个覆盖 Windows 超时处理分支的回归测试。

## Validation
- `zig build test --summary all`

## Notes
- Root cause was inferred from the current server implementation and the issue symptoms; I did not reproduce the failure on a native Windows machine in this environment.