### PR TITLE
docs: add Docker onboarding troubleshooting for AccessDenied error

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -265,3 +265,51 @@ brew uninstall nullclaw
 - [Configuration](./configuration.md)
 - [Usage and Operations](./usage.md)
 - [Commands](./commands.md)
+
+## Docker Troubleshooting
+
+### AccessDenied Error During Onboarding
+
+If you encounter `error: AccessDenied` when running Docker compose onboarding:
+
+```bash
+docker compose --profile agent run --rm agent onboard --interactive
+# Error at step 8: AccessDenied
+```
+
+**Cause:** The default workspace path `/nullclaw-data/.nullclaw/workspace` may have permission issues with the Docker volume mount.
+
+**Solution 1: Use a custom workspace path**
+
+When prompted at step 8, enter a simpler path:
+
+```
+Step 8/8: Workspace path [/nullclaw-data/.nullclaw/workspace]: /tmp/nullclaw-workspace
+```
+
+**Solution 2: Fix volume permissions**
+
+Ensure the Docker volume is properly mounted in `docker-compose.yml`:
+
+```yaml
+volumes:
+  - nullclaw-data:/nullclaw-data
+```
+
+Then recreate the volume:
+
+```bash
+docker compose down -v
+docker compose --profile agent run --rm agent onboard --interactive
+```
+
+**Solution 3: Run with explicit volume mount**
+
+```bash
+docker run --rm -it \
+  -v nullclaw-data:/nullclaw-data \
+  ghcr.io/nullclaw/nullclaw:latest \
+  onboard --interactive
+```
+
+At step 8, use: `/nullclaw-data/workspace`


### PR DESCRIPTION
## Description

Fixes #747 - Adds documentation workaround for Docker compose onboarding AccessDenied error.

## Changes

- Added troubleshooting section to installation.md
- Documents the AccessDenied error at step 8 of onboarding
- Provides 3 solutions:
  1. Use custom workspace path (/tmp/nullclaw-workspace)
  2. Fix Docker volume permissions
  3. Run with explicit volume mount

## Testing

Verified the workaround by testing with Docker:
```bash
docker compose --profile agent run --rm agent onboard --interactive
# At step 8, enter: /tmp/nullclaw-workspace
```

## Validation

- [x] Documentation only change
- [x] zig fmt --check docs/