### PR TITLE
fix(cli): filter streamed tool-call markup

### DIFF
--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -35,6 +35,7 @@ const Agent = @import("root.zig").Agent;
 const CliStreamCtx = struct {
     sink: streaming.Sink,
     emitted_text: bool = false,
+    filter: streaming.TagFilter = undefined,
 };
 
 const CliProviderContext = struct {
@@ -65,6 +66,11 @@ fn cliStreamSinkCallback(_: *anyopaque, event: streaming.Event) void {
     const wr = &bw.interface;
     wr.print("{s}", .{event.text}) catch {};
     wr.flush() catch {};
+}
+
+fn makeCliStreamSink(raw_sink: streaming.Sink, filter: *streaming.TagFilter) streaming.Sink {
+    filter.* = streaming.TagFilter.init(raw_sink);
+    return filter.sink();
 }
 
 /// Streaming callback that forwards provider chunks into unified stream sink events.
@@ -486,13 +492,14 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         defer agent.deinit();
 
         // Enable streaming if provider supports it
-        var stream_sink_ctx: u8 = 0;
         var stream_ctx = CliStreamCtx{
-            .sink = .{
-                .callback = cliStreamSinkCallback,
-                .ctx = @ptrCast(&stream_sink_ctx),
-            },
+            .sink = undefined,
         };
+        const raw_stream_sink = streaming.Sink{
+            .callback = cliStreamSinkCallback,
+            .ctx = @ptrCast(&stream_ctx),
+        };
+        stream_ctx.sink = makeCliStreamSink(raw_stream_sink, &stream_ctx.filter);
         if (supports_streaming) {
             agent.stream_callback = cliStreamCallback;
             agent.stream_ctx = @ptrCast(&stream_ctx);
@@ -594,13 +601,14 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
     defer agent.deinit();
 
     // Enable streaming if provider supports it
-    var stream_sink_ctx: u8 = 0;
     var stream_ctx = CliStreamCtx{
-        .sink = .{
-            .callback = cliStreamSinkCallback,
-            .ctx = @ptrCast(&stream_sink_ctx),
-        },
+        .sink = undefined,
     };
+    const raw_stream_sink = streaming.Sink{
+        .callback = cliStreamSinkCallback,
+        .ctx = @ptrCast(&stream_ctx),
+    };
+    stream_ctx.sink = makeCliStreamSink(raw_stream_sink, &stream_ctx.filter);
     if (supports_streaming) {
         agent.stream_callback = cliStreamCallback;
         agent.stream_ctx = @ptrCast(&stream_ctx);
@@ -827,6 +835,37 @@ test "cliStreamCallback text delta chunk" {
     try std.testing.expectEqualStrings("hello", chunk.delta);
     try std.testing.expect(!chunk.is_final);
     try std.testing.expectEqual(@as(u32, 2), chunk.token_count);
+    try std.testing.expect(ctx.emitted_text);
+}
+
+test "makeCliStreamSink strips streamed tool_call markup" {
+    const Collector = struct {
+        buf: [128]u8 = undefined,
+        len: usize = 0,
+
+        fn callback(ctx_ptr: *anyopaque, event: streaming.Event) void {
+            if (event.stage != .chunk or event.text.len == 0) return;
+            const self: *@This() = @ptrCast(@alignCast(ctx_ptr));
+            @memcpy(self.buf[self.len..][0..event.text.len], event.text);
+            self.len += event.text.len;
+        }
+    };
+
+    var collector = Collector{};
+    var filter: streaming.TagFilter = undefined;
+    const raw_sink = streaming.Sink{
+        .callback = Collector.callback,
+        .ctx = @ptrCast(&collector),
+    };
+    const filtered_sink = makeCliStreamSink(raw_sink, &filter);
+
+    var ctx = CliStreamCtx{ .sink = filtered_sink };
+    cliStreamCallback(@ptrCast(&ctx), providers.StreamChunk.textDelta(
+        "Let me check the projects for you.<tool_call>{\"name\":\"mcp_vikunja_vikunja_list_projects\",\"arguments\":{}}</tool_call>",
+    ));
+    cliStreamCallback(@ptrCast(&ctx), providers.StreamChunk.finalChunk());
+
+    try std.testing.expectEqualStrings("Let me check the projects for you.", collector.buf[0..collector.len]);
     try std.testing.expect(ctx.emitted_text);
 }
 

--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -4,6 +4,7 @@
 //! for `nullclaw agent`) and the streaming stdout callback.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const log = std.log.scoped(.agent);
 const Config = @import("../config.zig").Config;
 const config_types = @import("../config_types.zig");
@@ -59,8 +60,14 @@ fn shouldPrintTurnResponse(supports_streaming: bool, emitted_text: bool) bool {
     return !supports_streaming or !emitted_text;
 }
 
-fn cliStreamSinkCallback(_: *anyopaque, event: streaming.Event) void {
+fn cliStreamSinkCallback(ctx_ptr: *anyopaque, event: streaming.Event) void {
     if (event.stage != .chunk or event.text.len == 0) return;
+    const stream_ctx: *CliStreamCtx = @ptrCast(@alignCast(ctx_ptr));
+    stream_ctx.emitted_text = true;
+
+    // In tests, stdout is used by Zig's test runner protocol (`--listen`).
+    if (builtin.is_test) return;
+
     var buf: [4096]u8 = undefined;
     var bw = std.fs.File.stdout().writer(&buf);
     const wr = &bw.interface;
@@ -76,9 +83,6 @@ fn makeCliStreamSink(raw_sink: streaming.Sink, filter: *streaming.TagFilter) str
 /// Streaming callback that forwards provider chunks into unified stream sink events.
 fn cliStreamCallback(ctx_ptr: *anyopaque, chunk: providers.StreamChunk) void {
     const stream_ctx: *CliStreamCtx = @ptrCast(@alignCast(ctx_ptr));
-    if (!chunk.is_final and chunk.delta.len > 0) {
-        stream_ctx.emitted_text = true;
-    }
     streaming.forwardProviderChunk(stream_ctx.sink, chunk);
 }
 
@@ -823,13 +827,14 @@ test "buildCliDebouncedInput preserves queued bypass command" {
 }
 
 test "cliStreamCallback text delta chunk" {
-    var sink_ctx: u8 = 0;
     var ctx = CliStreamCtx{
-        .sink = .{
-            .callback = noopSinkEvent,
-            .ctx = @ptrCast(&sink_ctx),
-        },
+        .sink = undefined,
     };
+    const raw_sink = streaming.Sink{
+        .callback = cliStreamSinkCallback,
+        .ctx = @ptrCast(&ctx),
+    };
+    ctx.sink = makeCliStreamSink(raw_sink, &ctx.filter);
     const chunk = providers.StreamChunk.textDelta("hello");
     cliStreamCallback(@ptrCast(&ctx), chunk);
     try std.testing.expectEqualStrings("hello", chunk.delta);
@@ -866,7 +871,26 @@ test "makeCliStreamSink strips streamed tool_call markup" {
     cliStreamCallback(@ptrCast(&ctx), providers.StreamChunk.finalChunk());
 
     try std.testing.expectEqualStrings("Let me check the projects for you.", collector.buf[0..collector.len]);
-    try std.testing.expect(ctx.emitted_text);
+}
+
+test "cliStreamCallback keeps emitted_text false for filtered tool_call-only chunk" {
+    var ctx = CliStreamCtx{
+        .sink = undefined,
+    };
+    const raw_sink = streaming.Sink{
+        .callback = cliStreamSinkCallback,
+        .ctx = @ptrCast(&ctx),
+    };
+    ctx.sink = makeCliStreamSink(raw_sink, &ctx.filter);
+
+    // Regression: tool-only streamed control markup must not suppress the final fallback response.
+    cliStreamCallback(@ptrCast(&ctx), providers.StreamChunk.textDelta(
+        "<tool_call>{\"name\":\"mcp_vikunja_vikunja_list_projects\",\"arguments\":{}}</tool_call>",
+    ));
+    cliStreamCallback(@ptrCast(&ctx), providers.StreamChunk.finalChunk());
+
+    try std.testing.expect(!ctx.emitted_text);
+    try std.testing.expect(shouldPrintTurnResponse(true, ctx.emitted_text));
 }
 
 test "parseAgentArgs parses provider and model overrides" {

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -33,6 +33,7 @@ pub const McpServer = struct {
     name: []const u8,
     config: McpServerConfig,
     child: ?std.process.Child,
+    child_env: ?std.process.EnvMap,
     http_client: ?std.http.Client,
     next_id: u32,
     mcp_session_id: ?[]u8,
@@ -43,6 +44,7 @@ pub const McpServer = struct {
             .name = config.name,
             .config = config,
             .child = null,
+            .child_env = null,
             .http_client = null,
             .next_id = 1,
             .mcp_session_id = null,
@@ -97,6 +99,7 @@ pub const McpServer = struct {
 
         // Build environment: inherit parent + config overrides
         var env = std.process.EnvMap.init(self.allocator);
+        errdefer env.deinit();
         // Add PATH, HOME, etc. from parent
         const inherit_vars = [_][]const u8{
             "PATH",              "HOME",        "TERM",    "LANG",         "LC_ALL",
@@ -120,6 +123,7 @@ pub const McpServer = struct {
 
         try child.spawn();
         self.child = child;
+        self.child_env = env;
     }
 
     fn connectHttp(self: *McpServer) !void {
@@ -173,6 +177,10 @@ pub const McpServer = struct {
             _ = child.wait() catch {};
         }
         self.child = null;
+        if (self.child_env) |*env| {
+            env.deinit();
+            self.child_env = null;
+        }
     }
 
     // ── Internal I/O ────────────────────────────────────────────

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -33,7 +33,6 @@ pub const McpServer = struct {
     name: []const u8,
     config: McpServerConfig,
     child: ?std.process.Child,
-    child_env: ?std.process.EnvMap,
     http_client: ?std.http.Client,
     next_id: u32,
     mcp_session_id: ?[]u8,
@@ -44,7 +43,6 @@ pub const McpServer = struct {
             .name = config.name,
             .config = config,
             .child = null,
-            .child_env = null,
             .http_client = null,
             .next_id = 1,
             .mcp_session_id = null,
@@ -99,7 +97,7 @@ pub const McpServer = struct {
 
         // Build environment: inherit parent + config overrides
         var env = std.process.EnvMap.init(self.allocator);
-        errdefer env.deinit();
+        defer env.deinit();
         // Add PATH, HOME, etc. from parent
         const inherit_vars = [_][]const u8{
             "PATH",              "HOME",        "TERM",    "LANG",         "LC_ALL",
@@ -123,7 +121,6 @@ pub const McpServer = struct {
 
         try child.spawn();
         self.child = child;
-        self.child_env = env;
     }
 
     fn connectHttp(self: *McpServer) !void {
@@ -177,10 +174,6 @@ pub const McpServer = struct {
             _ = child.wait() catch {};
         }
         self.child = null;
-        if (self.child_env) |*env| {
-            env.deinit();
-            self.child_env = null;
-        }
     }
 
     // ── Internal I/O ────────────────────────────────────────────
@@ -635,6 +628,21 @@ test "McpServer init fields" {
     try std.testing.expectEqual(@as(u32, 1), server.next_id);
     try std.testing.expect(server.child == null);
     try std.testing.expectEqualStrings("/usr/bin/echo", server.config.command);
+}
+
+test "McpServer connectStdio deinit frees env map after spawn" {
+    var server = McpServer.init(std.testing.allocator, .{
+        .name = "cat",
+        .transport = "stdio",
+        .command = "sh",
+        .args = &.{ "-c", "cat" },
+        .env = &.{.{ .key = "NULLCLAW_TEST_ENV", .value = "1" }},
+    });
+    defer server.deinit();
+
+    // Regression: connectStdio used to leak its EnvMap when stdio servers had env overrides.
+    try server.connectStdio();
+    try std.testing.expect(server.child != null);
 }
 
 test "McpServer sendRequest requires http client for http transport" {


### PR DESCRIPTION
## Summary
- wrap `nullclaw agent` CLI streaming output with the existing `streaming.TagFilter` so raw `<tool_call>...</tool_call>` blocks do not leak into foreground terminal output
- add a regression test covering streamed tool-call suppression in `src/agent/cli.zig`
- retain and free MCP stdio child environment maps in `src/mcp.zig` to fix the repository-wide leak surfaced by `zig build test --summary all`

## Why
- streamed provider deltas in the CLI path were written directly to stdout, unlike daemon/channel streaming paths that already strip tool-control markup
- the full local validation required by `AGENTS.md` exposed an unrelated MCP env leak in the test suite, so this PR includes the minimal ownership fix needed to keep the suite green

## Validation
- zig build
- zig build -Doptimize=ReleaseSmall
- zig build test --summary all

## Notes
- this change is focused to the CLI streaming presentation path; tool execution behavior is unchanged
- unrelated untracked workspace files were left untouched