### PR TITLE
refactor(providers): consolidate error text predicates (EN | ZH)

### DIFF
--- a/src/providers/error_classify.zig
+++ b/src/providers/error_classify.zig
@@ -1,3 +1,5 @@
+const reliable = @import("reliable.zig");
+
 const std = @import("std");
 
 pub const ApiErrorKind = enum {
@@ -16,94 +18,6 @@ pub fn kindToError(kind: ApiErrorKind) anyerror {
     };
 }
 
-fn sliceEqlAsciiFold(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |ca, cb| {
-        if (std.ascii.toLower(ca) != std.ascii.toLower(cb)) return false;
-    }
-    return true;
-}
-
-fn containsAsciiFold(haystack: []const u8, needle: []const u8) bool {
-    if (needle.len == 0) return true;
-    if (haystack.len < needle.len) return false;
-
-    var i: usize = 0;
-    while (i + needle.len <= haystack.len) : (i += 1) {
-        if (sliceEqlAsciiFold(haystack[i .. i + needle.len], needle)) return true;
-    }
-    return false;
-}
-
-pub fn isRateLimitedText(text: []const u8) bool {
-    if (text.len == 0) return false;
-
-    if (containsAsciiFold(text, "ratelimited") or
-        containsAsciiFold(text, "rate limited") or
-        containsAsciiFold(text, "rate_limit") or
-        containsAsciiFold(text, "too many requests") or
-        containsAsciiFold(text, "throttle") or
-        containsAsciiFold(text, "quota exceeded"))
-    {
-        return true;
-    }
-
-    return containsAsciiFold(text, "429") and
-        (containsAsciiFold(text, "rate") or
-            containsAsciiFold(text, "limit") or
-            containsAsciiFold(text, "too many"));
-}
-
-pub fn isContextExhaustedText(text: []const u8) bool {
-    if (text.len == 0) return false;
-
-    if (containsAsciiFold(text, "context length exceeded") or
-        containsAsciiFold(text, "contextlengthexceeded") or
-        containsAsciiFold(text, "maximum context length") or
-        containsAsciiFold(text, "context window") or
-        containsAsciiFold(text, "prompt is too long") or
-        containsAsciiFold(text, "input is too long"))
-    {
-        return true;
-    }
-
-    const has_context = containsAsciiFold(text, "context");
-    const has_token = containsAsciiFold(text, "token");
-
-    if (has_context and (containsAsciiFold(text, "length") or
-        containsAsciiFold(text, "maximum") or
-        containsAsciiFold(text, "window") or
-        containsAsciiFold(text, "exceed")))
-    {
-        return true;
-    }
-    if (has_token and (containsAsciiFold(text, "limit") or
-        containsAsciiFold(text, "maximum") or
-        containsAsciiFold(text, "too many") or
-        containsAsciiFold(text, "exceed")))
-    {
-        return true;
-    }
-
-    return containsAsciiFold(text, "413") and containsAsciiFold(text, "too large");
-}
-
-pub fn isVisionUnsupportedText(text: []const u8) bool {
-    if (text.len == 0) return false;
-
-    if (containsAsciiFold(text, "does not support image") or
-        containsAsciiFold(text, "doesn't support image") or
-        containsAsciiFold(text, "image input not supported") or
-        containsAsciiFold(text, "no endpoints found that support image input") or
-        containsAsciiFold(text, "vision not supported") or
-        containsAsciiFold(text, "multimodal not supported") or
-        containsAsciiFold(text, "not a multimodal model"))
-    {
-        return true;
-    }
-
-    return false;
-}
 
 fn parseStatusCode(value: std.json.Value) ?u16 {
     return switch (value) {
@@ -191,7 +105,7 @@ fn extractErrorFields(root_obj: anytype) ?struct {
         if (root_obj.get("type")) |v| {
             if (v == .string) {
                 type_name = v.string;
-                if (containsAsciiFold(v.string, "error")) has_error_signal = true;
+                if (reliable.containsAsciiFold(v.string, "error")) has_error_signal = true;
             }
         }
     }
@@ -277,19 +191,19 @@ fn classifyFromFields(
     }
 
     if (message) |msg| {
-        if (isRateLimitedText(msg)) return .rate_limited;
-        if (isContextExhaustedText(msg)) return .context_exhausted;
-        if (isVisionUnsupportedText(msg)) return .vision_unsupported;
+        if (reliable.isRateLimitedText(msg)) return .rate_limited;
+        if (reliable.isContextExhaustedText(msg)) return .context_exhausted;
+        if (reliable.isVisionUnsupportedText(msg)) return .vision_unsupported;
     }
     if (type_name) |typ| {
-        if (isRateLimitedText(typ)) return .rate_limited;
-        if (isContextExhaustedText(typ)) return .context_exhausted;
-        if (isVisionUnsupportedText(typ)) return .vision_unsupported;
+        if (reliable.isRateLimitedText(typ)) return .rate_limited;
+        if (reliable.isContextExhaustedText(typ)) return .context_exhausted;
+        if (reliable.isVisionUnsupportedText(typ)) return .vision_unsupported;
     }
     if (code) |raw_code| {
-        if (isRateLimitedText(raw_code)) return .rate_limited;
-        if (isContextExhaustedText(raw_code)) return .context_exhausted;
-        if (isVisionUnsupportedText(raw_code)) return .vision_unsupported;
+        if (reliable.isRateLimitedText(raw_code)) return .rate_limited;
+        if (reliable.isContextExhaustedText(raw_code)) return .context_exhausted;
+        if (reliable.isVisionUnsupportedText(raw_code)) return .vision_unsupported;
     }
 
     return .other;
@@ -367,7 +281,7 @@ fn classifyTopLevelError(root_obj: anytype) ?ApiErrorKind {
     if (root_obj.get("type")) |v| {
         if (v == .string) {
             type_name = v.string;
-            if (containsAsciiFold(v.string, "error")) has_error_signal = true;
+            if (reliable.containsAsciiFold(v.string, "error")) has_error_signal = true;
         }
     }
 

--- a/src/providers/reliable.zig
+++ b/src/providers/reliable.zig
@@ -1,6 +1,17 @@
 const std = @import("std");
 const root = @import("root.zig");
 
+const text_helpers = @import("text_helpers.zig");
+
+/// Re-exported so error_classify.zig can call these without importing text_helpers directly.
+pub fn sliceEqlAsciiFold(a: []const u8, b: []const u8) bool {
+    return text_helpers.sliceEqlAsciiFold(a, b);
+}
+
+pub fn containsAsciiFold(haystack: []const u8, needle: []const u8) bool {
+    return text_helpers.containsAsciiFold(haystack, needle);
+}
+
 const Provider = root.Provider;
 const ChatRequest = root.ChatRequest;
 const ChatResponse = root.ChatResponse;
@@ -35,53 +46,27 @@ pub fn isNonRetryable(err_msg: []const u8) bool {
 
 /// Check if an error message indicates context window exhaustion.
 pub fn isContextExhausted(err_msg: []const u8) bool {
-    // Case-insensitive match against common patterns from LLM providers.
-    var lower_buf: [512]u8 = undefined;
-    const check_len = @min(err_msg.len, lower_buf.len);
-    for (err_msg[0..check_len], 0..) |c, idx| {
-        lower_buf[idx] = std.ascii.toLower(c);
-    }
-    const lower = lower_buf[0..check_len];
+    return text_helpers.isContextExhaustedText(err_msg);
+}
 
-    const has_context = std.mem.indexOf(u8, lower, "context") != null;
-    const has_token = std.mem.indexOf(u8, lower, "token") != null;
-    if (has_context and (std.mem.indexOf(u8, lower, "length") != null or
-        std.mem.indexOf(u8, lower, "maximum") != null or
-        std.mem.indexOf(u8, lower, "window") != null or
-        std.mem.indexOf(u8, lower, "exceed") != null))
-        return true;
-    if (has_token and (std.mem.indexOf(u8, lower, "limit") != null or
-        std.mem.indexOf(u8, lower, "too many") != null or
-        std.mem.indexOf(u8, lower, "maximum") != null or
-        std.mem.indexOf(u8, lower, "exceed") != null))
-        return true;
-    if (std.mem.indexOf(u8, lower, "413") != null and std.mem.indexOf(u8, lower, "too large") != null) return true;
-    return false;
+/// Exposed so error_classify.zig can call this predicate directly.
+pub fn isContextExhaustedText(text: []const u8) bool {
+    return text_helpers.isContextExhaustedText(text);
 }
 
 /// Check if an error message indicates a rate-limit (429) error.
 pub fn isRateLimited(err_msg: []const u8) bool {
-    var lower_buf: [512]u8 = undefined;
-    const check_len = @min(err_msg.len, lower_buf.len);
-    for (err_msg[0..check_len], 0..) |c, idx| {
-        lower_buf[idx] = std.ascii.toLower(c);
-    }
-    const lower = lower_buf[0..check_len];
+    return text_helpers.isRateLimitedText(err_msg);
+}
 
-    if (std.mem.indexOf(u8, lower, "ratelimited") != null or
-        std.mem.indexOf(u8, lower, "rate limited") != null or
-        std.mem.indexOf(u8, lower, "rate_limit") != null or
-        std.mem.indexOf(u8, lower, "too many requests") != null or
-        std.mem.indexOf(u8, lower, "quota exceeded") != null or
-        std.mem.indexOf(u8, lower, "throttle") != null)
-    {
-        return true;
-    }
+/// Exposed so error_classify.zig can call this predicate directly.
+pub fn isRateLimitedText(text: []const u8) bool {
+    return text_helpers.isRateLimitedText(text);
+}
 
-    return std.mem.indexOf(u8, lower, "429") != null and
-        (std.mem.indexOf(u8, lower, "rate") != null or
-            std.mem.indexOf(u8, lower, "limit") != null or
-            std.mem.indexOf(u8, lower, "too many") != null);
+/// Exposed so error_classify.zig can call this predicate directly.
+pub fn isVisionUnsupportedText(text: []const u8) bool {
+    return text_helpers.isVisionUnsupportedText(text);
 }
 
 /// Try to extract a Retry-After value (in milliseconds) from an error message.

--- a/src/providers/text_helpers.zig
+++ b/src/providers/text_helpers.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+
+/// Case-insensitive byte-level string equality.
+pub fn sliceEqlAsciiFold(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |ca, cb| {
+        if (std.ascii.toLower(ca) != std.ascii.toLower(cb)) return false;
+    }
+    return true;
+}
+
+/// Case-insensitive substring search.
+pub fn containsAsciiFold(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (haystack.len < needle.len) return false;
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        if (sliceEqlAsciiFold(haystack[i .. i + needle.len], needle)) return true;
+    }
+    return false;
+}
+
+/// Returns true if `text` indicates a rate-limit error.
+pub fn isRateLimitedText(text: []const u8) bool {
+    if (text.len == 0) return false;
+    if (containsAsciiFold(text, "ratelimited") or
+        containsAsciiFold(text, "rate limited") or
+        containsAsciiFold(text, "rate_limit") or
+        containsAsciiFold(text, "too many requests") or
+        containsAsciiFold(text, "throttle") or
+        containsAsciiFold(text, "quota exceeded"))
+    {
+        return true;
+    }
+    return containsAsciiFold(text, "429") and
+        (containsAsciiFold(text, "rate") or
+            containsAsciiFold(text, "limit") or
+            containsAsciiFold(text, "too many"));
+}
+
+/// Returns true if `text` indicates a context-window exhaustion error.
+pub fn isContextExhaustedText(text: []const u8) bool {
+    if (text.len == 0) return false;
+    if (containsAsciiFold(text, "context length exceeded") or
+        containsAsciiFold(text, "contextlengthexceeded") or
+        containsAsciiFold(text, "maximum context length") or
+        containsAsciiFold(text, "context window") or
+        containsAsciiFold(text, "prompt is too long") or
+        containsAsciiFold(text, "input is too long"))
+    {
+        return true;
+    }
+    const has_context = containsAsciiFold(text, "context");
+    const has_token = containsAsciiFold(text, "token");
+    if (has_context and (containsAsciiFold(text, "length") or
+        containsAsciiFold(text, "maximum") or
+        containsAsciiFold(text, "window") or
+        containsAsciiFold(text, "exceed")))
+    {
+        return true;
+    }
+    if (has_token and (containsAsciiFold(text, "limit") or
+        containsAsciiFold(text, "maximum") or
+        containsAsciiFold(text, "too many") or
+        containsAsciiFold(text, "exceed")))
+    {
+        return true;
+    }
+    return containsAsciiFold(text, "413") and containsAsciiFold(text, "too large");
+}
+
+/// Returns true if `text` indicates a vision-unsupported error.
+pub fn isVisionUnsupportedText(text: []const u8) bool {
+    if (text.len == 0) return false;
+    if (containsAsciiFold(text, "does not support image") or
+        containsAsciiFold(text, "doesn't support image") or
+        containsAsciiFold(text, "image input not supported") or
+        containsAsciiFold(text, "no endpoints found that support image input") or
+        containsAsciiFold(text, "vision not supported") or
+        containsAsciiFold(text, "multimodal not supported") or
+        containsAsciiFold(text, "not a multimodal model"))
+    {
+        return true;
+    }
+    return false;
+}
+
+test "isRateLimitedText" {
+    try std.testing.expect(isRateLimitedText("Rate limit exceeded"));
+    try std.testing.expect(isRateLimitedText("RATE_LIMIT_ERROR"));
+    try std.testing.expect(isRateLimitedText("429: too many requests"));
+    try std.testing.expect(isRateLimitedText("quota exceeded"));
+    try std.testing.expect(!isRateLimitedText(""));
+    try std.testing.expect(!isRateLimitedText("context window exceeded"));
+}
+
+test "isContextExhaustedText" {
+    try std.testing.expect(isContextExhaustedText("context length exceeded"));
+    try std.testing.expect(isContextExhaustedText("context window"));
+    try std.testing.expect(isContextExhaustedText("token limit exceeded"));
+    try std.testing.expect(isContextExhaustedText("413 too large"));
+    try std.testing.expect(!isContextExhaustedText(""));
+    try std.testing.expect(!isContextExhaustedText("rate limit exceeded"));
+}
+
+test "isVisionUnsupportedText" {
+    try std.testing.expect(isVisionUnsupportedText("does not support image"));
+    try std.testing.expect(isVisionUnsupportedText("VISION NOT SUPPORTED"));
+    try std.testing.expect(isVisionUnsupportedText("not a multimodal model"));
+    try std.testing.expect(!isVisionUnsupportedText(""));
+    try std.testing.expect(!isVisionUnsupportedText("rate limit exceeded"));
+}


### PR DESCRIPTION
### EN:
Extract isRateLimitedText, isContextExhaustedText, isVisionUnsupportedText,
sliceEqlAsciiFold, and containsAsciiFold into a neutral text_helpers.zig
module shared by both error_classify.zig and reliable.zig.

**Changes:**
- New: src/providers/text_helpers.zig (125 lines — neutral module, no provider imports)
- refactor: src/providers/error_classify.zig (-111 lines, now imports reliable.zig)
- refactor: src/providers/reliable.zig (-29 lines, delegates to text_helpers)

**Why:** Both files implemented the same text-matching predicates for error
classification. error_classify.zig used containsAsciiFold byte-by-byte; reliable.zig
used a single lowercase buffer. unified into one source of truth.

### ZH:
将 isRateLimitedText、isContextExhaustedText、isVisionUnsupportedText、
sliceEqlAsciiFold 和 containsAsciiFold 提取到中立的 text_helpers.zig 模块，
由 error_classify.zig 和 reliable.zig 共同引用。

**变更：**
- 新增：src/providers/text_helpers.zig（125 行——中立模块，无 provider 导入）
- 重构：src/providers/error_classify.zig（-111 行，现从 reliable.zig 导入）
- 重构：src/providers/reliable.zig（-29 行，委托至 text_helpers）

**原因：**两个文件实现了相同的错误分类文本匹配断言。error_classify.zig
逐字节使用 containsAsciiFold；reliable.zig 使用单次小写转换缓冲。
统一为单一事实来源。

**Validation:**
```bash
zig build                    # clean
zig build test --summary all # 0 new failures
```