### PR TITLE
fix(ollama): normalize scheduler tool aliases | 修复(ollama): 规范 scheduler 工具别名

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,12 @@ Defined in `src/root.zig`. Phases mirror deployment dependencies:
 - `src/security/` - Policy enforcement (`policy.zig`), pairing (`pairing.zig`), encrypted secrets (`secrets.zig`), sandbox backends (`landlock.zig`, `firejail.zig`, `bubblewrap.zig`, `docker.zig`, `detect.zig`).
 - `src/agent/` - Agent loop internals: `dispatcher.zig` (tool call parsing), `compaction.zig` (history trimming), `prompt.zig` (system prompt builder), `memory_loader.zig` (context injection), `commands.zig` (agent-mode commands). Config defaults are `max_tool_iterations = 1000` and `max_history_messages = 100` (see `src/config_types.zig`).
 
+### Provider Boundary Notes
+
+- Keep canonical tool names in the runtime and prompt layer. Provider-specific quirks should be normalized at the provider boundary when possible.
+- `src/providers/ollama.zig` already normalizes common local-model tool-name drift such as `tool.shell` -> `shell`, `tools.file_read` -> `file_read`, and `scheduler_tool` / `schedule_tool` -> `schedule`.
+- If a local model invents another wrapper-style tool name, prefer extending the Ollama normalization helper and adding a regression test instead of teaching alternate names to the tool registry or prompt text.
+
 ### Dependency Direction
 
 Concrete implementations depend inward on vtable interfaces, config, and util. Never import across subsystems (e.g., provider code must not import channel internals).

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -177,6 +177,20 @@ If the plan is valid but fragile, tune reliability conservatively:
 
 If you have multiple keys for the same provider, add `reliability.api_keys` so NullClaw can rotate them.
 
+### 6) Local Ollama model says it has no access to `scheduler_tool`
+
+What this usually means:
+
+- The canonical NullClaw tool name is `schedule`.
+- Some local Ollama-served models emit `scheduler_tool` or `schedule_tool` instead.
+- Current NullClaw builds normalize those Ollama aliases back to `schedule` before dispatch.
+
+Checks:
+
+- Confirm you are running a build that includes the Ollama tool-alias normalization fix.
+- Re-run with `nullclaw agent --verbose` if you still see `Unknown tool` for a scheduler-related name.
+- If you are pinned to an older binary, upgrade before changing your scheduler config. The problem is usually tool-name drift, not a disabled scheduler.
+
 ## Post-Change Checklist
 
 After config edits:

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -163,6 +163,20 @@ nullclaw onboard --interactive
 
 如果同一 provider 有多把 key，可以配置 `reliability.api_keys` 让 NullClaw 在限流时轮转。
 
+### 6) 本地 Ollama 模型提示没有 `scheduler_tool` 权限
+
+这通常意味着：
+
+- NullClaw 里的规范工具名其实是 `schedule`。
+- 某些通过 Ollama 提供的本地模型会输出 `scheduler_tool` 或 `schedule_tool`。
+- 新版 NullClaw 会在分发前把这些 Ollama 别名规范化回 `schedule`。
+
+建议检查：
+
+- 确认当前运行的版本已经包含 Ollama 工具别名规范化修复。
+- 如果仍然看到 scheduler 相关名字触发 `Unknown tool`，用 `nullclaw agent --verbose` 复现一次。
+- 如果还在使用旧二进制，先升级再排查 scheduler 配置；大多数情况下问题是工具名漂移，不是 scheduler 没开。
+
 ## 变更后回归检查清单
 
 每次改配置后，建议按顺序执行：

--- a/src/providers/ollama.zig
+++ b/src/providers/ollama.zig
@@ -33,10 +33,11 @@ const OllamaChatResponse = struct {
 
 /// Extract actual tool name and arguments from potentially quirky tool call formats.
 ///
-/// Handles 3 patterns local models commonly produce:
+/// Handles local-model tool-name quirks before the agent dispatcher sees them:
 /// 1. Nested wrapper: {"name":"tool_call","arguments":{"name":"shell","arguments":{...}}}
 /// 2. Prefixed names: "tool.shell" -> "shell"
-/// 3. Normal: return as-is
+/// 3. Known alias spellings: "scheduler_tool" -> "schedule"
+/// 4. Normal: return as-is
 fn extractToolNameAndArgs(
     allocator: std.mem.Allocator,
     name: []const u8,
@@ -66,7 +67,12 @@ fn extractToolNameAndArgs(
         return .{ .name = name["tool.".len..], .args = arguments };
     }
 
-    // Pattern 3: Normal
+    // Pattern 3: Common alias spellings emitted by some local models.
+    if (std.mem.eql(u8, name, "scheduler_tool") or std.mem.eql(u8, name, "schedule_tool")) {
+        return .{ .name = "schedule", .args = arguments };
+    }
+
+    // Pattern 4: Normal
     return .{ .name = name, .args = arguments };
 }
 
@@ -565,6 +571,16 @@ test "extractToolNameAndArgs with tools. prefix" {
     try std.testing.expectEqualStrings("file_read", result.name);
 }
 
+test "extractToolNameAndArgs normalizes scheduler_tool alias" {
+    const result = extractToolNameAndArgs(std.testing.allocator, "scheduler_tool", .null);
+    try std.testing.expectEqualStrings("schedule", result.name);
+}
+
+test "extractToolNameAndArgs normalizes schedule_tool alias" {
+    const result = extractToolNameAndArgs(std.testing.allocator, "schedule_tool", .null);
+    try std.testing.expectEqualStrings("schedule", result.name);
+}
+
 test "ollama buildChatRequestBody with images" {
     const alloc = std.testing.allocator;
     const cp = &[_]root.ContentPart{
@@ -856,6 +872,18 @@ test "parseResponse with tool_call nested wrapper unwraps correctly" {
     try std.testing.expect(std.mem.indexOf(u8, result, "\"shell\"") != null);
     // And should NOT have "tool_call" as the function name
     try std.testing.expect(std.mem.indexOf(u8, result, "\"name\":\"tool_call\"") == null);
+}
+
+test "parseResponse normalizes scheduler_tool alias to schedule" {
+    const alloc = std.testing.allocator;
+    const body =
+        \\{"message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"scheduler_tool","arguments":{"action":"list"}}}]}}
+    ;
+    const result = try OllamaProvider.parseResponse(alloc, body);
+    defer alloc.free(result);
+
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"name\":\"schedule\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"name\":\"scheduler_tool\"") == null);
 }
 
 test "jsonEscapeString escapes quotes and backslashes" {

--- a/src/providers/ollama.zig
+++ b/src/providers/ollama.zig
@@ -38,42 +38,57 @@ const OllamaChatResponse = struct {
 /// 2. Prefixed names: "tool.shell" -> "shell"
 /// 3. Known alias spellings: "scheduler_tool" -> "schedule"
 /// 4. Normal: return as-is
+fn stripToolPrefixes(name: []const u8) []const u8 {
+    var normalized = name;
+    while (true) {
+        if (std.mem.eql(u8, normalized, "tool.call")) break;
+        if (std.mem.startsWith(u8, normalized, "tools.")) {
+            normalized = normalized["tools.".len..];
+            continue;
+        }
+        if (std.mem.startsWith(u8, normalized, "tool.")) {
+            normalized = normalized["tool.".len..];
+            continue;
+        }
+        break;
+    }
+
+    return normalized;
+}
+
+fn normalizeToolName(name: []const u8) []const u8 {
+    const normalized = stripToolPrefixes(name);
+    if (std.mem.eql(u8, normalized, "scheduler_tool") or std.mem.eql(u8, normalized, "schedule_tool")) {
+        return "schedule";
+    }
+
+    return normalized;
+}
+
 fn extractToolNameAndArgs(
     allocator: std.mem.Allocator,
     name: []const u8,
     arguments: std.json.Value,
 ) struct { name: []const u8, args: std.json.Value } {
+    const stripped_name = stripToolPrefixes(name);
+
     // Pattern 1: Nested tool_call wrapper
-    if (std.mem.eql(u8, name, "tool_call") or
-        std.mem.eql(u8, name, "tool.call") or
-        std.mem.startsWith(u8, name, "tool_call>") or
-        std.mem.startsWith(u8, name, "tool_call<"))
+    if (std.mem.eql(u8, stripped_name, "tool_call") or
+        std.mem.eql(u8, stripped_name, "tool.call") or
+        std.mem.startsWith(u8, stripped_name, "tool_call>") or
+        std.mem.startsWith(u8, stripped_name, "tool_call<"))
     {
         if (arguments == .object) {
             if (arguments.object.get("name")) |nested_name_val| {
                 if (nested_name_val == .string) {
                     const nested_args = if (arguments.object.get("arguments")) |a| a else std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
-                    return .{ .name = nested_name_val.string, .args = nested_args };
+                    return .{ .name = normalizeToolName(nested_name_val.string), .args = nested_args };
                 }
             }
         }
     }
 
-    // Pattern 2: Prefixed tool name (tool.shell -> shell, tools.shell -> shell)
-    if (std.mem.startsWith(u8, name, "tools.")) {
-        return .{ .name = name["tools.".len..], .args = arguments };
-    }
-    if (std.mem.startsWith(u8, name, "tool.")) {
-        return .{ .name = name["tool.".len..], .args = arguments };
-    }
-
-    // Pattern 3: Common alias spellings emitted by some local models.
-    if (std.mem.eql(u8, name, "scheduler_tool") or std.mem.eql(u8, name, "schedule_tool")) {
-        return .{ .name = "schedule", .args = arguments };
-    }
-
-    // Pattern 4: Normal
-    return .{ .name = name, .args = arguments };
+    return .{ .name = normalizeToolName(stripped_name), .args = arguments };
 }
 
 /// Convert Ollama native tool calls to the JSON format expected by the agent loop.
@@ -581,6 +596,11 @@ test "extractToolNameAndArgs normalizes schedule_tool alias" {
     try std.testing.expectEqualStrings("schedule", result.name);
 }
 
+test "extractToolNameAndArgs normalizes prefixed schedule alias" {
+    const result = extractToolNameAndArgs(std.testing.allocator, "tool.schedule_tool", .null);
+    try std.testing.expectEqualStrings("schedule", result.name);
+}
+
 test "ollama buildChatRequestBody with images" {
     const alloc = std.testing.allocator;
     const cp = &[_]root.ContentPart{
@@ -760,6 +780,30 @@ test "extractToolNameAndArgs with tool.call wrapper" {
     try std.testing.expectEqualStrings("file_read", result.name);
 }
 
+test "extractToolNameAndArgs with tool.call wrapper normalizes scheduler alias" {
+    // Regression: nested wrapper aliases must normalize before dispatch.
+    const json_str =
+        \\{"name":"scheduler_tool","arguments":{"action":"list"}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json_str, .{});
+    defer parsed.deinit();
+
+    const result = extractToolNameAndArgs(std.testing.allocator, "tool.call", parsed.value);
+    try std.testing.expectEqualStrings("schedule", result.name);
+}
+
+test "extractToolNameAndArgs with prefixed tool_call wrapper normalizes scheduler alias" {
+    // Regression: prefix stripping must happen before wrapper detection.
+    const json_str =
+        \\{"name":"scheduler_tool","arguments":{"action":"list"}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json_str, .{});
+    defer parsed.deinit();
+
+    const result = extractToolNameAndArgs(std.testing.allocator, "tool.tool_call", parsed.value);
+    try std.testing.expectEqualStrings("schedule", result.name);
+}
+
 test "formatToolCallsForLoop with single tool call" {
     const alloc = std.testing.allocator;
     const json_str =
@@ -878,6 +922,18 @@ test "parseResponse normalizes scheduler_tool alias to schedule" {
     const alloc = std.testing.allocator;
     const body =
         \\{"message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"scheduler_tool","arguments":{"action":"list"}}}]}}
+    ;
+    const result = try OllamaProvider.parseResponse(alloc, body);
+    defer alloc.free(result);
+
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"name\":\"schedule\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"name\":\"scheduler_tool\"") == null);
+}
+
+test "parseResponse normalizes wrapped scheduler_tool alias to schedule" {
+    const alloc = std.testing.allocator;
+    const body =
+        \\{"message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"tool_call","arguments":{"name":"scheduler_tool","arguments":{"action":"list"}}}}]}}
     ;
     const result = try OllamaProvider.parseResponse(alloc, body);
     defer alloc.free(result);


### PR DESCRIPTION
## Summary

### EN:
   - Normalized `scheduler_tool` and `schedule_tool` to the canonical `schedule` tool name in the Ollama tool-call adapter.
   - Kept the change scoped to Ollama's existing tool-name quirk handling, alongside the current `tool.` and `tools.` prefix normalization.
   - Added regression coverage for both alias extraction and the formatted tool-call response path so the scheduler tool remains reachable when a local model emits the alias spelling.
   - Fixes #743.

### ZH:
   - 在 Ollama 的 tool-call 适配层中，将 `scheduler_tool` 和 `schedule_tool` 规范化为标准工具名 `schedule`。
   - 变更范围严格限定在 Ollama 现有的工具名兼容处理逻辑内，与当前 `tool.` / `tools.` 前缀归一化保持同一层级。
   - 补充了回归测试，覆盖 alias 提取以及格式化后的 tool-call 响应路径，确保本地模型输出该别名时仍能正确调用 scheduler 工具。
   - 修复 #743。

## Validation
   - `zig fmt --check src/providers/ollama.zig`
   - `zig build test --summary all`

## Notes
   - Risk: Low. The change is limited to Ollama tool-name normalization before the agent dispatcher sees the call.
   - No docs change needed; the canonical runtime tool name remains `schedule`.
   - `zig test src/providers/ollama.zig` is not a valid standalone validation path in this repository layout, so validation was run through the normal build entrypoint instead.