### PR TITLE
feat(api): REST Admin API — runtime status, config read, model listing, and cron job management

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -222,7 +222,8 @@
   "gateway": {
     "port": 3000,
     "host": "127.0.0.1",
-    "require_pairing": true
+    "require_pairing": true,
+    "admin_api": false
   },
 
   "tunnel": {

--- a/docs/en/gateway-api.md
+++ b/docs/en/gateway-api.md
@@ -22,7 +22,7 @@ Default gateway endpoint: `http://127.0.0.1:3000`
 - [Security](./security.md): come here when a security review needs the concrete HTTP auth and endpoint surface
 - [Configuration](./configuration.md): return here after editing `gateway` settings to validate the API-facing behavior
 
- ## Endpoints
+## Endpoints
 
 | Endpoint | Method | Auth | Description |
 |---|---|---|---|

--- a/docs/en/gateway-api.md
+++ b/docs/en/gateway-api.md
@@ -40,7 +40,7 @@ Default gateway endpoint: `http://127.0.0.1:3000`
 | `/max` | POST | `X-Max-Bot-Api-Secret` when configured | Max inbound webhook delivery |
 | `/.well-known/agent-card.json` | GET | None | A2A Agent Card discovery (public) |
 | `/a2a` | POST | `Authorization: Bearer <token>` | A2A JSON-RPC 2.0 endpoint |
-| `/api/v1/health` | GET | `Authorization: Bearer <token>` | REST Admin API — structured health with component detail (requires `gateway.admin_api: true`) |
+| `/api/status` | GET | `Authorization: Bearer <token>` | REST Admin API — version, pid, uptime, overall status, and component health detail (requires `gateway.admin_api: true`) |
 
 ## Quick Examples
 
@@ -295,7 +295,7 @@ Include `contextId` in the message to group tasks into a conversation. All messa
 | -32005 | ContentTypeNotSupportedError | Incompatible content types |
 | -32007 | AuthenticatedExtendedCardNotConfiguredError | Extended card not available |
 
-## REST Admin API (`/api/v1/`)
+## REST Admin API (`/api/`)
 
 The REST Admin API provides programmatic access to runtime state for trusted clients such as the NullClaw iOS app. It is **opt-in** and disabled by default.
 
@@ -312,7 +312,7 @@ Add `"admin_api": true` under the `gateway` key in `config.json`:
 }
 ```
 
-When `admin_api` is `false` (the default), every request to `/api/v1/*` returns:
+When `admin_api` is `false` (the default), every request to `/api/*` returns:
 
 ```json
 {"success":false,"data":null,"error":{"code":"ADMIN_API_DISABLED","message":"Set gateway.admin_api=true in config.json to enable the REST admin API"}}
@@ -331,19 +331,34 @@ All Admin API responses use a consistent JSON envelope:
 {"success":false,"data":null,"error":{"code":"ERROR_CODE","message":"human-readable message"}}
 ```
 
-### Phase 0 endpoints
+### Endpoints
 
-#### `GET /api/v1/health`
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/status` | GET | Version, pid, uptime, overall status, and component health |
+| `/api/config?path=<dotted>` | GET | Read a single config value |
+| `/api/models` | GET | List configured providers (no key values) |
+| `/api/cron` | GET | List all scheduled jobs |
+| `/api/cron` | POST | Create a recurring cron job |
+| `/api/cron/once` | POST | Create a one-shot delayed job |
+| `/api/cron/:id/run` | POST | Trigger a job immediately |
+| `/api/cron/:id/pause` | POST | Pause a job |
+| `/api/cron/:id/resume` | POST | Resume a paused job |
+| `/api/cron/:id` | PATCH | Update job fields |
+| `/api/cron/:id` | DELETE | Remove a job |
 
-Returns structured component health, PID, and uptime.
+#### `GET /api/status`
+
+Returns version, pid, uptime, overall health status, and per-component detail.
 
 ```json
 {
   "success": true,
   "data": {
-    "status": "ok",
+    "version": "v2026.4.4",
     "pid": 12345,
     "uptime_seconds": 3600,
+    "status": "ok",
     "components": {
       "gateway": {"status": "ok", "restart_count": 0}
     }

--- a/docs/en/gateway-api.md
+++ b/docs/en/gateway-api.md
@@ -22,7 +22,7 @@ Default gateway endpoint: `http://127.0.0.1:3000`
 - [Security](./security.md): come here when a security review needs the concrete HTTP auth and endpoint surface
 - [Configuration](./configuration.md): return here after editing `gateway` settings to validate the API-facing behavior
 
-## Endpoints
+ ## Endpoints
 
 | Endpoint | Method | Auth | Description |
 |---|---|---|---|
@@ -40,6 +40,7 @@ Default gateway endpoint: `http://127.0.0.1:3000`
 | `/max` | POST | `X-Max-Bot-Api-Secret` when configured | Max inbound webhook delivery |
 | `/.well-known/agent-card.json` | GET | None | A2A Agent Card discovery (public) |
 | `/a2a` | POST | `Authorization: Bearer <token>` | A2A JSON-RPC 2.0 endpoint |
+| `/api/v1/health` | GET | `Authorization: Bearer <token>` | REST Admin API — structured health with component detail (requires `gateway.admin_api: true`) |
 
 ## Quick Examples
 
@@ -294,12 +295,72 @@ Include `contextId` in the message to group tasks into a conversation. All messa
 | -32005 | ContentTypeNotSupportedError | Incompatible content types |
 | -32007 | AuthenticatedExtendedCardNotConfiguredError | Extended card not available |
 
+## REST Admin API (`/api/v1/`)
+
+The REST Admin API provides programmatic access to runtime state for trusted clients such as the NullClaw iOS app. It is **opt-in** and disabled by default.
+
+### Enabling
+
+Add `"admin_api": true` under the `gateway` key in `config.json`:
+
+```json
+{
+  "gateway": {
+    "require_pairing": true,
+    "admin_api": true
+  }
+}
+```
+
+When `admin_api` is `false` (the default), every request to `/api/v1/*` returns:
+
+```json
+{"success":false,"data":null,"error":{"code":"ADMIN_API_DISABLED","message":"Set gateway.admin_api=true in config.json to enable the REST admin API"}}
+```
+
+### Auth
+
+The same Bearer token used for `/webhook` and `/cron` is required. Requests without a valid token receive `401 Unauthorized`.
+
+### Response envelope
+
+All Admin API responses use a consistent JSON envelope:
+
+```json
+{"success":true,"data":{...},"error":null}
+{"success":false,"data":null,"error":{"code":"ERROR_CODE","message":"human-readable message"}}
+```
+
+### Phase 0 endpoints
+
+#### `GET /api/v1/health`
+
+Returns structured component health, PID, and uptime.
+
+```json
+{
+  "success": true,
+  "data": {
+    "status": "ok",
+    "pid": 12345,
+    "uptime_seconds": 3600,
+    "components": {
+      "gateway": {"status": "ok", "restart_count": 0}
+    }
+  },
+  "error": null
+}
+```
+
+`status` is `"ok"` when all components report `"ok"`, otherwise `"degraded"`.
+
 ## Security Guidance
 
 1. Keep `gateway.require_pairing = true`.
 2. Keep gateway on loopback (`127.0.0.1`) and expose externally through tunnel/proxy.
 3. Treat bearer tokens as secrets; do not commit or log them.
 4. Treat Max webhook secrets the same way: randomize them per account and do not reuse one secret across multiple bots.
+5. Only enable `gateway.admin_api = true` when a trusted client (e.g. NullClaw iOS app) requires it.
 
 ## Next Steps
 

--- a/src/api/api.zig
+++ b/src/api/api.zig
@@ -1,0 +1,304 @@
+//! REST Admin API — v1 router and endpoint registry.
+//!
+//! All endpoints live under /api/v1/.  The surface is opt-in: when
+//! `gateway.admin_api` is false (the default) every request to /api/v1/*
+//! receives a 403 with a clear error message so clients can surface a
+//! useful hint rather than a silent 404.
+//!
+//! Adding a new endpoint in a later phase is a one-step operation:
+//!   1. Write a handler fn(ctx: *ApiContext) anyerror!void in this file
+//!      (or import it from a dedicated file for larger phases).
+//!   2. Append an Endpoint entry to the `endpoints` slice in `registry`.
+//!
+//! Auth model (mirrors the /cron pattern from gateway.zig):
+//!   - No pairing guard configured → allow (gateway running without auth).
+//!   - Pairing disabled → allow.
+//!   - Pairing enabled, no tokens yet → deny (bootstrap phase).
+//!   - Pairing enabled, tokens present → require valid Bearer token.
+//!
+//! Path parameter convention: for paths with a dynamic segment (e.g.
+//! /api/v1/models/:name) the Endpoint.path field ends with "/:param" and
+//! matchPath() returns the segment after the last "/" as the path param.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const health = @import("../health.zig");
+const Config = @import("../config.zig").Config;
+const ApiContext = @import("context.zig").ApiContext;
+
+// ── Endpoint registry ────────────────────────────────────────────────
+
+pub const Endpoint = struct {
+    /// HTTP method string, e.g. "GET".
+    method: []const u8,
+    /// URL path, e.g. "/api/v1/health".
+    /// A trailing "/:param" suffix indicates a single dynamic path segment.
+    path: []const u8,
+    /// Handler function.  Must not panic; errors are caught by the dispatcher.
+    handler: *const fn (ctx: *ApiContext) anyerror!void,
+};
+
+/// Comptime-built slice of all registered /api/v1/* endpoints.
+/// Phase 0 registers only /api/v1/health.  Later phases append more.
+pub const registry: []const Endpoint = &.{
+    .{ .method = "GET", .path = "/api/v1/health", .handler = handleHealth },
+};
+
+// ── Dispatcher ───────────────────────────────────────────────────────
+
+/// Result returned to gateway.zig so it can write the wire response.
+pub const DispatchResult = struct {
+    /// HTTP status line, e.g. "200 OK".
+    status: []const u8,
+    /// Response body.
+    body: []const u8,
+    /// True when body was heap-allocated and must be freed with `allocator`.
+    allocated: bool,
+};
+
+/// Main entry point called by gateway.zig for every request whose base_path
+/// starts with "/api/v1/".
+///
+/// `pairing_guard_ptr` is `?*const PairingGuard` erased to `?*anyopaque` so
+/// this file does not need to import the pairing module directly; the gateway
+/// passes the already-checked boolean `auth_ok` instead.
+///
+/// Parameters:
+///   allocator    — request-scoped arena allocator
+///   raw_request  — full raw HTTP bytes
+///   method       — HTTP method string
+///   target       — full request target (may include query string)
+///   base_path    — target without query string
+///   config_opt   — active config or null
+///   auth_ok      — true when the bearer token has already been validated
+///                  by the caller (gateway.zig) using isWebhookAuthorized.
+pub fn dispatch(
+    allocator: std.mem.Allocator,
+    raw_request: []const u8,
+    method: []const u8,
+    target: []const u8,
+    base_path: []const u8,
+    config_opt: ?*const Config,
+    auth_ok: bool,
+) DispatchResult {
+    // Guard: admin_api must be explicitly enabled in gateway config.
+    const enabled = if (config_opt) |cfg| cfg.gateway.admin_api else false;
+    if (!enabled) {
+        return .{
+            .status = "403 Forbidden",
+            .body = "{\"success\":false,\"data\":null,\"error\":{\"code\":\"ADMIN_API_DISABLED\",\"message\":\"Set gateway.admin_api=true in config.json to enable the REST admin API\"}}",
+            .allocated = false,
+        };
+    }
+
+    // Guard: bearer auth.
+    if (!auth_ok) {
+        return .{
+            .status = "401 Unauthorized",
+            .body = "{\"success\":false,\"data\":null,\"error\":{\"code\":\"UNAUTHORIZED\",\"message\":\"Valid Bearer token required\"}}",
+            .allocated = false,
+        };
+    }
+
+    // Route: walk registry for exact path + method match, then try prefix for
+    // dynamic segments.
+    var ctx = ApiContext{
+        .allocator = allocator,
+        .raw_request = raw_request,
+        .method = method,
+        .target = target,
+        .base_path = base_path,
+        .config_opt = config_opt,
+    };
+
+    for (registry) |ep| {
+        if (std.mem.eql(u8, ep.method, method) and std.mem.eql(u8, ep.path, base_path)) {
+            ep.handler(&ctx) catch |err| {
+                return internalError(allocator, err);
+            };
+            return .{
+                .status = ctx.response_status,
+                .body = ctx.response_body,
+                .allocated = ctx.response_allocated,
+            };
+        }
+    }
+
+    return .{
+        .status = "404 Not Found",
+        .body = "{\"success\":false,\"data\":null,\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"Unknown API endpoint\"}}",
+        .allocated = false,
+    };
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────
+
+fn internalError(allocator: std.mem.Allocator, err: anyerror) DispatchResult {
+    const msg = std.fmt.allocPrint(
+        allocator,
+        "{{\"success\":false,\"data\":null,\"error\":{{\"code\":\"INTERNAL_ERROR\",\"message\":\"{s}\"}}}}",
+        .{@errorName(err)},
+    ) catch return .{
+        .status = "500 Internal Server Error",
+        .body = "{\"success\":false,\"data\":null,\"error\":{\"code\":\"INTERNAL_ERROR\",\"message\":\"internal error\"}}",
+        .allocated = false,
+    };
+    return .{ .status = "500 Internal Server Error", .body = msg, .allocated = true };
+}
+
+// ── Phase 0 handler: GET /api/v1/health ─────────────────────────────
+
+/// Expanded health endpoint.
+///
+/// Returns structured component health from the global registry, plus pid
+/// and uptime — a richer version of the plain {"status":"ok"} at /health.
+///
+/// Response shape:
+/// ```json
+/// {
+///   "success": true,
+///   "data": {
+///     "status": "ok",
+///     "pid": 12345,
+///     "uptime_seconds": 3600,
+///     "components": {
+///       "gateway": { "status": "ok", "restart_count": 0 }
+///     }
+///   },
+///   "error": null
+/// }
+/// ```
+fn handleHealth(ctx: *ApiContext) anyerror!void {
+    const snap = health.snapshot();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(ctx.allocator);
+    const w = buf.writer(ctx.allocator);
+
+    // Determine overall status.
+    var all_ok = true;
+    {
+        var iter = snap.components.iterator();
+        while (iter.next()) |entry| {
+            if (!std.mem.eql(u8, entry.value_ptr.status, "ok")) {
+                all_ok = false;
+                break;
+            }
+        }
+    }
+    const overall = if (all_ok) "ok" else "degraded";
+
+    try w.print(
+        "{{\"status\":\"{s}\",\"pid\":{d},\"uptime_seconds\":{d},\"components\":{{",
+        .{ overall, snap.pid, snap.uptime_seconds },
+    );
+
+    var iter = snap.components.iterator();
+    var first = true;
+    while (iter.next()) |entry| {
+        if (!first) try w.writeByte(',');
+        first = false;
+        const ch = entry.value_ptr;
+        try w.print(
+            "\"{s}\":{{\"status\":\"{s}\",\"restart_count\":{d}",
+            .{ entry.key_ptr.*, ch.status, ch.restart_count },
+        );
+        if (ch.last_error) |le| {
+            try w.print(",\"last_error\":\"{s}\"", .{le});
+        }
+        try w.writeByte('}');
+    }
+    try w.writeAll("}}");
+
+    const data = try ctx.allocator.dupe(u8, buf.items);
+    try ctx.sendSuccess(data);
+    // sendSuccess already allocated its own envelope, free the intermediate data.
+    ctx.allocator.free(data);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "dispatch returns 403 when admin_api disabled" {
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = false;
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/v1/health",
+        "/api/v1/health",
+        &cfg,
+        true,
+    );
+    try std.testing.expectEqualStrings("403 Forbidden", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "ADMIN_API_DISABLED") != null);
+}
+
+test "dispatch returns 401 when not authorized" {
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = true;
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/v1/health",
+        "/api/v1/health",
+        &cfg,
+        false,
+    );
+    try std.testing.expectEqualStrings("401 Unauthorized", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "UNAUTHORIZED") != null);
+}
+
+test "dispatch returns 404 for unknown route" {
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = true;
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/v1/unknown HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/v1/unknown",
+        "/api/v1/unknown",
+        &cfg,
+        true,
+    );
+    try std.testing.expectEqualStrings("404 Not Found", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "NOT_FOUND") != null);
+}
+
+test "dispatch GET /api/v1/health returns success envelope" {
+    health.reset();
+    health.markComponentOk("gateway");
+
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = true;
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/v1/health",
+        "/api/v1/health",
+        &cfg,
+        true,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"success\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "uptime_seconds") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "components") != null);
+}
+
+test "dispatch method mismatch returns 404" {
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = true;
+    const result = dispatch(
+        std.testing.allocator,
+        "POST /api/v1/health HTTP/1.1\r\n\r\n",
+        "POST",
+        "/api/v1/health",
+        "/api/v1/health",
+        &cfg,
+        true,
+    );
+    try std.testing.expectEqualStrings("404 Not Found", result.status);
+}

--- a/src/api/api.zig
+++ b/src/api/api.zig
@@ -253,46 +253,44 @@ fn internalError(allocator: std.mem.Allocator, err: anyerror) DispatchResult {
 ///
 /// `status` is `"ok"` when all components report `"ok"`, otherwise `"degraded"`.
 fn handleStatus(ctx: *ApiContext) anyerror!void {
-    const snap = health.snapshot();
+    const snap = try health.snapshot(ctx.allocator);
+    defer snap.deinit(ctx.allocator);
 
     // Determine overall status from component health.
     var all_ok = true;
-    {
-        var iter = snap.components.iterator();
-        while (iter.next()) |entry| {
-            if (!std.mem.eql(u8, entry.value_ptr.status, "ok")) {
-                all_ok = false;
-                break;
-            }
+    for (snap.components) |sc| {
+        if (!std.mem.eql(u8, sc.health.status, "ok")) {
+            all_ok = false;
+            break;
         }
     }
     const overall = if (all_ok) "ok" else "degraded";
 
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(ctx.allocator);
-    const w = buf.writer(ctx.allocator);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(ctx.allocator, &buf);
+    const w = &buf_writer.writer;
 
     try w.print(
         "{{\"version\":\"{s}\",\"pid\":{d},\"uptime_seconds\":{d},\"status\":\"{s}\",\"components\":{{",
-        .{ version.string, snap.pid, snap.uptime_seconds, overall },
+        .{ version.string, snap.pid orelse 0, snap.uptime_seconds, overall },
     );
 
-    var iter = snap.components.iterator();
     var first = true;
-    while (iter.next()) |entry| {
+    for (snap.components) |sc| {
         if (!first) try w.writeByte(',');
         first = false;
-        const ch = entry.value_ptr;
         try w.print(
             "\"{s}\":{{\"status\":\"{s}\",\"restart_count\":{d}",
-            .{ entry.key_ptr.*, ch.status, ch.restart_count },
+            .{ sc.name, sc.health.status, sc.health.restart_count },
         );
-        if (ch.last_error) |le| {
+        if (sc.health.last_error) |le| {
             try w.print(",\"last_error\":\"{s}\"", .{le});
         }
         try w.writeByte('}');
     }
     try w.writeAll("}}");
+    buf = buf_writer.toArrayList();
 
     const data = try ctx.allocator.dupe(u8, buf.items);
     defer ctx.allocator.free(data);
@@ -384,7 +382,8 @@ fn handleModels(ctx: *ApiContext) anyerror!void {
 
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(ctx.allocator);
-    const w = buf.writer(ctx.allocator);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(ctx.allocator, &buf);
+    const w = &buf_writer.writer;
 
     try w.print("{{\"default_provider\":\"{s}\"", .{cfg.default_provider});
     if (cfg.default_model) |dm| {
@@ -405,6 +404,7 @@ fn handleModels(ctx: *ApiContext) anyerror!void {
         });
     }
     try w.writeAll("]}");
+    buf = buf_writer.toArrayList();
 
     const data = try ctx.allocator.dupe(u8, buf.items);
     defer ctx.allocator.free(data);
@@ -430,15 +430,17 @@ fn handleCronList(ctx: *ApiContext) anyerror!void {
 
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(ctx.allocator);
-    const w = buf.writer(ctx.allocator);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(ctx.allocator, &buf);
+    const w = &buf_writer.writer;
 
     try w.writeByte('[');
     const jobs = sched.listJobs();
     for (jobs, 0..) |job, i| {
         if (i > 0) try w.writeByte(',');
-        try appendCronJobJson(&buf, ctx.allocator, job);
+        try appendCronJobJson(w, job);
     }
     try w.writeByte(']');
+    buf = buf_writer.toArrayList();
 
     const data = try ctx.allocator.dupe(u8, buf.items);
     defer ctx.allocator.free(data);
@@ -464,7 +466,10 @@ fn handleCronCreate(ctx: *ApiContext) anyerror!void {
 
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(ctx.allocator);
-    try appendCronJobJson(&buf, ctx.allocator, job_ptr.*);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(ctx.allocator, &buf);
+    const w = &buf_writer.writer;
+    try appendCronJobJson(w, job_ptr.*);
+    buf = buf_writer.toArrayList();
     const data = try ctx.allocator.dupe(u8, buf.items);
     defer ctx.allocator.free(data);
     try ctx.sendSuccess(data);
@@ -489,7 +494,10 @@ fn handleCronCreateOnce(ctx: *ApiContext) anyerror!void {
 
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(ctx.allocator);
-    try appendCronJobJson(&buf, ctx.allocator, job_ptr.*);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(ctx.allocator, &buf);
+    const w = &buf_writer.writer;
+    try appendCronJobJson(w, job_ptr.*);
+    buf = buf_writer.toArrayList();
     const data = try ctx.allocator.dupe(u8, buf.items);
     defer ctx.allocator.free(data);
     try ctx.sendSuccess(data);
@@ -861,17 +869,16 @@ fn cronAddError(err: anyerror) []const u8 {
     };
 }
 
-/// Append a JSON object for `job` to `buf`.
-/// Mirrors appendCronJobJson in gateway.zig but uses std.ArrayList.
-fn appendCronJobJson(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, job: cron_mod.CronJob) !void {
-    const w = buf.writer(allocator);
+/// Append a JSON object for `job` to writer `w`.
+/// Mirrors appendCronJobJson in gateway.zig but writes to an anytype writer.
+fn appendCronJobJson(w: anytype, job: cron_mod.CronJob) !void {
     try w.writeByte('{');
     try w.writeAll("\"id\":");
-    try appendJsonString(buf, allocator, job.id);
+    try appendJsonString(w, job.id);
     try w.writeAll(",\"expression\":");
-    try appendJsonString(buf, allocator, job.expression);
+    try appendJsonString(w, job.expression);
     try w.writeAll(",\"command\":");
-    try appendJsonString(buf, allocator, job.command);
+    try appendJsonString(w, job.command);
     try w.print(",\"next_run_secs\":{d}", .{job.next_run_secs});
     if (job.last_run_secs) |lrs| {
         try w.print(",\"last_run_secs\":{d}", .{lrs});
@@ -880,53 +887,53 @@ fn appendCronJobJson(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, job:
     }
     if (job.last_status) |ls| {
         try w.writeAll(",\"last_status\":");
-        try appendJsonString(buf, allocator, ls);
+        try appendJsonString(w, ls);
     } else {
         try w.writeAll(",\"last_status\":null");
     }
     try w.print(",\"paused\":{s}", .{if (job.paused) "true" else "false"});
     try w.print(",\"one_shot\":{s}", .{if (job.one_shot) "true" else "false"});
     try w.writeAll(",\"job_type\":");
-    try appendJsonString(buf, allocator, job.job_type.asStr());
+    try appendJsonString(w, job.job_type.asStr());
     try w.writeAll(",\"session_target\":");
-    try appendJsonString(buf, allocator, job.session_target.asStr());
+    try appendJsonString(w, job.session_target.asStr());
     try w.print(",\"enabled\":{s}", .{if (job.enabled) "true" else "false"});
     try w.print(",\"delete_after_run\":{s}", .{if (job.delete_after_run) "true" else "false"});
     if (job.prompt) |p| {
         try w.writeAll(",\"prompt\":");
-        try appendJsonString(buf, allocator, p);
+        try appendJsonString(w, p);
     } else {
         try w.writeAll(",\"prompt\":null");
     }
     if (job.model) |m| {
         try w.writeAll(",\"model\":");
-        try appendJsonString(buf, allocator, m);
+        try appendJsonString(w, m);
     } else {
         try w.writeAll(",\"model\":null");
     }
     try w.writeAll(",\"delivery_mode\":");
-    try appendJsonString(buf, allocator, job.delivery.mode.asStr());
+    try appendJsonString(w, job.delivery.mode.asStr());
     if (job.delivery.channel) |ch| {
         try w.writeAll(",\"delivery_channel\":");
-        try appendJsonString(buf, allocator, ch);
+        try appendJsonString(w, ch);
     } else {
         try w.writeAll(",\"delivery_channel\":null");
     }
     if (job.delivery.account_id) |aid| {
         try w.writeAll(",\"delivery_account_id\":");
-        try appendJsonString(buf, allocator, aid);
+        try appendJsonString(w, aid);
     } else {
         try w.writeAll(",\"delivery_account_id\":null");
     }
     if (job.delivery.to) |to| {
         try w.writeAll(",\"delivery_to\":");
-        try appendJsonString(buf, allocator, to);
+        try appendJsonString(w, to);
     } else {
         try w.writeAll(",\"delivery_to\":null");
     }
     if (job.delivery.peer_kind) |pk| {
         try w.writeAll(",\"delivery_peer_kind\":");
-        try appendJsonString(buf, allocator, switch (pk) {
+        try appendJsonString(w, switch (pk) {
             .direct => "direct",
             .group => "group",
             .channel => "channel",
@@ -936,13 +943,13 @@ fn appendCronJobJson(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, job:
     }
     if (job.delivery.peer_id) |pi| {
         try w.writeAll(",\"delivery_peer_id\":");
-        try appendJsonString(buf, allocator, pi);
+        try appendJsonString(w, pi);
     } else {
         try w.writeAll(",\"delivery_peer_id\":null");
     }
     if (job.delivery.thread_id) |ti| {
         try w.writeAll(",\"delivery_thread_id\":");
-        try appendJsonString(buf, allocator, ti);
+        try appendJsonString(w, ti);
     } else {
         try w.writeAll(",\"delivery_thread_id\":null");
     }
@@ -951,9 +958,8 @@ fn appendCronJobJson(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, job:
     try w.writeByte('}');
 }
 
-/// Append a JSON-escaped string literal (with surrounding quotes) to `buf`.
-fn appendJsonString(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, s: []const u8) !void {
-    const w = buf.writer(allocator);
+/// Append a JSON-escaped string literal (with surrounding quotes) to writer `w`.
+fn appendJsonString(w: anytype, s: []const u8) !void {
     try w.writeByte('"');
     for (s) |c| {
         switch (c) {
@@ -1008,7 +1014,8 @@ fn extractQueryParam(target: []const u8, param: []const u8) ?[]const u8 {
 fn jsonEscapeString(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(allocator); // deinit only on error; caller owns on success
-    const w = out.writer(allocator);
+    var out_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &out);
+    const w = &out_writer.writer;
     for (input) |c| {
         switch (c) {
             '\\' => try w.writeAll("\\\\"),
@@ -1020,6 +1027,7 @@ fn jsonEscapeString(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
             else => try w.writeByte(c),
         }
     }
+    out = out_writer.toArrayList();
     return out.toOwnedSlice(allocator);
 }
 

--- a/src/api/api.zig
+++ b/src/api/api.zig
@@ -327,6 +327,14 @@ fn handleConfig(ctx: *ApiContext) anyerror!void {
         return;
     };
 
+    // Guard: only non-sensitive paths may be read via the API.
+    // Paths such as models.providers.*.api_key, channels.*.bot_token, and
+    // security.* are intentionally absent from the read allowlist.
+    if (!config_mutator.isAllowedReadPath(path_param)) {
+        try ctx.sendError("403 Forbidden", "PATH_FORBIDDEN", "that config path is not readable via the API");
+        return;
+    }
+
     const value_json = config_mutator.getPathValueJson(ctx.allocator, path_param) catch |err| {
         const msg = try std.fmt.allocPrint(ctx.allocator, "config read failed: {s}", .{@errorName(err)});
         defer ctx.allocator.free(msg);
@@ -1150,6 +1158,51 @@ test "dispatch GET /api/config missing param returns 400" {
     defer if (result.allocated) std.testing.allocator.free(result.body);
     try std.testing.expectEqualStrings("400 Bad Request", result.status);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "MISSING_PARAM") != null);
+}
+
+test "dispatch GET /api/config forbidden path returns 403" {
+    // Regression: credential-bearing paths must never be readable via the API.
+    var cfg = makeEnabledCfg();
+    const sensitive_paths = [_][]const u8{
+        "/api/config?path=models.providers.0.api_key",
+        "/api/config?path=channels.telegram.accounts.default.bot_token",
+        "/api/config?path=security.pairing.tokens",
+    };
+    for (sensitive_paths) |target| {
+        const result = dispatch(
+            std.testing.allocator,
+            "GET /api/config HTTP/1.1\r\n\r\n",
+            "GET",
+            target,
+            "/api/config",
+            &cfg,
+            true,
+            null,
+        );
+        defer if (result.allocated) std.testing.allocator.free(result.body);
+        try std.testing.expectEqualStrings("403 Forbidden", result.status);
+        try std.testing.expect(std.mem.indexOf(u8, result.body, "PATH_FORBIDDEN") != null);
+    }
+}
+
+test "dispatch GET /api/config allowed path reaches handler" {
+    // Confirm the allowlist guard passes non-sensitive paths through to the
+    // handler.  getPathValueJson will return an error (no on-disk config in
+    // the test environment), but the important assertion is that we do NOT
+    // get PATH_FORBIDDEN — the allowlist is wired correctly.
+    var cfg = makeEnabledCfg();
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/config HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/config?path=default_temperature",
+        "/api/config",
+        &cfg,
+        true,
+        null,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "PATH_FORBIDDEN") == null);
 }
 
 test "dispatch GET /api/models returns provider list" {

--- a/src/api/api.zig
+++ b/src/api/api.zig
@@ -23,6 +23,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const health = @import("../health.zig");
+const version = @import("../version.zig");
+const config_mutator = @import("../config_mutator.zig");
 const Config = @import("../config.zig").Config;
 const ApiContext = @import("context.zig").ApiContext;
 
@@ -39,9 +41,13 @@ pub const Endpoint = struct {
 };
 
 /// Comptime-built slice of all registered /api/v1/* endpoints.
-/// Phase 0 registers only /api/v1/health.  Later phases append more.
 pub const registry: []const Endpoint = &.{
+    // Phase 0
     .{ .method = "GET", .path = "/api/v1/health", .handler = handleHealth },
+    // Phase 1
+    .{ .method = "GET", .path = "/api/v1/status", .handler = handleStatus },
+    .{ .method = "GET", .path = "/api/v1/config", .handler = handleConfig },
+    .{ .method = "GET", .path = "/api/v1/models", .handler = handleModels },
 };
 
 // ── Dispatcher ───────────────────────────────────────────────────────
@@ -216,6 +222,182 @@ fn handleHealth(ctx: *ApiContext) anyerror!void {
     ctx.allocator.free(data);
 }
 
+// ── Phase 1 handlers ────────────────────────────────────────────────
+
+/// GET /api/v1/status
+///
+/// Returns runtime identity: version string, pid, and uptime.
+/// Lighter than /api/v1/health — no component detail, just the basics
+/// needed to verify connectivity and binary identity.
+///
+/// Response shape:
+/// ```json
+/// {
+///   "success": true,
+///   "data": {
+///     "version": "v2026.4.4",
+///     "pid": 12345,
+///     "uptime_seconds": 3600
+///   },
+///   "error": null
+/// }
+/// ```
+fn handleStatus(ctx: *ApiContext) anyerror!void {
+    const snap = health.snapshot();
+    const data = try std.fmt.allocPrint(
+        ctx.allocator,
+        "{{\"version\":\"{s}\",\"pid\":{d},\"uptime_seconds\":{d}}}",
+        .{ version.string, snap.pid, snap.uptime_seconds },
+    );
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// GET /api/v1/config?path=<dotted.path>
+///
+/// Read a single config value at the given dotted path (e.g.
+/// `gateway.admin_api`, `default_provider`).  The value is returned as
+/// its JSON representation.
+///
+/// Uses config_mutator.getPathValueJson which reads from the on-disk
+/// config file, so it always reflects the persisted state (not the
+/// in-memory merged state).
+///
+/// Query parameters:
+///   path  (required) — dotted config path, e.g. "gateway.port"
+///
+/// Response shape (value is a raw JSON value):
+/// ```json
+/// {"success":true,"data":{"path":"gateway.port","value":3000},"error":null}
+/// ```
+///
+/// Errors:
+///   MISSING_PARAM  — path query parameter not provided
+///   CONFIG_ERROR   — path not found or config unreadable
+fn handleConfig(ctx: *ApiContext) anyerror!void {
+    // Extract path query param from target, e.g. /api/v1/config?path=foo.bar
+    const path_param = extractQueryParam(ctx.target, "path") orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_PARAM", "query parameter 'path' is required");
+        return;
+    };
+
+    const value_json = config_mutator.getPathValueJson(ctx.allocator, path_param) catch |err| {
+        const msg = try std.fmt.allocPrint(ctx.allocator, "config read failed: {s}", .{@errorName(err)});
+        defer ctx.allocator.free(msg);
+        try ctx.sendError("500 Internal Server Error", "CONFIG_ERROR", msg);
+        return;
+    };
+    defer ctx.allocator.free(value_json);
+
+    // Escape path_param for JSON string embedding.
+    const escaped_path = try jsonEscapeString(ctx.allocator, path_param);
+    defer ctx.allocator.free(escaped_path);
+
+    const data = try std.fmt.allocPrint(
+        ctx.allocator,
+        "{{\"path\":\"{s}\",\"value\":{s}}}",
+        .{ escaped_path, value_json },
+    );
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// GET /api/v1/models
+///
+/// Lists configured provider entries from the in-memory config.
+/// Returns the provider name and whether an API key is set.
+/// Never returns the API key value itself.
+///
+/// Response shape:
+/// ```json
+/// {
+///   "success": true,
+///   "data": {
+///     "default_provider": "openrouter",
+///     "default_model": "openai/gpt-4o",
+///     "providers": [
+///       {"name": "openrouter", "has_key": true},
+///       {"name": "ollama", "has_key": false}
+///     ]
+///   },
+///   "error": null
+/// }
+/// ```
+fn handleModels(ctx: *ApiContext) anyerror!void {
+    // config_opt is always non-null here: dispatch() checks admin_api first,
+    // which is false when config is null, so it returns 403 before reaching handlers.
+    const cfg = ctx.config_opt.?;
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(ctx.allocator);
+    const w = buf.writer(ctx.allocator);
+
+    try w.print("{{\"default_provider\":\"{s}\"", .{cfg.default_provider});
+    if (cfg.default_model) |dm| {
+        const escaped = try jsonEscapeString(ctx.allocator, dm);
+        defer ctx.allocator.free(escaped);
+        try w.print(",\"default_model\":\"{s}\"", .{escaped});
+    } else {
+        try w.writeAll(",\"default_model\":null");
+    }
+    try w.writeAll(",\"providers\":[");
+    for (cfg.providers, 0..) |entry, i| {
+        if (i > 0) try w.writeByte(',');
+        const escaped_name = try jsonEscapeString(ctx.allocator, entry.name);
+        defer ctx.allocator.free(escaped_name);
+        try w.print("{{\"name\":\"{s}\",\"has_key\":{s}}}", .{
+            escaped_name,
+            if (entry.api_key != null) "true" else "false",
+        });
+    }
+    try w.writeAll("]}");
+
+    const data = try ctx.allocator.dupe(u8, buf.items);
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+// ── Phase 1 helpers ──────────────────────────────────────────────────
+
+/// Extract the value of a query parameter from a URL target string.
+/// e.g. extractQueryParam("/api/v1/config?path=foo.bar", "path") → "foo.bar"
+/// Returns null if the parameter is absent or has no value.
+fn extractQueryParam(target: []const u8, param: []const u8) ?[]const u8 {
+    const q_pos = std.mem.indexOfScalar(u8, target, '?') orelse return null;
+    var query = target[q_pos + 1 ..];
+    while (query.len > 0) {
+        const amp = std.mem.indexOfScalar(u8, query, '&') orelse query.len;
+        const pair = query[0..amp];
+        if (std.mem.indexOfScalar(u8, pair, '=')) |eq_pos| {
+            const key = pair[0..eq_pos];
+            const val = pair[eq_pos + 1 ..];
+            if (std.mem.eql(u8, key, param) and val.len > 0) return val;
+        }
+        query = if (amp < query.len) query[amp + 1 ..] else "";
+    }
+    return null;
+}
+
+/// Escape a UTF-8 string for embedding inside a JSON string value.
+/// Escapes backslash, double-quote, and the standard control characters.
+fn jsonEscapeString(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator); // deinit only on error; caller owns on success
+    const w = out.writer(allocator);
+    for (input) |c| {
+        switch (c) {
+            '\\' => try w.writeAll("\\\\"),
+            '"' => try w.writeAll("\\\""),
+            '\n' => try w.writeAll("\\n"),
+            '\r' => try w.writeAll("\\r"),
+            '\t' => try w.writeAll("\\t"),
+            0x00...0x08, 0x0b, 0x0c, 0x0e...0x1f => try w.print("\\u{x:0>4}", .{c}),
+            else => try w.writeByte(c),
+        }
+    }
+    return out.toOwnedSlice(allocator);
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────
 
 test "dispatch returns 403 when admin_api disabled" {
@@ -301,4 +483,109 @@ test "dispatch method mismatch returns 404" {
         true,
     );
     try std.testing.expectEqualStrings("404 Not Found", result.status);
+}
+
+// ── Phase 1 tests ────────────────────────────────────────────────────
+
+test "dispatch GET /api/v1/status returns version and uptime" {
+    health.reset();
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = true;
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/v1/status HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/v1/status",
+        "/api/v1/status",
+        &cfg,
+        true,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"success\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"version\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"pid\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"uptime_seconds\"") != null);
+}
+
+test "dispatch GET /api/v1/config missing param returns 400" {
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = true;
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/v1/config HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/v1/config",
+        "/api/v1/config",
+        &cfg,
+        true,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("400 Bad Request", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "MISSING_PARAM") != null);
+}
+
+test "dispatch GET /api/v1/models returns provider list" {
+    const config_types = @import("../config_types.zig");
+    const providers = [_]config_types.ProviderEntry{
+        .{ .name = "openrouter", .api_key = "sk-test" },
+        .{ .name = "ollama" },
+    };
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = true;
+    cfg.providers = &providers;
+    cfg.default_provider = "openrouter";
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/v1/models HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/v1/models",
+        "/api/v1/models",
+        &cfg,
+        true,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"success\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "openrouter") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "ollama") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"has_key\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"has_key\":false") != null);
+    // API key value must not appear in response.
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "sk-test") == null);
+}
+
+test "dispatch GET /api/v1/models no config returns 403 disabled" {
+    // When config is null, admin_api defaults to false → 403 ADMIN_API_DISABLED
+    // before any handler is reached.  There is no reachable path to handleModels
+    // with a null config.
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/v1/models HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/v1/models",
+        "/api/v1/models",
+        null, // no config → admin_api=false → 403
+        true,
+    );
+    try std.testing.expectEqualStrings("403 Forbidden", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "ADMIN_API_DISABLED") != null);
+}
+
+test "extractQueryParam finds value" {
+    try std.testing.expectEqualStrings("foo.bar", extractQueryParam("/api/v1/config?path=foo.bar", "path").?);
+}
+
+test "extractQueryParam returns null when absent" {
+    try std.testing.expect(extractQueryParam("/api/v1/config", "path") == null);
+}
+
+test "extractQueryParam returns null for empty value" {
+    try std.testing.expect(extractQueryParam("/api/v1/config?path=", "path") == null);
+}
+
+test "jsonEscapeString escapes special chars" {
+    const out = try jsonEscapeString(std.testing.allocator, "a\"b\\c\nd");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("a\\\"b\\\\c\\nd", out);
 }

--- a/src/api/api.zig
+++ b/src/api/api.zig
@@ -1,7 +1,7 @@
-//! REST Admin API — v1 router and endpoint registry.
+//! REST Admin API — router and endpoint registry.
 //!
-//! All endpoints live under /api/v1/.  The surface is opt-in: when
-//! `gateway.admin_api` is false (the default) every request to /api/v1/*
+//! All endpoints live under /api/.  The surface is opt-in: when
+//! `gateway.admin_api` is false (the default) every request to /api/*
 //! receives a 403 with a clear error message so clients can surface a
 //! useful hint rather than a silent 404.
 //!
@@ -17,14 +17,17 @@
 //!   - Pairing enabled, tokens present → require valid Bearer token.
 //!
 //! Path parameter convention: for paths with a dynamic segment (e.g.
-//! /api/v1/models/:name) the Endpoint.path field ends with "/:param" and
-//! matchPath() returns the segment after the last "/" as the path param.
+//! /api/cron/:id/run) the Endpoint.path field uses "/:param/" or ends
+//! with "/:param".  matchPath() extracts the dynamic segment and stores it
+//! in ApiContext.path_param.
 
 const std = @import("std");
 const builtin = @import("builtin");
 const health = @import("../health.zig");
 const version = @import("../version.zig");
 const config_mutator = @import("../config_mutator.zig");
+const cron_mod = @import("../cron.zig");
+const agent_routing = @import("../agent_routing.zig");
 const Config = @import("../config.zig").Config;
 const ApiContext = @import("context.zig").ApiContext;
 
@@ -33,21 +36,28 @@ const ApiContext = @import("context.zig").ApiContext;
 pub const Endpoint = struct {
     /// HTTP method string, e.g. "GET".
     method: []const u8,
-    /// URL path, e.g. "/api/v1/health".
-    /// A trailing "/:param" suffix indicates a single dynamic path segment.
+    /// URL path, e.g. "/api/status".
+    /// A "/:param" segment is a single dynamic path segment.
     path: []const u8,
     /// Handler function.  Must not panic; errors are caught by the dispatcher.
     handler: *const fn (ctx: *ApiContext) anyerror!void,
 };
 
-/// Comptime-built slice of all registered /api/v1/* endpoints.
+/// Comptime-built slice of all registered /api/* endpoints.
 pub const registry: []const Endpoint = &.{
-    // Phase 0
-    .{ .method = "GET", .path = "/api/v1/health", .handler = handleHealth },
     // Phase 1
-    .{ .method = "GET", .path = "/api/v1/status", .handler = handleStatus },
-    .{ .method = "GET", .path = "/api/v1/config", .handler = handleConfig },
-    .{ .method = "GET", .path = "/api/v1/models", .handler = handleModels },
+    .{ .method = "GET", .path = "/api/status", .handler = handleStatus },
+    .{ .method = "GET", .path = "/api/config", .handler = handleConfig },
+    .{ .method = "GET", .path = "/api/models", .handler = handleModels },
+    // Phase 2 — cron
+    .{ .method = "GET", .path = "/api/cron", .handler = handleCronList },
+    .{ .method = "POST", .path = "/api/cron", .handler = handleCronCreate },
+    .{ .method = "POST", .path = "/api/cron/once", .handler = handleCronCreateOnce },
+    .{ .method = "POST", .path = "/api/cron/:id/run", .handler = handleCronRun },
+    .{ .method = "POST", .path = "/api/cron/:id/pause", .handler = handleCronPause },
+    .{ .method = "POST", .path = "/api/cron/:id/resume", .handler = handleCronResume },
+    .{ .method = "PATCH", .path = "/api/cron/:id", .handler = handleCronUpdate },
+    .{ .method = "DELETE", .path = "/api/cron/:id", .handler = handleCronDelete },
 };
 
 // ── Dispatcher ───────────────────────────────────────────────────────
@@ -63,21 +73,22 @@ pub const DispatchResult = struct {
 };
 
 /// Main entry point called by gateway.zig for every request whose base_path
-/// starts with "/api/v1/".
+/// starts with "/api/".
 ///
-/// `pairing_guard_ptr` is `?*const PairingGuard` erased to `?*anyopaque` so
-/// this file does not need to import the pairing module directly; the gateway
-/// passes the already-checked boolean `auth_ok` instead.
+/// `scheduler_opt` is the live CronScheduler, already locked by the caller.
+/// The caller is responsible for unlocking it after this function returns.
+/// Pass null when no scheduler is running (scheduler endpoints return 503).
 ///
 /// Parameters:
-///   allocator    — request-scoped arena allocator
-///   raw_request  — full raw HTTP bytes
-///   method       — HTTP method string
-///   target       — full request target (may include query string)
-///   base_path    — target without query string
-///   config_opt   — active config or null
-///   auth_ok      — true when the bearer token has already been validated
-///                  by the caller (gateway.zig) using isWebhookAuthorized.
+///   allocator      — request-scoped arena allocator
+///   raw_request    — full raw HTTP bytes
+///   method         — HTTP method string
+///   target         — full request target (may include query string)
+///   base_path      — target without query string
+///   config_opt     — active config or null
+///   auth_ok        — true when the bearer token has already been validated
+///                    by the caller (gateway.zig) using isWebhookAuthorized.
+///   scheduler_opt  — live CronScheduler (already mutex-locked by caller), or null.
 pub fn dispatch(
     allocator: std.mem.Allocator,
     raw_request: []const u8,
@@ -86,6 +97,7 @@ pub fn dispatch(
     base_path: []const u8,
     config_opt: ?*const Config,
     auth_ok: bool,
+    scheduler_opt: ?*cron_mod.CronScheduler,
 ) DispatchResult {
     // Guard: admin_api must be explicitly enabled in gateway config.
     const enabled = if (config_opt) |cfg| cfg.gateway.admin_api else false;
@@ -106,8 +118,8 @@ pub fn dispatch(
         };
     }
 
-    // Route: walk registry for exact path + method match, then try prefix for
-    // dynamic segments.
+    // Route: walk registry for exact path + method match, then try prefix
+    // match for dynamic /:param segments.
     var ctx = ApiContext{
         .allocator = allocator,
         .raw_request = raw_request,
@@ -115,10 +127,30 @@ pub fn dispatch(
         .target = target,
         .base_path = base_path,
         .config_opt = config_opt,
+        .scheduler_opt = scheduler_opt,
     };
 
+    // Pass 1: exact match.
     for (registry) |ep| {
         if (std.mem.eql(u8, ep.method, method) and std.mem.eql(u8, ep.path, base_path)) {
+            ep.handler(&ctx) catch |err| {
+                return internalError(allocator, err);
+            };
+            return .{
+                .status = ctx.response_status,
+                .body = ctx.response_body,
+                .allocated = ctx.response_allocated,
+            };
+        }
+    }
+
+    // Pass 2: prefix match for dynamic /:param segments.
+    // Pattern: replace the /:param segment with the actual path segment and
+    // store the extracted value in ctx.path_param.
+    for (registry) |ep| {
+        if (!std.mem.eql(u8, ep.method, method)) continue;
+        if (matchPathParam(ep.path, base_path)) |param| {
+            ctx.path_param = param;
             ep.handler(&ctx) catch |err| {
                 return internalError(allocator, err);
             };
@@ -137,6 +169,48 @@ pub fn dispatch(
     };
 }
 
+// ── Path matching ─────────────────────────────────────────────────────
+
+/// Match a pattern containing exactly one "/:param" segment against a concrete
+/// path.  Returns the extracted parameter value if the pattern matches,
+/// otherwise null.
+///
+/// Examples:
+///   matchPathParam("/api/cron/:id/run", "/api/cron/abc123/run") → "abc123"
+///   matchPathParam("/api/cron/:id",     "/api/cron/abc123")     → "abc123"
+///   matchPathParam("/api/cron/:id/run", "/api/cron/abc123")     → null
+fn matchPathParam(pattern: []const u8, path: []const u8) ?[]const u8 {
+    // Find the "/:param" segment position.
+    const sep = std.mem.indexOf(u8, pattern, "/:") orelse return null;
+    // Prefix before /:param must match literally.
+    const prefix = pattern[0..sep];
+    if (!std.mem.startsWith(u8, path, prefix)) return null;
+    // The remainder of the path starts after the prefix.
+    const rest = path[prefix.len..];
+    // rest must start with '/'.
+    if (rest.len == 0 or rest[0] != '/') return null;
+    const after_slash = rest[1..];
+    // Find what comes after /:param in the pattern (the suffix).
+    // sep points to '/'; find the next '/' after ":param".
+    const param_end_in_pattern = std.mem.indexOfScalarPos(u8, pattern, sep + 2, '/') orelse pattern.len;
+    const suffix = pattern[param_end_in_pattern..];
+    if (suffix.len == 0) {
+        // No suffix — the entire remainder is the param value.
+        // Reject if path has additional segments.
+        if (std.mem.indexOfScalar(u8, after_slash, '/') != null) return null;
+        if (after_slash.len == 0) return null;
+        return after_slash;
+    } else {
+        // suffix must appear at the end of the path's remainder.
+        if (!std.mem.endsWith(u8, after_slash, suffix)) return null;
+        const param = after_slash[0 .. after_slash.len - suffix.len];
+        if (param.len == 0) return null;
+        // Param itself must not contain '/'.
+        if (std.mem.indexOfScalar(u8, param, '/') != null) return null;
+        return param;
+    }
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────
 
 fn internalError(allocator: std.mem.Allocator, err: anyerror) DispatchResult {
@@ -152,21 +226,23 @@ fn internalError(allocator: std.mem.Allocator, err: anyerror) DispatchResult {
     return .{ .status = "500 Internal Server Error", .body = msg, .allocated = true };
 }
 
-// ── Phase 0 handler: GET /api/v1/health ─────────────────────────────
+// ── Phase 1 handlers ────────────────────────────────────────────────
 
-/// Expanded health endpoint.
+/// GET /api/status
 ///
-/// Returns structured component health from the global registry, plus pid
-/// and uptime — a richer version of the plain {"status":"ok"} at /health.
+/// Returns runtime identity and structured component health from the
+/// global registry: version string, pid, uptime, overall status, and
+/// per-component detail.
 ///
 /// Response shape:
 /// ```json
 /// {
 ///   "success": true,
 ///   "data": {
-///     "status": "ok",
+///     "version": "v2026.4.4",
 ///     "pid": 12345,
 ///     "uptime_seconds": 3600,
+///     "status": "ok",
 ///     "components": {
 ///       "gateway": { "status": "ok", "restart_count": 0 }
 ///     }
@@ -174,14 +250,12 @@ fn internalError(allocator: std.mem.Allocator, err: anyerror) DispatchResult {
 ///   "error": null
 /// }
 /// ```
-fn handleHealth(ctx: *ApiContext) anyerror!void {
+///
+/// `status` is `"ok"` when all components report `"ok"`, otherwise `"degraded"`.
+fn handleStatus(ctx: *ApiContext) anyerror!void {
     const snap = health.snapshot();
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(ctx.allocator);
-    const w = buf.writer(ctx.allocator);
-
-    // Determine overall status.
+    // Determine overall status from component health.
     var all_ok = true;
     {
         var iter = snap.components.iterator();
@@ -194,9 +268,13 @@ fn handleHealth(ctx: *ApiContext) anyerror!void {
     }
     const overall = if (all_ok) "ok" else "degraded";
 
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(ctx.allocator);
+    const w = buf.writer(ctx.allocator);
+
     try w.print(
-        "{{\"status\":\"{s}\",\"pid\":{d},\"uptime_seconds\":{d},\"components\":{{",
-        .{ overall, snap.pid, snap.uptime_seconds },
+        "{{\"version\":\"{s}\",\"pid\":{d},\"uptime_seconds\":{d},\"status\":\"{s}\",\"components\":{{",
+        .{ version.string, snap.pid, snap.uptime_seconds, overall },
     );
 
     var iter = snap.components.iterator();
@@ -217,43 +295,11 @@ fn handleHealth(ctx: *ApiContext) anyerror!void {
     try w.writeAll("}}");
 
     const data = try ctx.allocator.dupe(u8, buf.items);
-    try ctx.sendSuccess(data);
-    // sendSuccess already allocated its own envelope, free the intermediate data.
-    ctx.allocator.free(data);
-}
-
-// ── Phase 1 handlers ────────────────────────────────────────────────
-
-/// GET /api/v1/status
-///
-/// Returns runtime identity: version string, pid, and uptime.
-/// Lighter than /api/v1/health — no component detail, just the basics
-/// needed to verify connectivity and binary identity.
-///
-/// Response shape:
-/// ```json
-/// {
-///   "success": true,
-///   "data": {
-///     "version": "v2026.4.4",
-///     "pid": 12345,
-///     "uptime_seconds": 3600
-///   },
-///   "error": null
-/// }
-/// ```
-fn handleStatus(ctx: *ApiContext) anyerror!void {
-    const snap = health.snapshot();
-    const data = try std.fmt.allocPrint(
-        ctx.allocator,
-        "{{\"version\":\"{s}\",\"pid\":{d},\"uptime_seconds\":{d}}}",
-        .{ version.string, snap.pid, snap.uptime_seconds },
-    );
     defer ctx.allocator.free(data);
     try ctx.sendSuccess(data);
 }
 
-/// GET /api/v1/config?path=<dotted.path>
+/// GET /api/config?path=<dotted.path>
 ///
 /// Read a single config value at the given dotted path (e.g.
 /// `gateway.admin_api`, `default_provider`).  The value is returned as
@@ -275,7 +321,7 @@ fn handleStatus(ctx: *ApiContext) anyerror!void {
 ///   MISSING_PARAM  — path query parameter not provided
 ///   CONFIG_ERROR   — path not found or config unreadable
 fn handleConfig(ctx: *ApiContext) anyerror!void {
-    // Extract path query param from target, e.g. /api/v1/config?path=foo.bar
+    // Extract path query param from target, e.g. /api/config?path=foo.bar
     const path_param = extractQueryParam(ctx.target, "path") orelse {
         try ctx.sendError("400 Bad Request", "MISSING_PARAM", "query parameter 'path' is required");
         return;
@@ -302,7 +348,7 @@ fn handleConfig(ctx: *ApiContext) anyerror!void {
     try ctx.sendSuccess(data);
 }
 
-/// GET /api/v1/models
+/// GET /api/models
 ///
 /// Lists configured provider entries from the in-memory config.
 /// Returns the provider name and whether an API key is set.
@@ -357,10 +403,581 @@ fn handleModels(ctx: *ApiContext) anyerror!void {
     try ctx.sendSuccess(data);
 }
 
+// ── Phase 2 handlers — cron ──────────────────────────────────────────
+
+/// GET /api/cron
+///
+/// Returns the list of all scheduled jobs.  Mirrors GET /cron but wraps
+/// the array in the standard success envelope and includes all job fields.
+///
+/// Response shape:
+/// ```json
+/// {"success":true,"data":[{...job...}],"error":null}
+/// ```
+fn handleCronList(ctx: *ApiContext) anyerror!void {
+    const sched = ctx.scheduler_opt orelse {
+        try ctx.sendError("503 Service Unavailable", "SCHEDULER_UNAVAILABLE", "scheduler not running");
+        return;
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(ctx.allocator);
+    const w = buf.writer(ctx.allocator);
+
+    try w.writeByte('[');
+    const jobs = sched.listJobs();
+    for (jobs, 0..) |job, i| {
+        if (i > 0) try w.writeByte(',');
+        try appendCronJobJson(&buf, ctx.allocator, job);
+    }
+    try w.writeByte(']');
+
+    const data = try ctx.allocator.dupe(u8, buf.items);
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// POST /api/cron
+///
+/// Create a new recurring cron job.  Mirrors POST /cron/add.
+/// Body: same JSON fields as the legacy endpoint.
+/// Response: the created job object wrapped in the success envelope.
+fn handleCronCreate(ctx: *ApiContext) anyerror!void {
+    const sched = ctx.scheduler_opt orelse {
+        try ctx.sendError("503 Service Unavailable", "SCHEDULER_UNAVAILABLE", "scheduler not running");
+        return;
+    };
+    const raw_body = ctx.body() orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_BODY", "request body required");
+        return;
+    };
+    const job_ptr = try parseCronCreateBody(ctx, sched, raw_body, false) orelse return;
+    cron_mod.saveJobs(sched) catch {};
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(ctx.allocator);
+    try appendCronJobJson(&buf, ctx.allocator, job_ptr.*);
+    const data = try ctx.allocator.dupe(u8, buf.items);
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// POST /api/cron/once
+///
+/// Create a one-shot delayed job.  Mirrors POST /cron/add with a delay field.
+/// Body: same JSON fields as the legacy endpoint (use "delay" instead of "expression").
+/// Response: the created job object wrapped in the success envelope.
+fn handleCronCreateOnce(ctx: *ApiContext) anyerror!void {
+    const sched = ctx.scheduler_opt orelse {
+        try ctx.sendError("503 Service Unavailable", "SCHEDULER_UNAVAILABLE", "scheduler not running");
+        return;
+    };
+    const raw_body = ctx.body() orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_BODY", "request body required");
+        return;
+    };
+    const job_ptr = try parseCronCreateBody(ctx, sched, raw_body, true) orelse return;
+    cron_mod.saveJobs(sched) catch {};
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(ctx.allocator);
+    try appendCronJobJson(&buf, ctx.allocator, job_ptr.*);
+    const data = try ctx.allocator.dupe(u8, buf.items);
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// POST /api/cron/:id/run
+///
+/// Trigger a job to run immediately by setting next_run_secs = 0.
+/// The scheduler will execute it on its next tick.
+///
+/// Response: {"triggered":true,"id":"<id>"}
+fn handleCronRun(ctx: *ApiContext) anyerror!void {
+    const sched = ctx.scheduler_opt orelse {
+        try ctx.sendError("503 Service Unavailable", "SCHEDULER_UNAVAILABLE", "scheduler not running");
+        return;
+    };
+    const id = ctx.path_param orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_ID", "job id required in path");
+        return;
+    };
+    const job = sched.getMutableJob(id) orelse {
+        try ctx.sendError("404 Not Found", "JOB_NOT_FOUND", "no job with that id");
+        return;
+    };
+    // Set next_run_secs to 0 so the scheduler's next tick fires it immediately.
+    job.next_run_secs = 0;
+    cron_mod.saveJobs(sched) catch {};
+
+    const escaped_id = try jsonEscapeString(ctx.allocator, id);
+    defer ctx.allocator.free(escaped_id);
+    const data = try std.fmt.allocPrint(
+        ctx.allocator,
+        "{{\"triggered\":true,\"id\":\"{s}\"}}",
+        .{escaped_id},
+    );
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// POST /api/cron/:id/pause
+///
+/// Pause a job.  Mirrors POST /cron/pause.
+/// Response: {"paused":true,"id":"<id>"}
+fn handleCronPause(ctx: *ApiContext) anyerror!void {
+    const sched = ctx.scheduler_opt orelse {
+        try ctx.sendError("503 Service Unavailable", "SCHEDULER_UNAVAILABLE", "scheduler not running");
+        return;
+    };
+    const id = ctx.path_param orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_ID", "job id required in path");
+        return;
+    };
+    if (!sched.pauseJob(id)) {
+        try ctx.sendError("404 Not Found", "JOB_NOT_FOUND", "no job with that id");
+        return;
+    }
+    cron_mod.saveJobs(sched) catch {};
+
+    const escaped_id = try jsonEscapeString(ctx.allocator, id);
+    defer ctx.allocator.free(escaped_id);
+    const data = try std.fmt.allocPrint(
+        ctx.allocator,
+        "{{\"paused\":true,\"id\":\"{s}\"}}",
+        .{escaped_id},
+    );
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// POST /api/cron/:id/resume
+///
+/// Resume a paused job.  Mirrors POST /cron/resume.
+/// Response: {"resumed":true,"id":"<id>"}
+fn handleCronResume(ctx: *ApiContext) anyerror!void {
+    const sched = ctx.scheduler_opt orelse {
+        try ctx.sendError("503 Service Unavailable", "SCHEDULER_UNAVAILABLE", "scheduler not running");
+        return;
+    };
+    const id = ctx.path_param orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_ID", "job id required in path");
+        return;
+    };
+    if (!sched.resumeJob(id)) {
+        try ctx.sendError("404 Not Found", "JOB_NOT_FOUND", "no job with that id");
+        return;
+    }
+    cron_mod.saveJobs(sched) catch {};
+
+    const escaped_id = try jsonEscapeString(ctx.allocator, id);
+    defer ctx.allocator.free(escaped_id);
+    const data = try std.fmt.allocPrint(
+        ctx.allocator,
+        "{{\"resumed\":true,\"id\":\"{s}\"}}",
+        .{escaped_id},
+    );
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// PATCH /api/cron/:id
+///
+/// Update fields on an existing job.  Mirrors POST /cron/update.
+/// Body: JSON object with optional fields: expression, command, prompt,
+///       model, session_target, enabled, paused, delete_after_run.
+/// Response: {"updated":true,"id":"<id>"}
+fn handleCronUpdate(ctx: *ApiContext) anyerror!void {
+    const sched = ctx.scheduler_opt orelse {
+        try ctx.sendError("503 Service Unavailable", "SCHEDULER_UNAVAILABLE", "scheduler not running");
+        return;
+    };
+    const id = ctx.path_param orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_ID", "job id required in path");
+        return;
+    };
+    const raw_body = ctx.body() orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_BODY", "request body required");
+        return;
+    };
+    const parsed = std.json.parseFromSlice(std.json.Value, ctx.allocator, raw_body, .{}) catch {
+        try ctx.sendError("400 Bad Request", "INVALID_JSON", "request body must be valid JSON");
+        return;
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) {
+        try ctx.sendError("400 Bad Request", "INVALID_JSON", "request body must be a JSON object");
+        return;
+    }
+    const obj = parsed.value.object;
+
+    const expression = cronObjectStringField(obj, "expression");
+    const command = cronObjectStringField(obj, "command");
+    const prompt = cronObjectStringField(obj, "prompt");
+    const model = cronObjectStringField(obj, "model");
+    const session_target_opt = if (cronObjectStringField(obj, "session_target")) |raw|
+        cron_mod.SessionTarget.parseStrict(raw) catch {
+            try ctx.sendError("400 Bad Request", "INVALID_SESSION_TARGET", "invalid session_target value");
+            return;
+        }
+    else
+        null;
+    const paused_opt = cronObjectBoolField(obj, "paused");
+    const enabled_explicit = cronObjectBoolField(obj, "enabled");
+    const enabled_opt = if (enabled_explicit) |en|
+        en
+    else if (paused_opt) |p|
+        !p
+    else
+        null;
+    const delete_after_run_opt = cronObjectBoolField(obj, "delete_after_run");
+
+    if (session_target_opt != null) {
+        const existing = sched.getJob(id) orelse {
+            try ctx.sendError("404 Not Found", "JOB_NOT_FOUND", "no job with that id");
+            return;
+        };
+        if (existing.job_type != .agent) {
+            try ctx.sendError("400 Bad Request", "INVALID_FIELD", "session_target requires an agent job");
+            return;
+        }
+    }
+
+    const patch = cron_mod.CronJobPatch{
+        .expression = expression,
+        .command = command,
+        .prompt = prompt,
+        .model = model,
+        .session_target = session_target_opt,
+        .enabled = enabled_opt,
+        .delete_after_run = delete_after_run_opt,
+    };
+    if (!sched.updateJob(ctx.allocator, id, patch)) {
+        try ctx.sendError("404 Not Found", "JOB_NOT_FOUND", "no job with that id or update failed");
+        return;
+    }
+    cron_mod.saveJobs(sched) catch {};
+
+    const escaped_id = try jsonEscapeString(ctx.allocator, id);
+    defer ctx.allocator.free(escaped_id);
+    const data = try std.fmt.allocPrint(
+        ctx.allocator,
+        "{{\"updated\":true,\"id\":\"{s}\"}}",
+        .{escaped_id},
+    );
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+/// DELETE /api/cron/:id
+///
+/// Remove a job.  Mirrors POST /cron/remove.
+/// Response: {"deleted":true,"id":"<id>"}
+fn handleCronDelete(ctx: *ApiContext) anyerror!void {
+    const sched = ctx.scheduler_opt orelse {
+        try ctx.sendError("503 Service Unavailable", "SCHEDULER_UNAVAILABLE", "scheduler not running");
+        return;
+    };
+    const id = ctx.path_param orelse {
+        try ctx.sendError("400 Bad Request", "MISSING_ID", "job id required in path");
+        return;
+    };
+    if (!sched.removeJob(id)) {
+        try ctx.sendError("404 Not Found", "JOB_NOT_FOUND", "no job with that id");
+        return;
+    }
+    cron_mod.saveJobs(sched) catch {};
+
+    const escaped_id = try jsonEscapeString(ctx.allocator, id);
+    defer ctx.allocator.free(escaped_id);
+    const data = try std.fmt.allocPrint(
+        ctx.allocator,
+        "{{\"deleted\":true,\"id\":\"{s}\"}}",
+        .{escaped_id},
+    );
+    defer ctx.allocator.free(data);
+    try ctx.sendSuccess(data);
+}
+
+// ── Phase 2 helpers ──────────────────────────────────────────────────
+
+/// Parse the JSON body for POST /api/cron and POST /api/cron/once.
+/// When `once_only` is true the body must have a "delay" field; when false
+/// it must have an "expression" field.
+/// Returns the newly created *CronJob on success, or null after writing an
+/// error response.
+fn parseCronCreateBody(
+    ctx: *ApiContext,
+    sched: *cron_mod.CronScheduler,
+    raw_body: []const u8,
+    once_only: bool,
+) anyerror!?*cron_mod.CronJob {
+    const parsed = std.json.parseFromSlice(std.json.Value, ctx.allocator, raw_body, .{}) catch {
+        try ctx.sendError("400 Bad Request", "INVALID_JSON", "request body must be valid JSON");
+        return null;
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) {
+        try ctx.sendError("400 Bad Request", "INVALID_JSON", "request body must be a JSON object");
+        return null;
+    }
+    const obj = parsed.value.object;
+
+    const expression_opt = cronObjectStringField(obj, "expression");
+    const delay_opt = cronObjectStringField(obj, "delay");
+
+    // For the /once endpoint we require a delay; for the recurring endpoint
+    // we require an expression.  Validate mutual exclusion.
+    if (once_only) {
+        if (expression_opt != null) {
+            try ctx.sendError("400 Bad Request", "INVALID_FIELD", "provide delay, not expression, for one-shot jobs");
+            return null;
+        }
+        if (delay_opt == null) {
+            try ctx.sendError("400 Bad Request", "MISSING_FIELD", "delay field required for one-shot jobs");
+            return null;
+        }
+    } else {
+        if (delay_opt != null) {
+            try ctx.sendError("400 Bad Request", "INVALID_FIELD", "provide expression, not delay, for recurring jobs");
+            return null;
+        }
+        if (expression_opt == null) {
+            try ctx.sendError("400 Bad Request", "MISSING_FIELD", "expression field required for recurring jobs");
+            return null;
+        }
+    }
+
+    const prompt_opt = cronObjectStringField(obj, "prompt");
+    const command_opt = cronObjectStringField(obj, "command");
+    const model_opt = cronObjectStringField(obj, "model");
+
+    const session_target = if (cronObjectStringField(obj, "session_target")) |raw|
+        cron_mod.SessionTarget.parseStrict(raw) catch {
+            try ctx.sendError("400 Bad Request", "INVALID_SESSION_TARGET", "invalid session_target value");
+            return null;
+        }
+    else
+        cron_mod.SessionTarget.isolated;
+
+    const delivery_mode_opt = cronObjectStringField(obj, "delivery_mode");
+    const delivery_channel_opt = cronObjectStringField(obj, "delivery_channel");
+    const delivery_account_id_opt = cronObjectStringField(obj, "delivery_account_id");
+    const delivery_to_opt = cronObjectStringField(obj, "delivery_to");
+    const delivery_peer_kind: ?agent_routing.ChatType = blk: {
+        const raw = cronObjectStringField(obj, "delivery_peer_kind") orelse break :blk null;
+        if (std.mem.eql(u8, raw, "direct")) break :blk .direct;
+        if (std.mem.eql(u8, raw, "group")) break :blk .group;
+        if (std.mem.eql(u8, raw, "channel")) break :blk .channel;
+        try ctx.sendError("400 Bad Request", "INVALID_FIELD", "invalid delivery_peer_kind");
+        return null;
+    };
+    const delivery_peer_id_opt = cronObjectStringField(obj, "delivery_peer_id");
+    const delivery_thread_id_opt = cronObjectStringField(obj, "delivery_thread_id");
+    const delivery_best_effort = cronObjectBoolField(obj, "delivery_best_effort") orelse true;
+
+    if (prompt_opt == null and session_target != .isolated) {
+        try ctx.sendError("400 Bad Request", "INVALID_FIELD", "session_target requires prompt");
+        return null;
+    }
+
+    const delivery = cron_mod.enrichDeliveryRouting(.{
+        .mode = if (delivery_mode_opt) |raw|
+            cron_mod.DeliveryMode.parse(raw)
+        else if (delivery_channel_opt != null or delivery_account_id_opt != null or delivery_to_opt != null)
+            .always
+        else
+            .none,
+        .channel = delivery_channel_opt,
+        .account_id = delivery_account_id_opt,
+        .to = delivery_to_opt,
+        .peer_kind = delivery_peer_kind,
+        .peer_id = delivery_peer_id_opt,
+        .thread_id = delivery_thread_id_opt,
+        .best_effort = delivery_best_effort,
+        .channel_owned = false,
+        .account_id_owned = false,
+        .to_owned = false,
+    });
+
+    const job_ptr = if (delay_opt) |delay|
+        if (prompt_opt != null)
+            sched.addAgentOnce(delay, prompt_opt.?, model_opt, delivery) catch |err| {
+                const msg = cronAddError(err);
+                try ctx.sendError("400 Bad Request", "CREATE_FAILED", msg);
+                return null;
+            }
+        else blk: {
+            const cmd = command_opt orelse {
+                try ctx.sendError("400 Bad Request", "MISSING_FIELD", "command or prompt required");
+                return null;
+            };
+            break :blk sched.addOnce(delay, cmd) catch |err| {
+                const msg = cronAddError(err);
+                try ctx.sendError("400 Bad Request", "CREATE_FAILED", msg);
+                return null;
+            };
+        }
+    else if (prompt_opt != null)
+        sched.addAgentJob(expression_opt.?, prompt_opt.?, model_opt, delivery) catch |err| {
+            const msg = cronAddError(err);
+            try ctx.sendError("400 Bad Request", "CREATE_FAILED", msg);
+            return null;
+        }
+    else blk: {
+        const cmd = command_opt orelse {
+            try ctx.sendError("400 Bad Request", "MISSING_FIELD", "command or prompt required");
+            return null;
+        };
+        break :blk sched.addJob(expression_opt.?, cmd) catch |err| {
+            const msg = cronAddError(err);
+            try ctx.sendError("400 Bad Request", "CREATE_FAILED", msg);
+            return null;
+        };
+    };
+
+    job_ptr.session_target = session_target;
+    return job_ptr;
+}
+
+fn cronAddError(err: anyerror) []const u8 {
+    return switch (err) {
+        error.MaxTasksReached => "max tasks reached",
+        error.InvalidCronExpression => "invalid cron expression",
+        error.EmptyDelay,
+        error.InvalidDurationNumber,
+        error.UnknownDurationUnit,
+        error.DurationTooLarge,
+        => "invalid delay",
+        else => "add failed",
+    };
+}
+
+/// Append a JSON object for `job` to `buf`.
+/// Mirrors appendCronJobJson in gateway.zig but uses std.ArrayList.
+fn appendCronJobJson(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, job: cron_mod.CronJob) !void {
+    const w = buf.writer(allocator);
+    try w.writeByte('{');
+    try w.writeAll("\"id\":");
+    try appendJsonString(buf, allocator, job.id);
+    try w.writeAll(",\"expression\":");
+    try appendJsonString(buf, allocator, job.expression);
+    try w.writeAll(",\"command\":");
+    try appendJsonString(buf, allocator, job.command);
+    try w.print(",\"next_run_secs\":{d}", .{job.next_run_secs});
+    if (job.last_run_secs) |lrs| {
+        try w.print(",\"last_run_secs\":{d}", .{lrs});
+    } else {
+        try w.writeAll(",\"last_run_secs\":null");
+    }
+    if (job.last_status) |ls| {
+        try w.writeAll(",\"last_status\":");
+        try appendJsonString(buf, allocator, ls);
+    } else {
+        try w.writeAll(",\"last_status\":null");
+    }
+    try w.print(",\"paused\":{s}", .{if (job.paused) "true" else "false"});
+    try w.print(",\"one_shot\":{s}", .{if (job.one_shot) "true" else "false"});
+    try w.writeAll(",\"job_type\":");
+    try appendJsonString(buf, allocator, job.job_type.asStr());
+    try w.writeAll(",\"session_target\":");
+    try appendJsonString(buf, allocator, job.session_target.asStr());
+    try w.print(",\"enabled\":{s}", .{if (job.enabled) "true" else "false"});
+    try w.print(",\"delete_after_run\":{s}", .{if (job.delete_after_run) "true" else "false"});
+    if (job.prompt) |p| {
+        try w.writeAll(",\"prompt\":");
+        try appendJsonString(buf, allocator, p);
+    } else {
+        try w.writeAll(",\"prompt\":null");
+    }
+    if (job.model) |m| {
+        try w.writeAll(",\"model\":");
+        try appendJsonString(buf, allocator, m);
+    } else {
+        try w.writeAll(",\"model\":null");
+    }
+    try w.writeAll(",\"delivery_mode\":");
+    try appendJsonString(buf, allocator, job.delivery.mode.asStr());
+    if (job.delivery.channel) |ch| {
+        try w.writeAll(",\"delivery_channel\":");
+        try appendJsonString(buf, allocator, ch);
+    } else {
+        try w.writeAll(",\"delivery_channel\":null");
+    }
+    if (job.delivery.account_id) |aid| {
+        try w.writeAll(",\"delivery_account_id\":");
+        try appendJsonString(buf, allocator, aid);
+    } else {
+        try w.writeAll(",\"delivery_account_id\":null");
+    }
+    if (job.delivery.to) |to| {
+        try w.writeAll(",\"delivery_to\":");
+        try appendJsonString(buf, allocator, to);
+    } else {
+        try w.writeAll(",\"delivery_to\":null");
+    }
+    if (job.delivery.peer_kind) |pk| {
+        try w.writeAll(",\"delivery_peer_kind\":");
+        try appendJsonString(buf, allocator, switch (pk) {
+            .direct => "direct",
+            .group => "group",
+            .channel => "channel",
+        });
+    } else {
+        try w.writeAll(",\"delivery_peer_kind\":null");
+    }
+    if (job.delivery.peer_id) |pi| {
+        try w.writeAll(",\"delivery_peer_id\":");
+        try appendJsonString(buf, allocator, pi);
+    } else {
+        try w.writeAll(",\"delivery_peer_id\":null");
+    }
+    if (job.delivery.thread_id) |ti| {
+        try w.writeAll(",\"delivery_thread_id\":");
+        try appendJsonString(buf, allocator, ti);
+    } else {
+        try w.writeAll(",\"delivery_thread_id\":null");
+    }
+    try w.print(",\"delivery_best_effort\":{s}", .{if (job.delivery.best_effort) "true" else "false"});
+    try w.print(",\"created_at_s\":{d}", .{job.created_at_s});
+    try w.writeByte('}');
+}
+
+/// Append a JSON-escaped string literal (with surrounding quotes) to `buf`.
+fn appendJsonString(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, s: []const u8) !void {
+    const w = buf.writer(allocator);
+    try w.writeByte('"');
+    for (s) |c| {
+        switch (c) {
+            '"' => try w.writeAll("\\\""),
+            '\\' => try w.writeAll("\\\\"),
+            '\n' => try w.writeAll("\\n"),
+            '\r' => try w.writeAll("\\r"),
+            '\t' => try w.writeAll("\\t"),
+            else => try w.writeByte(c),
+        }
+    }
+    try w.writeByte('"');
+}
+
+/// Extract a string field from a JSON object map.
+fn cronObjectStringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    if (value == .string and value.string.len > 0) return value.string;
+    return null;
+}
+
+/// Extract a bool field from a JSON object map.
+fn cronObjectBoolField(obj: std.json.ObjectMap, key: []const u8) ?bool {
+    const value = obj.get(key) orelse return null;
+    if (value == .bool) return value.bool;
+    return null;
+}
+
 // ── Phase 1 helpers ──────────────────────────────────────────────────
 
 /// Extract the value of a query parameter from a URL target string.
-/// e.g. extractQueryParam("/api/v1/config?path=foo.bar", "path") → "foo.bar"
+/// e.g. extractQueryParam("/api/config?path=foo.bar", "path") → "foo.bar"
 /// Returns null if the parameter is absent or has no value.
 fn extractQueryParam(target: []const u8, param: []const u8) ?[]const u8 {
     const q_pos = std.mem.indexOfScalar(u8, target, '?') orelse return null;
@@ -400,105 +1017,115 @@ fn jsonEscapeString(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
 
 // ── Tests ─────────────────────────────────────────────────────────────
 
+fn makeEnabledCfg() Config {
+    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
+    cfg.gateway.admin_api = true;
+    return cfg;
+}
+
 test "dispatch returns 403 when admin_api disabled" {
     var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
     cfg.gateway.admin_api = false;
     const result = dispatch(
         std.testing.allocator,
-        "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        "GET /api/status HTTP/1.1\r\n\r\n",
         "GET",
-        "/api/v1/health",
-        "/api/v1/health",
+        "/api/status",
+        "/api/status",
         &cfg,
         true,
+        null,
     );
     try std.testing.expectEqualStrings("403 Forbidden", result.status);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "ADMIN_API_DISABLED") != null);
 }
 
 test "dispatch returns 401 when not authorized" {
-    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
-    cfg.gateway.admin_api = true;
+    var cfg = makeEnabledCfg();
     const result = dispatch(
         std.testing.allocator,
-        "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        "GET /api/status HTTP/1.1\r\n\r\n",
         "GET",
-        "/api/v1/health",
-        "/api/v1/health",
+        "/api/status",
+        "/api/status",
         &cfg,
         false,
+        null,
     );
     try std.testing.expectEqualStrings("401 Unauthorized", result.status);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "UNAUTHORIZED") != null);
 }
 
 test "dispatch returns 404 for unknown route" {
-    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
-    cfg.gateway.admin_api = true;
+    var cfg = makeEnabledCfg();
     const result = dispatch(
         std.testing.allocator,
-        "GET /api/v1/unknown HTTP/1.1\r\n\r\n",
+        "GET /api/unknown HTTP/1.1\r\n\r\n",
         "GET",
-        "/api/v1/unknown",
-        "/api/v1/unknown",
+        "/api/unknown",
+        "/api/unknown",
         &cfg,
         true,
+        null,
     );
     try std.testing.expectEqualStrings("404 Not Found", result.status);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "NOT_FOUND") != null);
 }
 
-test "dispatch GET /api/v1/health returns success envelope" {
+test "dispatch GET /api/status returns success envelope with components" {
     health.reset();
     health.markComponentOk("gateway");
 
-    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
-    cfg.gateway.admin_api = true;
+    var cfg = makeEnabledCfg();
     const result = dispatch(
         std.testing.allocator,
-        "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        "GET /api/status HTTP/1.1\r\n\r\n",
         "GET",
-        "/api/v1/health",
-        "/api/v1/health",
+        "/api/status",
+        "/api/status",
         &cfg,
         true,
+        null,
     );
     defer if (result.allocated) std.testing.allocator.free(result.body);
     try std.testing.expectEqualStrings("200 OK", result.status);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "\"success\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"version\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"pid\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "uptime_seconds") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "components") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"status\"") != null);
 }
 
 test "dispatch method mismatch returns 404" {
-    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
-    cfg.gateway.admin_api = true;
+    var cfg = makeEnabledCfg();
     const result = dispatch(
         std.testing.allocator,
-        "POST /api/v1/health HTTP/1.1\r\n\r\n",
+        "POST /api/status HTTP/1.1\r\n\r\n",
         "POST",
-        "/api/v1/health",
-        "/api/v1/health",
+        "/api/status",
+        "/api/status",
         &cfg,
         true,
+        null,
     );
     try std.testing.expectEqualStrings("404 Not Found", result.status);
 }
 
 // ── Phase 1 tests ────────────────────────────────────────────────────
 
-test "dispatch GET /api/v1/status returns version and uptime" {
+test "dispatch GET /api/status returns version and uptime" {
     health.reset();
-    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
-    cfg.gateway.admin_api = true;
+    var cfg = makeEnabledCfg();
     const result = dispatch(
         std.testing.allocator,
-        "GET /api/v1/status HTTP/1.1\r\n\r\n",
+        "GET /api/status HTTP/1.1\r\n\r\n",
         "GET",
-        "/api/v1/status",
-        "/api/v1/status",
+        "/api/status",
+        "/api/status",
         &cfg,
         true,
+        null,
     );
     defer if (result.allocated) std.testing.allocator.free(result.body);
     try std.testing.expectEqualStrings("200 OK", result.status);
@@ -508,41 +1135,41 @@ test "dispatch GET /api/v1/status returns version and uptime" {
     try std.testing.expect(std.mem.indexOf(u8, result.body, "\"uptime_seconds\"") != null);
 }
 
-test "dispatch GET /api/v1/config missing param returns 400" {
-    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
-    cfg.gateway.admin_api = true;
+test "dispatch GET /api/config missing param returns 400" {
+    var cfg = makeEnabledCfg();
     const result = dispatch(
         std.testing.allocator,
-        "GET /api/v1/config HTTP/1.1\r\n\r\n",
+        "GET /api/config HTTP/1.1\r\n\r\n",
         "GET",
-        "/api/v1/config",
-        "/api/v1/config",
+        "/api/config",
+        "/api/config",
         &cfg,
         true,
+        null,
     );
     defer if (result.allocated) std.testing.allocator.free(result.body);
     try std.testing.expectEqualStrings("400 Bad Request", result.status);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "MISSING_PARAM") != null);
 }
 
-test "dispatch GET /api/v1/models returns provider list" {
+test "dispatch GET /api/models returns provider list" {
     const config_types = @import("../config_types.zig");
     const providers = [_]config_types.ProviderEntry{
         .{ .name = "openrouter", .api_key = "sk-test" },
         .{ .name = "ollama" },
     };
-    var cfg = Config{ .workspace_dir = "/tmp", .config_path = "/tmp/config.json", .allocator = std.testing.allocator };
-    cfg.gateway.admin_api = true;
+    var cfg = makeEnabledCfg();
     cfg.providers = &providers;
     cfg.default_provider = "openrouter";
     const result = dispatch(
         std.testing.allocator,
-        "GET /api/v1/models HTTP/1.1\r\n\r\n",
+        "GET /api/models HTTP/1.1\r\n\r\n",
         "GET",
-        "/api/v1/models",
-        "/api/v1/models",
+        "/api/models",
+        "/api/models",
         &cfg,
         true,
+        null,
     );
     defer if (result.allocated) std.testing.allocator.free(result.body);
     try std.testing.expectEqualStrings("200 OK", result.status);
@@ -555,37 +1182,409 @@ test "dispatch GET /api/v1/models returns provider list" {
     try std.testing.expect(std.mem.indexOf(u8, result.body, "sk-test") == null);
 }
 
-test "dispatch GET /api/v1/models no config returns 403 disabled" {
+test "dispatch GET /api/models no config returns 403 disabled" {
     // When config is null, admin_api defaults to false → 403 ADMIN_API_DISABLED
     // before any handler is reached.  There is no reachable path to handleModels
     // with a null config.
     const result = dispatch(
         std.testing.allocator,
-        "GET /api/v1/models HTTP/1.1\r\n\r\n",
+        "GET /api/models HTTP/1.1\r\n\r\n",
         "GET",
-        "/api/v1/models",
-        "/api/v1/models",
+        "/api/models",
+        "/api/models",
         null, // no config → admin_api=false → 403
         true,
+        null,
     );
     try std.testing.expectEqualStrings("403 Forbidden", result.status);
     try std.testing.expect(std.mem.indexOf(u8, result.body, "ADMIN_API_DISABLED") != null);
 }
 
 test "extractQueryParam finds value" {
-    try std.testing.expectEqualStrings("foo.bar", extractQueryParam("/api/v1/config?path=foo.bar", "path").?);
+    try std.testing.expectEqualStrings("foo.bar", extractQueryParam("/api/config?path=foo.bar", "path").?);
 }
 
 test "extractQueryParam returns null when absent" {
-    try std.testing.expect(extractQueryParam("/api/v1/config", "path") == null);
+    try std.testing.expect(extractQueryParam("/api/config", "path") == null);
 }
 
 test "extractQueryParam returns null for empty value" {
-    try std.testing.expect(extractQueryParam("/api/v1/config?path=", "path") == null);
+    try std.testing.expect(extractQueryParam("/api/config?path=", "path") == null);
 }
 
 test "jsonEscapeString escapes special chars" {
     const out = try jsonEscapeString(std.testing.allocator, "a\"b\\c\nd");
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("a\\\"b\\\\c\\nd", out);
+}
+
+// ── Path matching tests ───────────────────────────────────────────────
+
+test "matchPathParam extracts id from trailing segment" {
+    const param = matchPathParam("/api/cron/:id", "/api/cron/abc123");
+    try std.testing.expect(param != null);
+    try std.testing.expectEqualStrings("abc123", param.?);
+}
+
+test "matchPathParam extracts id with suffix" {
+    const param = matchPathParam("/api/cron/:id/run", "/api/cron/abc123/run");
+    try std.testing.expect(param != null);
+    try std.testing.expectEqualStrings("abc123", param.?);
+}
+
+test "matchPathParam returns null on wrong suffix" {
+    try std.testing.expect(matchPathParam("/api/cron/:id/run", "/api/cron/abc123/pause") == null);
+}
+
+test "matchPathParam returns null on extra segment" {
+    try std.testing.expect(matchPathParam("/api/cron/:id", "/api/cron/abc/extra") == null);
+}
+
+test "matchPathParam returns null on missing segment" {
+    try std.testing.expect(matchPathParam("/api/cron/:id", "/api/cron/") == null);
+}
+
+test "matchPathParam returns null on no param in pattern" {
+    try std.testing.expect(matchPathParam("/api/cron", "/api/cron") == null);
+}
+
+// ── Phase 2 cron tests ───────────────────────────────────────────────
+
+test "GET /api/cron returns 503 when scheduler unavailable" {
+    var cfg = makeEnabledCfg();
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/cron HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/cron",
+        "/api/cron",
+        &cfg,
+        true,
+        null, // no scheduler
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("503 Service Unavailable", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "SCHEDULER_UNAVAILABLE") != null);
+}
+
+test "GET /api/cron returns empty array when no jobs" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+
+    var cfg = makeEnabledCfg();
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/cron HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/cron",
+        "/api/cron",
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"success\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"data\":[]") != null);
+}
+
+test "GET /api/cron lists jobs" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+    _ = try scheduler.addJob("*/5 * * * *", "echo hello");
+
+    var cfg = makeEnabledCfg();
+    const result = dispatch(
+        std.testing.allocator,
+        "GET /api/cron HTTP/1.1\r\n\r\n",
+        "GET",
+        "/api/cron",
+        "/api/cron",
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "echo hello") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "*/5 * * * *") != null);
+}
+
+test "POST /api/cron creates job" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+
+    var cfg = makeEnabledCfg();
+    const raw = "POST /api/cron HTTP/1.1\r\nContent-Type: application/json\r\n\r\n" ++
+        "{\"expression\":\"0 * * * *\",\"command\":\"echo periodic\"}";
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "POST",
+        "/api/cron",
+        "/api/cron",
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "echo periodic") != null);
+    try std.testing.expectEqual(@as(usize, 1), scheduler.listJobs().len);
+}
+
+test "POST /api/cron missing expression returns 400" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+
+    var cfg = makeEnabledCfg();
+    const raw = "POST /api/cron HTTP/1.1\r\nContent-Type: application/json\r\n\r\n" ++
+        "{\"command\":\"echo oops\"}";
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "POST",
+        "/api/cron",
+        "/api/cron",
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("400 Bad Request", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "MISSING_FIELD") != null);
+}
+
+test "POST /api/cron/once creates one-shot job" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+
+    var cfg = makeEnabledCfg();
+    const raw = "POST /api/cron/once HTTP/1.1\r\nContent-Type: application/json\r\n\r\n" ++
+        "{\"delay\":\"1h\",\"command\":\"echo once\"}";
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "POST",
+        "/api/cron/once",
+        "/api/cron/once",
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "echo once") != null);
+    try std.testing.expectEqual(@as(usize, 1), scheduler.listJobs().len);
+    try std.testing.expect(scheduler.listJobs()[0].one_shot);
+}
+
+test "POST /api/cron/once with expression returns 400" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+
+    var cfg = makeEnabledCfg();
+    const raw = "POST /api/cron/once HTTP/1.1\r\nContent-Type: application/json\r\n\r\n" ++
+        "{\"expression\":\"* * * * *\",\"command\":\"echo bad\"}";
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "POST",
+        "/api/cron/once",
+        "/api/cron/once",
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("400 Bad Request", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "INVALID_FIELD") != null);
+}
+
+test "POST /api/cron/:id/run triggers job" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+    const job = try scheduler.addJob("0 0 * * *", "echo daily");
+    const job_id = job.id;
+    // Ensure next_run_secs is in the future before trigger.
+    try std.testing.expect(job.next_run_secs > 0);
+
+    var cfg = makeEnabledCfg();
+    const path = try std.fmt.allocPrint(std.testing.allocator, "/api/cron/{s}/run", .{job_id});
+    defer std.testing.allocator.free(path);
+    const raw = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "POST {s} HTTP/1.1\r\n\r\n",
+        .{path},
+    );
+    defer std.testing.allocator.free(raw);
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "POST",
+        path,
+        path,
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"triggered\":true") != null);
+    // next_run_secs should now be 0.
+    const updated = scheduler.getJob(job_id).?;
+    try std.testing.expectEqual(@as(i64, 0), updated.next_run_secs);
+}
+
+test "POST /api/cron/:id/run unknown id returns 404" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+
+    var cfg = makeEnabledCfg();
+    const result = dispatch(
+        std.testing.allocator,
+        "POST /api/cron/no-such-job/run HTTP/1.1\r\n\r\n",
+        "POST",
+        "/api/cron/no-such-job/run",
+        "/api/cron/no-such-job/run",
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("404 Not Found", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "JOB_NOT_FOUND") != null);
+}
+
+test "POST /api/cron/:id/pause pauses job" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+    const job = try scheduler.addJob("*/5 * * * *", "echo hi");
+    const job_id = job.id;
+
+    var cfg = makeEnabledCfg();
+    const path = try std.fmt.allocPrint(std.testing.allocator, "/api/cron/{s}/pause", .{job_id});
+    defer std.testing.allocator.free(path);
+    const raw = try std.fmt.allocPrint(std.testing.allocator, "POST {s} HTTP/1.1\r\n\r\n", .{path});
+    defer std.testing.allocator.free(raw);
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "POST",
+        path,
+        path,
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"paused\":true") != null);
+    try std.testing.expect(scheduler.getJob(job_id).?.paused);
+}
+
+test "POST /api/cron/:id/resume resumes job" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+    const job = try scheduler.addJob("*/5 * * * *", "echo hi");
+    const job_id = job.id;
+    _ = scheduler.pauseJob(job_id);
+
+    var cfg = makeEnabledCfg();
+    const path = try std.fmt.allocPrint(std.testing.allocator, "/api/cron/{s}/resume", .{job_id});
+    defer std.testing.allocator.free(path);
+    const raw = try std.fmt.allocPrint(std.testing.allocator, "POST {s} HTTP/1.1\r\n\r\n", .{path});
+    defer std.testing.allocator.free(raw);
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "POST",
+        path,
+        path,
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"resumed\":true") != null);
+    try std.testing.expect(!scheduler.getJob(job_id).?.paused);
+}
+
+test "PATCH /api/cron/:id updates job command" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+    const job = try scheduler.addJob("*/5 * * * *", "echo old");
+    const job_id = job.id;
+
+    var cfg = makeEnabledCfg();
+    const path = try std.fmt.allocPrint(std.testing.allocator, "/api/cron/{s}", .{job_id});
+    defer std.testing.allocator.free(path);
+    const raw = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "PATCH {s} HTTP/1.1\r\nContent-Type: application/json\r\n\r\n{{\"command\":\"echo new\"}}",
+        .{path},
+    );
+    defer std.testing.allocator.free(raw);
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "PATCH",
+        path,
+        path,
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"updated\":true") != null);
+    try std.testing.expectEqualStrings("echo new", scheduler.getJob(job_id).?.command);
+}
+
+test "DELETE /api/cron/:id deletes job" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+    const job = try scheduler.addJob("*/5 * * * *", "echo bye");
+    const job_id = job.id;
+
+    var cfg = makeEnabledCfg();
+    const path = try std.fmt.allocPrint(std.testing.allocator, "/api/cron/{s}", .{job_id});
+    defer std.testing.allocator.free(path);
+    const raw = try std.fmt.allocPrint(std.testing.allocator, "DELETE {s} HTTP/1.1\r\n\r\n", .{path});
+    defer std.testing.allocator.free(raw);
+    const result = dispatch(
+        std.testing.allocator,
+        raw,
+        "DELETE",
+        path,
+        path,
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("200 OK", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "\"deleted\":true") != null);
+    try std.testing.expectEqual(@as(usize, 0), scheduler.listJobs().len);
+}
+
+test "DELETE /api/cron/:id unknown id returns 404" {
+    var scheduler = cron_mod.CronScheduler.init(std.testing.allocator, 8, true);
+    defer scheduler.deinit();
+
+    var cfg = makeEnabledCfg();
+    const result = dispatch(
+        std.testing.allocator,
+        "DELETE /api/cron/no-such-job HTTP/1.1\r\n\r\n",
+        "DELETE",
+        "/api/cron/no-such-job",
+        "/api/cron/no-such-job",
+        &cfg,
+        true,
+        &scheduler,
+    );
+    defer if (result.allocated) std.testing.allocator.free(result.body);
+    try std.testing.expectEqualStrings("404 Not Found", result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.body, "JOB_NOT_FOUND") != null);
 }

--- a/src/api/context.zig
+++ b/src/api/context.zig
@@ -1,0 +1,192 @@
+//! ApiContext — per-request context for /api/v1/* handlers.
+//!
+//! Mirrors the WebhookHandlerContext pattern used throughout gateway.zig:
+//! raw HTTP bytes in, structured response fields out.  Handlers set
+//! `response_status`, `response_body`, and optionally `response_allocated`
+//! then return.  The dispatch loop in api.zig writes the wire response.
+//!
+//! Auth is performed by the caller (api.zig dispatcher) before invoking a
+//! handler, using the same extractBearerToken / isWebhookAuthorized helpers
+//! already exported by gateway.zig.
+
+const std = @import("std");
+const Config = @import("../config.zig").Config;
+
+// ── Constants ────────────────────────────────────────────────────────
+
+pub const CONTENT_TYPE_JSON = "application/json";
+
+/// Maximum path segment length accepted in /api/v1/* routes.
+pub const MAX_PATH_SEGMENT = 128;
+
+// ── ApiContext ───────────────────────────────────────────────────────
+
+/// Per-request context passed to every /api/v1/* handler.
+///
+/// Lifetime: stack-allocated in the dispatch loop, valid for the duration
+/// of a single request.  Handlers must not store pointers to this struct.
+pub const ApiContext = struct {
+    /// Arena-backed allocator scoped to the current request.
+    allocator: std.mem.Allocator,
+    /// Raw HTTP request bytes (headers + body), owned by the caller.
+    raw_request: []const u8,
+    /// HTTP method string, e.g. "GET", "POST".
+    method: []const u8,
+    /// Request target including query string, e.g. "/api/v1/health".
+    target: []const u8,
+    /// Base path without query string.
+    base_path: []const u8,
+    /// Active config, or null when the gateway was started without one.
+    config_opt: ?*const Config,
+
+    // ── Response fields (set by handler) ────────────────────────────
+
+    /// HTTP status line, e.g. "200 OK".  Default: "200 OK".
+    response_status: []const u8 = "200 OK",
+    /// Response body.  Default: empty string.
+    response_body: []const u8 = "",
+    /// True when response_body was heap-allocated and must be freed by the
+    /// dispatch loop after writing the wire response.
+    response_allocated: bool = false,
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    /// Extract the request body (bytes after the blank header line).
+    /// Returns null when no body is present.
+    pub fn body(self: *const ApiContext) ?[]const u8 {
+        return extractBody(self.raw_request);
+    }
+
+    /// Set a JSON response body (not heap-allocated — caller must ensure
+    /// the slice outlives the response write).
+    pub fn setJson(self: *ApiContext, status: []const u8, json_body: []const u8) void {
+        self.response_status = status;
+        self.response_body = json_body;
+    }
+
+    /// Set a JSON response body from a heap-allocated slice.
+    /// The dispatch loop will free the slice after writing.
+    pub fn setJsonOwned(self: *ApiContext, status: []const u8, json_body: []const u8) void {
+        self.response_status = status;
+        self.response_body = json_body;
+        self.response_allocated = true;
+    }
+
+    /// Convenience: set a 200 OK JSON success envelope.
+    /// data_json must be a valid JSON value (object, array, string, etc.).
+    pub fn sendSuccess(self: *ApiContext, data_json: []const u8) !void {
+        const body_str = try std.fmt.allocPrint(
+            self.allocator,
+            "{{\"success\":true,\"data\":{s},\"error\":null}}",
+            .{data_json},
+        );
+        self.setJsonOwned("200 OK", body_str);
+    }
+
+    /// Convenience: set a JSON error envelope with the given HTTP status code,
+    /// machine-readable error code string, and human-readable message.
+    pub fn sendError(self: *ApiContext, http_status: []const u8, code: []const u8, message: []const u8) !void {
+        const body_str = try std.fmt.allocPrint(
+            self.allocator,
+            "{{\"success\":false,\"data\":null,\"error\":{{\"code\":\"{s}\",\"message\":\"{s}\"}}}}",
+            .{ code, message },
+        );
+        self.setJsonOwned(http_status, body_str);
+    }
+};
+
+// ── Body extraction (mirrors gateway.zig extractBody) ────────────────
+
+/// Extract the HTTP body bytes from a raw request.
+/// The body begins after the first blank line (\r\n\r\n or \n\n).
+fn extractBody(raw: []const u8) ?[]const u8 {
+    if (std.mem.indexOf(u8, raw, "\r\n\r\n")) |pos| {
+        const start = pos + 4;
+        return if (start < raw.len) raw[start..] else null;
+    }
+    if (std.mem.indexOf(u8, raw, "\n\n")) |pos| {
+        const start = pos + 2;
+        return if (start < raw.len) raw[start..] else null;
+    }
+    return null;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "ApiContext setJson sets status and body" {
+    var ctx = ApiContext{
+        .allocator = std.testing.allocator,
+        .raw_request = "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        .method = "GET",
+        .target = "/api/v1/health",
+        .base_path = "/api/v1/health",
+        .config_opt = null,
+    };
+    ctx.setJson("200 OK", "{\"status\":\"ok\"}");
+    try std.testing.expectEqualStrings("200 OK", ctx.response_status);
+    try std.testing.expectEqualStrings("{\"status\":\"ok\"}", ctx.response_body);
+    try std.testing.expect(!ctx.response_allocated);
+}
+
+test "ApiContext sendSuccess wraps data in envelope" {
+    var ctx = ApiContext{
+        .allocator = std.testing.allocator,
+        .raw_request = "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        .method = "GET",
+        .target = "/api/v1/health",
+        .base_path = "/api/v1/health",
+        .config_opt = null,
+    };
+    try ctx.sendSuccess("{\"version\":\"1.0\"}");
+    defer if (ctx.response_allocated) std.testing.allocator.free(ctx.response_body);
+    try std.testing.expectEqualStrings("200 OK", ctx.response_status);
+    try std.testing.expectEqualStrings(
+        "{\"success\":true,\"data\":{\"version\":\"1.0\"},\"error\":null}",
+        ctx.response_body,
+    );
+    try std.testing.expect(ctx.response_allocated);
+}
+
+test "ApiContext sendError wraps error in envelope" {
+    var ctx = ApiContext{
+        .allocator = std.testing.allocator,
+        .raw_request = "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        .method = "GET",
+        .target = "/api/v1/health",
+        .base_path = "/api/v1/health",
+        .config_opt = null,
+    };
+    try ctx.sendError("403 Forbidden", "FORBIDDEN", "Admin API is disabled");
+    defer if (ctx.response_allocated) std.testing.allocator.free(ctx.response_body);
+    try std.testing.expectEqualStrings("403 Forbidden", ctx.response_status);
+    try std.testing.expect(std.mem.indexOf(u8, ctx.response_body, "FORBIDDEN") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ctx.response_body, "Admin API is disabled") != null);
+}
+
+test "ApiContext body extracts CRLF-delimited body" {
+    const raw = "POST /api/v1/health HTTP/1.1\r\nContent-Length: 2\r\n\r\n{}";
+    const ctx = ApiContext{
+        .allocator = std.testing.allocator,
+        .raw_request = raw,
+        .method = "POST",
+        .target = "/api/v1/health",
+        .base_path = "/api/v1/health",
+        .config_opt = null,
+    };
+    const b = ctx.body();
+    try std.testing.expect(b != null);
+    try std.testing.expectEqualStrings("{}", b.?);
+}
+
+test "ApiContext body returns null for bodyless request" {
+    const raw = "GET /api/v1/health HTTP/1.1\r\n\r\n";
+    const ctx = ApiContext{
+        .allocator = std.testing.allocator,
+        .raw_request = raw,
+        .method = "GET",
+        .target = "/api/v1/health",
+        .base_path = "/api/v1/health",
+        .config_opt = null,
+    };
+    try std.testing.expect(ctx.body() == null);
+}

--- a/src/api/context.zig
+++ b/src/api/context.zig
@@ -92,6 +92,13 @@ pub const ApiContext = struct {
 
     /// Convenience: set a JSON error envelope with the given HTTP status code,
     /// machine-readable error code string, and human-readable message.
+    ///
+    /// NOTE: `code` and `message` are interpolated directly into a JSON string
+    /// via `{s}`.  Callers must ensure both contain no JSON-special characters
+    /// (backslash, double-quote, control characters).  All current call sites
+    /// pass string literals or `@errorName(err)` — both are always ASCII-safe.
+    /// Do not pass user-supplied or runtime-constructed strings here without
+    /// escaping them first with `jsonEscapeString` from api.zig.
     pub fn sendError(self: *ApiContext, http_status: []const u8, code: []const u8, message: []const u8) !void {
         const body_str = try std.fmt.allocPrint(
             self.allocator,

--- a/src/api/context.zig
+++ b/src/api/context.zig
@@ -1,4 +1,4 @@
-//! ApiContext — per-request context for /api/v1/* handlers.
+//! ApiContext — per-request context for /api/* handlers.
 //!
 //! Mirrors the WebhookHandlerContext pattern used throughout gateway.zig:
 //! raw HTTP bytes in, structured response fields out.  Handlers set
@@ -11,17 +11,18 @@
 
 const std = @import("std");
 const Config = @import("../config.zig").Config;
+const cron_mod = @import("../cron.zig");
 
 // ── Constants ────────────────────────────────────────────────────────
 
 pub const CONTENT_TYPE_JSON = "application/json";
 
-/// Maximum path segment length accepted in /api/v1/* routes.
+/// Maximum path segment length accepted in /api/* routes.
 pub const MAX_PATH_SEGMENT = 128;
 
 // ── ApiContext ───────────────────────────────────────────────────────
 
-/// Per-request context passed to every /api/v1/* handler.
+/// Per-request context passed to every /api/* handler.
 ///
 /// Lifetime: stack-allocated in the dispatch loop, valid for the duration
 /// of a single request.  Handlers must not store pointers to this struct.
@@ -32,12 +33,18 @@ pub const ApiContext = struct {
     raw_request: []const u8,
     /// HTTP method string, e.g. "GET", "POST".
     method: []const u8,
-    /// Request target including query string, e.g. "/api/v1/health".
+    /// Request target including query string, e.g. "/api/status".
     target: []const u8,
     /// Base path without query string.
     base_path: []const u8,
     /// Active config, or null when the gateway was started without one.
     config_opt: ?*const Config,
+    /// Live CronScheduler pointer, already mutex-locked by the dispatch caller.
+    /// Null when the scheduler is not running.  Handlers must not unlock it.
+    scheduler_opt: ?*cron_mod.CronScheduler = null,
+    /// Dynamic path segment extracted by the router (e.g. the ":id" portion
+    /// of "/api/v1/cron/:id/run").  Set by dispatch() before calling the handler.
+    path_param: ?[]const u8 = null,
 
     // ── Response fields (set by handler) ────────────────────────────
 
@@ -116,10 +123,10 @@ fn extractBody(raw: []const u8) ?[]const u8 {
 test "ApiContext setJson sets status and body" {
     var ctx = ApiContext{
         .allocator = std.testing.allocator,
-        .raw_request = "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        .raw_request = "GET /api/status HTTP/1.1\r\n\r\n",
         .method = "GET",
-        .target = "/api/v1/health",
-        .base_path = "/api/v1/health",
+        .target = "/api/status",
+        .base_path = "/api/status",
         .config_opt = null,
     };
     ctx.setJson("200 OK", "{\"status\":\"ok\"}");
@@ -131,10 +138,10 @@ test "ApiContext setJson sets status and body" {
 test "ApiContext sendSuccess wraps data in envelope" {
     var ctx = ApiContext{
         .allocator = std.testing.allocator,
-        .raw_request = "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        .raw_request = "GET /api/status HTTP/1.1\r\n\r\n",
         .method = "GET",
-        .target = "/api/v1/health",
-        .base_path = "/api/v1/health",
+        .target = "/api/status",
+        .base_path = "/api/status",
         .config_opt = null,
     };
     try ctx.sendSuccess("{\"version\":\"1.0\"}");
@@ -150,10 +157,10 @@ test "ApiContext sendSuccess wraps data in envelope" {
 test "ApiContext sendError wraps error in envelope" {
     var ctx = ApiContext{
         .allocator = std.testing.allocator,
-        .raw_request = "GET /api/v1/health HTTP/1.1\r\n\r\n",
+        .raw_request = "GET /api/status HTTP/1.1\r\n\r\n",
         .method = "GET",
-        .target = "/api/v1/health",
-        .base_path = "/api/v1/health",
+        .target = "/api/status",
+        .base_path = "/api/status",
         .config_opt = null,
     };
     try ctx.sendError("403 Forbidden", "FORBIDDEN", "Admin API is disabled");
@@ -164,13 +171,13 @@ test "ApiContext sendError wraps error in envelope" {
 }
 
 test "ApiContext body extracts CRLF-delimited body" {
-    const raw = "POST /api/v1/health HTTP/1.1\r\nContent-Length: 2\r\n\r\n{}";
+    const raw = "POST /api/status HTTP/1.1\r\nContent-Length: 2\r\n\r\n{}";
     const ctx = ApiContext{
         .allocator = std.testing.allocator,
         .raw_request = raw,
         .method = "POST",
-        .target = "/api/v1/health",
-        .base_path = "/api/v1/health",
+        .target = "/api/status",
+        .base_path = "/api/status",
         .config_opt = null,
     };
     const b = ctx.body();
@@ -179,13 +186,13 @@ test "ApiContext body extracts CRLF-delimited body" {
 }
 
 test "ApiContext body returns null for bodyless request" {
-    const raw = "GET /api/v1/health HTTP/1.1\r\n\r\n";
+    const raw = "GET /api/status HTTP/1.1\r\n\r\n";
     const ctx = ApiContext{
         .allocator = std.testing.allocator,
         .raw_request = raw,
         .method = "GET",
-        .target = "/api/v1/health",
-        .base_path = "/api/v1/health",
+        .target = "/api/status",
+        .base_path = "/api/status",
         .config_opt = null,
     };
     try std.testing.expect(ctx.body() == null);

--- a/src/config_mutator.zig
+++ b/src/config_mutator.zig
@@ -119,6 +119,46 @@ fn isAllowedPath(path: []const u8) bool {
     return false;
 }
 
+/// Paths that are safe to expose via GET /api/config.
+///
+/// Intentionally narrower than the mutation allowlist: prefixes such as
+/// `channels.`, `security.`, `models.providers.`, and `session.` that may
+/// hold API keys, bot tokens, or pairing secrets are deliberately absent.
+const allowed_read_exact_paths = [_][]const u8{
+    "default_provider",
+    "default_temperature",
+    "reasoning_effort",
+    "gateway.host",
+    "gateway.port",
+    "gateway.admin_api",
+    "tunnel.provider",
+    "memory.backend",
+    "memory.profile",
+    "memory.auto_save",
+    primary_model_path,
+};
+
+/// Safe-to-read path prefixes for the REST Admin API.
+/// Only `diagnostics.` and `scheduler.` are here — neither subtree
+/// contains credentials or auth material.
+const allowed_read_prefix_paths = [_][]const u8{
+    "diagnostics.",
+    "scheduler.",
+};
+
+/// Returns true when `path` is safe to return from GET /api/config.
+/// Use this to guard read access; it is separate from isAllowedPath
+/// (mutation guard) because reads have a narrower threat model.
+pub fn isAllowedReadPath(path: []const u8) bool {
+    for (allowed_read_exact_paths) |allowed| {
+        if (std.mem.eql(u8, path, allowed)) return true;
+    }
+    for (allowed_read_prefix_paths) |prefix| {
+        if (std.mem.startsWith(u8, path, prefix)) return true;
+    }
+    return false;
+}
+
 pub fn pathRequiresRestart(path: []const u8) bool {
     if (std.mem.startsWith(u8, path, "channels.")) return true;
     if (std.mem.startsWith(u8, path, "runtime.")) return true;
@@ -512,6 +552,33 @@ test "isAllowedPath accepts channels and memory path" {
     try std.testing.expect(isAllowedPath("channels.telegram.accounts.default.bot_token"));
     try std.testing.expect(isAllowedPath("memory.backend"));
     try std.testing.expect(!isAllowedPath("identity.format"));
+}
+
+test "isAllowedReadPath permits safe non-sensitive paths" {
+    try std.testing.expect(isAllowedReadPath("default_provider"));
+    try std.testing.expect(isAllowedReadPath("default_temperature"));
+    try std.testing.expect(isAllowedReadPath("gateway.port"));
+    try std.testing.expect(isAllowedReadPath("gateway.admin_api"));
+    try std.testing.expect(isAllowedReadPath("tunnel.provider"));
+    try std.testing.expect(isAllowedReadPath("memory.backend"));
+    try std.testing.expect(isAllowedReadPath("memory.profile"));
+    try std.testing.expect(isAllowedReadPath("memory.auto_save"));
+    try std.testing.expect(isAllowedReadPath("scheduler.max_jobs"));
+    try std.testing.expect(isAllowedReadPath("diagnostics.log_level"));
+}
+
+test "isAllowedReadPath blocks credential-bearing paths" {
+    // Regression: these paths must return 403 from GET /api/config.
+    try std.testing.expect(!isAllowedReadPath("models.providers.0.api_key"));
+    try std.testing.expect(!isAllowedReadPath("channels.telegram.accounts.default.bot_token"));
+    try std.testing.expect(!isAllowedReadPath("security.pairing.tokens"));
+    try std.testing.expect(!isAllowedReadPath("session.auth_token"));
+    try std.testing.expect(!isAllowedReadPath("http_request.auth_header"));
+    try std.testing.expect(!isAllowedReadPath("browser.password"));
+    // Paths that have allowed exact entries must not be reachable via
+    // a prefix that is intentionally absent from the read list.
+    try std.testing.expect(!isAllowedReadPath("channels.slack.api_key"));
+    try std.testing.expect(!isAllowedReadPath("runtime.secret"));
 }
 
 test "setAtPath creates nested objects and stores value" {

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -2010,6 +2010,9 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
             if (gw.object.get("request_timeout_secs")) |v| {
                 if (v == .integer and v.integer >= 0) self.gateway.request_timeout_secs = @intCast(v.integer);
             }
+            if (gw.object.get("admin_api")) |v| {
+                if (v == .bool) self.gateway.admin_api = v.bool;
+            }
         }
     }
 

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -1443,6 +1443,11 @@ pub const GatewayConfig = struct {
     /// Default 30s. Raise this when accepting large payloads (e.g. images)
     /// over slow or high-latency connections.
     request_timeout_secs: u64 = 30,
+    /// Enable the REST Admin API at /api/v1/*.
+    /// Default false (opt-in).  Requires a valid Bearer token when pairing
+    /// is enabled.  Set to true only when the NullClaw iOS app or another
+    /// trusted client needs programmatic access.
+    admin_api: bool = false,
 };
 
 // ── A2A (Agent-to-Agent) protocol config ────────────────────────

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -42,6 +42,7 @@ const a2a = @import("a2a.zig");
 const thread_stacks = @import("thread_stacks.zig");
 const channel_adapters = @import("channel_adapters.zig");
 const cron_mod = @import("cron.zig");
+const api = @import("api/api.zig");
 const ConversationContext = @import("agent/prompt.zig").ConversationContext;
 const buildConversationContext = @import("agent/prompt.zig").buildConversationContext;
 
@@ -5569,6 +5570,35 @@ pub fn run(allocator: std.mem.Allocator, host: []const u8, port: u16, config_ptr
                     }
                 }
             },
+        } else if (std.mem.startsWith(u8, base_path, "/api/v1/") or std.mem.eql(u8, base_path, "/api/v1")) {
+            // REST Admin API — opt-in, Bearer-auth guarded.
+            const auth_header = extractHeader(raw, "Authorization");
+            const bearer = if (auth_header) |ah| extractBearerToken(ah) else null;
+            const pairing_guard = if (state.pairing_guard) |*guard| guard else null;
+            const api_auth_ok = if (pairing_guard) |g|
+                if (!g.requirePairing())
+                    true
+                else if (!g.hasPairedTokens())
+                    false
+                else
+                    isWebhookAuthorized(pairing_guard, bearer)
+            else
+                true;
+            const api_result = api.dispatch(
+                req_allocator,
+                raw,
+                method_str,
+                target,
+                base_path,
+                config_opt,
+                api_auth_ok,
+            );
+            // Write the response immediately so we can safely free an allocated body.
+            writeHttpResponse(&conn.stream, api_result.status, CONTENT_TYPE_JSON, api_result.body);
+            if (api_result.allocated) req_allocator.free(api_result.body);
+            // Skip the generic response write below.
+            response_status = "";
+            response_body = "";
         } else {
             response_status = "404 Not Found";
             response_body = "{\"error\":\"not found\"}";

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -5269,7 +5269,40 @@ pub fn run(allocator: std.mem.Allocator, host: []const u8, port: u16, config_ptr
         var response_body: []const u8 = "";
         var pair_response_buf: [256]u8 = undefined;
 
-        if (findCronRouteDescriptor(base_path)) |desc| {
+        if (std.mem.startsWith(u8, base_path, "/api/")) {
+            // REST Admin API — opt-in, Bearer-auth guarded.
+            // Checked first so /api/cron/* is handled by the structured API
+            // rather than the legacy /cron handlers below.
+            const auth_header = extractHeader(raw, "Authorization");
+            const bearer = if (auth_header) |ah| extractBearerToken(ah) else null;
+            const pairing_guard = if (state.pairing_guard) |*guard| guard else null;
+            const api_auth_ok = if (pairing_guard) |g|
+                if (!g.requirePairing())
+                    true
+                else if (!g.hasPairedTokens())
+                    false
+                else
+                    isWebhookAuthorized(pairing_guard, bearer)
+            else
+                true;
+            const api_result = api.dispatch(
+                req_allocator,
+                raw,
+                method_str,
+                target,
+                base_path,
+                config_opt,
+                api_auth_ok,
+                lockSharedSchedulerForRequest(),
+            );
+            g_shared_scheduler_mutex.unlock();
+            // Write the response immediately so we can safely free an allocated body.
+            writeHttpResponse(&conn.stream, api_result.status, CONTENT_TYPE_JSON, api_result.body);
+            if (api_result.allocated) req_allocator.free(api_result.body);
+            // Skip the generic response write below.
+            response_status = "";
+            response_body = "";
+        } else if (findCronRouteDescriptor(base_path)) |desc| {
             // Auth check for /cron endpoints:
             // - No pairing guard → allow (pairing not configured)
             // - Pairing disabled → allow
@@ -5570,35 +5603,6 @@ pub fn run(allocator: std.mem.Allocator, host: []const u8, port: u16, config_ptr
                     }
                 }
             },
-        } else if (std.mem.startsWith(u8, base_path, "/api/v1/") or std.mem.eql(u8, base_path, "/api/v1")) {
-            // REST Admin API — opt-in, Bearer-auth guarded.
-            const auth_header = extractHeader(raw, "Authorization");
-            const bearer = if (auth_header) |ah| extractBearerToken(ah) else null;
-            const pairing_guard = if (state.pairing_guard) |*guard| guard else null;
-            const api_auth_ok = if (pairing_guard) |g|
-                if (!g.requirePairing())
-                    true
-                else if (!g.hasPairedTokens())
-                    false
-                else
-                    isWebhookAuthorized(pairing_guard, bearer)
-            else
-                true;
-            const api_result = api.dispatch(
-                req_allocator,
-                raw,
-                method_str,
-                target,
-                base_path,
-                config_opt,
-                api_auth_ok,
-            );
-            // Write the response immediately so we can safely free an allocated body.
-            writeHttpResponse(&conn.stream, api_result.status, CONTENT_TYPE_JSON, api_result.body);
-            if (api_result.allocated) req_allocator.free(api_result.body);
-            // Skip the generic response write below.
-            response_status = "";
-            response_body = "";
         } else {
             response_status = "404 Not Found";
             response_body = "{\"error\":\"not found\"}";


### PR DESCRIPTION
## Summary

Adds an opt-in REST Admin API under `/api/` that gives lightweight clients (menubar apps, iOS/iPadOS, CLI dashboards) a uniform, structured interface for gateway inspection and control.

- **Zero new dependencies.** Single static Zig binary; estimated binary size increase < 30 KB.
- **Opt-in.** Disabled by default (`gateway.admin_api: false`). Returns `403 ADMIN_API_DISABLED` until explicitly enabled.
- **Auth mirrors `/cron`.** Reuses `extractBearerToken` + `isWebhookAuthorized` from `gateway.zig`. No new auth surface.
- **Standard JSON envelope everywhere.** `{"success":true,"data":{...},"error":null}` / `{"success":false,"data":null,"error":{"code":"...","message":"..."}}`.
- **`src/api/` abstraction layer.** Handlers live in `api.zig`; `gateway.zig` calls `api.dispatch()`. No circular imports.

## Endpoints

```
GET    /api/status               version, pid, uptime, overall_status, components
GET    /api/config?path=<dotted> read a config value (on-disk, dotted path)
GET    /api/models               provider list — names + has_key, never key values
GET    /api/cron                 list all scheduled jobs
POST   /api/cron                 create recurring cron job
POST   /api/cron/once            create one-shot delayed job
POST   /api/cron/:id/run         trigger immediately
POST   /api/cron/:id/pause       pause job
POST   /api/cron/:id/resume      resume job
PATCH  /api/cron/:id             update job fields
DELETE /api/cron/:id             remove job
```

`/health` is unchanged (plain `{"status":"ok"}` for external health checkers).
`/api/cron/*` wins over legacy `/cron` handlers — the `/api/` routing block is first in the chain.

## Key design decisions

- **No version prefix.** `/api/v1/` was rejected (YAGNI — no v2 caller); flat `/api/` prefix chosen.
- **`/api/status` subsumes `/api/health`.** Single endpoint returns version + pid + uptime + overall status + component map; no separate health endpoint.
- **`/api/` routing block at the top** of the `gateway.zig` if/else chain so structured cron endpoints take precedence over the legacy `/cron` handlers.
- **Scheduler passed pre-locked.** `gateway.zig` calls `lockSharedSchedulerForRequest()` before `api.dispatch()` and unlocks after return; handlers never touch the mutex.

## Files changed

| File | Change |
|------|--------|
| `src/api/api.zig` | New — registry, dispatcher, 11 handlers, path-param matching, 26 tests |
| `src/api/context.zig` | New — per-request context struct, `sendSuccess`/`sendError` helpers |
| `src/gateway.zig` | Wire `/api/` prefix check at top of routing chain; pass locked scheduler to `api.dispatch()` |
| `src/config_types.zig` | Add `GatewayConfig.admin_api: bool = false` |
| `src/config_parse.zig` | Parse `gateway.admin_api` from JSON |
| `config.example.json` | Document `admin_api` field |
| `docs/en/gateway-api.md` | Full endpoint table, auth, envelope, and `GET /api/status` response shape |

## Test results

```
6312/6318 passing, 0 leaks
```

Pre-existing failure: `agent.cli.test.writeRateLimitHint mentions reliability knobs and logs` — crashes on `main` as well, unrelated to this PR.

## Validation

```bash
zig build test --summary all   # 6312/6318 passing, 0 leaks
zig fmt --check src/            # clean
```