### PR TITLE
fix: correct Responses API tool schema and null error classification

### DIFF
--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -545,7 +545,7 @@ pub const OpenAiCompatibleProvider = struct {
         if (request.tools) |tools| {
             if (tools.len > 0) {
                 try buf.appendSlice(allocator, ",\"tools\":");
-                try root.convertToolsOpenAI(&buf, allocator, tools);
+                try root.convertToolsResponses(&buf, allocator, tools);
                 try buf.appendSlice(allocator, ",\"tool_choice\":\"auto\"");
             }
         }

--- a/src/providers/error_classify.zig
+++ b/src/providers/error_classify.zig
@@ -309,6 +309,7 @@ fn classifyFromFields(
 /// Anthropic, and Gemini APIs.
 pub fn classifyErrorObject(root_obj: anytype) ?ApiErrorKind {
     const err_value = root_obj.get("error") orelse return null;
+    if (err_value == .null) return null;
     if (err_value == .string) {
         return classifyFromFields(null, null, null, err_value.string);
     }

--- a/src/providers/helpers.zig
+++ b/src/providers/helpers.zig
@@ -505,6 +505,28 @@ pub fn convertToolsOpenAI(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.A
     try buf.append(allocator, ']');
 }
 
+/// Serialize tool definitions into an OpenAI Responses API format JSON array, appending directly into `buf`.
+/// Format: [{"type":"function","name":"...","description":"...","parameters":{...}}]
+/// Unlike chat completions, the Responses API uses a flat structure without the nested "function" wrapper.
+pub fn convertToolsResponses(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, tools: []const ToolSpec) !void {
+    if (tools.len == 0) {
+        try buf.appendSlice(allocator, "[]");
+        return;
+    }
+    try buf.append(allocator, '[');
+    for (tools, 0..) |tool, i| {
+        if (i > 0) try buf.append(allocator, ',');
+        try buf.appendSlice(allocator, "{\"type\":\"function\",\"name\":");
+        try json_util.appendJsonString(buf, allocator, tool.name);
+        try buf.appendSlice(allocator, ",\"description\":");
+        try json_util.appendJsonString(buf, allocator, tool.description);
+        try buf.appendSlice(allocator, ",\"parameters\":");
+        try buf.appendSlice(allocator, tool.parameters_json);
+        try buf.append(allocator, '}');
+    }
+    try buf.append(allocator, ']');
+}
+
 /// Serialize tool definitions into an Anthropic-format JSON array, appending directly into `buf`.
 /// Format: [{"name":"...","description":"...","input_schema":{...}}]
 pub fn convertToolsAnthropic(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, tools: []const ToolSpec) !void {

--- a/src/providers/root.zig
+++ b/src/providers/root.zig
@@ -61,6 +61,7 @@ pub const convertToolsOpenAI = helpers.convertToolsOpenAI;
 pub const serializeMessageContent = helpers.serializeMessageContent;
 pub const serializeContentPart = helpers.serializeContentPart;
 pub const convertToolsAnthropic = helpers.convertToolsAnthropic;
+pub const convertToolsResponses = helpers.convertToolsResponses;
 pub const curlPostTimed = helpers.curlPostTimed;
 pub const curlPostFormTimed = helpers.curlPostFormTimed;
 pub const extractContent = helpers.extractContent;


### PR DESCRIPTION
## Problem

Two bugs prevented the Responses API (`api_mode=responses`) from working with providers that implement the OpenAI Responses endpoint (e.g. foxnio):

Fixes #773

### 1. Tool schema format mismatch
`buildResponsesRequestBody` called `convertToolsOpenAI`, which emits the **chat completions** nested format:
```json
{"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}
```
The Responses API requires a **flat** format:
```json
{"type": "function", "name": "...", "description": "...", "parameters": {...}}
```
This caused providers to reject requests with `Missing required parameter: 'tools[0].name'`.

### 2. Null error misclassification
Responses API returns `"error": null` in successful responses. `classifyErrorObject` treated any non-string, non-object `error` field value as `.other` (an API error), causing valid completed responses to be rejected as errors.

## Changes

| File | Change |
|------|--------|
| `src/providers/helpers.zig` | Added `convertToolsResponses` with flat tool schema format |
| `src/providers/root.zig` | Export `convertToolsResponses` |
| `src/providers/compatible.zig` | `buildResponsesRequestBody` now calls `convertToolsResponses` |
| `src/providers/error_classify.zig` | `classifyErrorObject` skips `"error": null` instead of misclassifying it |

## Validation

- `zig build test --summary all`: 6337 passed, 0 failures, 0 leaks
- End-to-end verified with foxnio/gpt-5.4 via `nullclaw agent --no-stream`