### PR TITLE
docs: update outdated stats across all documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Key extension points:
 - `src/runtime.zig` (`RuntimeAdapter`) — execution environments
 - `src/peripherals.zig` (`Peripheral`) — hardware boards (Arduino, STM32, RPi)
 
-Current scale: **245 source files, ~204K lines of code, 5,640+ tests**.
+Current scale: **259 source files, ~237K lines of code, 6,300+ tests**.
 
 Build and test:
 
@@ -61,7 +61,7 @@ These codebase realities should drive every design decision:
    - SQLite: linked via `/opt/homebrew/opt/sqlite/{lib,include}` on the compile step, not the module.
    - `ArrayListUnmanaged`: init with `.empty`, pass allocator to every method.
 
-5. **All 5,640+ tests must pass at zero leaks**
+5. **All 6,300+ tests must pass at zero leaks**
    - The test suite uses `std.testing.allocator` (leak-detecting GPA). Every allocation must be freed.
    - `Config.load()` allocates — always wrap in `std.heap.ArenaAllocator` in tests and production.
    - `ChaCha20Poly1305.decrypt` segfaults on tag failure with heap-allocated output on macOS/Zig 0.15 — use a stack buffer then `allocator.dupe()`.
@@ -132,9 +132,9 @@ src/
   peripherals.zig       hardware peripherals (Arduino, STM32/Nucleo, RPi)
   security/             policy, pairing, secrets, sandbox backends
   memory/               SQLite + markdown backends, embeddings, vector search
-  providers/            50+ AI provider implementations (9 core + 41 compatible services)
-  channels/             17 channel implementations
-  tools/                30+ tool implementations
+  providers/            100+ AI provider integrations (12 core + 92+ compatible services)
+  channels/             24 channel implementations
+  tools/                38+ tool implementations
   agent/                agent loop, context, planner
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ Read `AGENTS.md` before any code change. It is the authoritative engineering pro
 ```bash
 # Requires exactly Zig 0.15.2 (verify: zig version)
 zig build                           # dev build
-zig build -Doptimize=ReleaseSmall   # release build (target: <1 MB binary)
-zig build test --summary all        # run all 5,300+ tests (must pass with 0 leaks)
+zig build -Doptimize=ReleaseSmall   # release build
+zig build test --summary all        # run all 6,300+ tests (must pass with 0 leaks)
 zig fmt src/                        # format all source files
 zig fmt --check src/                # check formatting (used by pre-commit hook)
 ```
@@ -45,7 +45,7 @@ git config core.hooksPath .githooks
 
 ## Project Overview
 
-NullClaw is an autonomous AI assistant runtime written in Zig 0.15.2. Hard constraints: 678 KB binary, ~1 MB peak RSS, <2 ms startup. Every dependency and abstraction has a measurable size/memory cost. Only two external dependencies: vendored SQLite (with build-time SHA256 hash verification) and `websocket.zig` (pinned commit).
+NullClaw is an autonomous AI assistant runtime written in Zig 0.15.2. Hard constraints: ~2.7 MB minimal binary, ~1 MB peak RSS, <2 ms startup. Every dependency and abstraction has a measurable size/memory cost. Only two external dependencies: vendored SQLite (with build-time SHA256 hash verification) and `websocket.zig` (pinned commit).
 
 ## Architecture
 
@@ -74,7 +74,7 @@ Defined in `src/root.zig`. Phases mirror deployment dependencies:
 
 ### Subsystem Directories
 
-- `src/providers/` - AI model providers. 9 core implementations + 41+ OpenAI-compatible services via `compatible.zig`. Factory in `factory.zig`, single source of truth for provider URLs and auth styles.
+- `src/providers/` - AI model providers. 12 core implementations + 92+ OpenAI-compatible services via `compatible.zig`. Factory in `factory.zig`, single source of truth for provider URLs and auth styles.
 - `src/channels/` - Messaging channels. Each implements `Channel.VTable` (`start`, `stop`, `send`, `name`, `healthCheck`). Factory in `root.zig`.
 - `src/tools/` - Tool implementations. Each implements `Tool.VTable` (`execute`, `name`, `description`, `parameters_json`). Tools receive args as `JsonObjectMap` and return `ToolResult`. Factory in `root.zig`.
 - `src/memory/` - Layered architecture: **engines** (SQLite, Markdown, LRU, Redis, PostgreSQL, LanceDB, Lucid, ClickHouse, API, None) and **retrieval** (hybrid search, RRF, embeddings). Engines conditionally compiled via build flags.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Want a simpler way to install and configure nullclaw with a UI? Try [nullhub](ht
 
 <p align="center">
   <strong>Null overhead. Null compromise. 100% Zig. 100% Agnostic.</strong><br>
-  <strong>678 KB binary. ~1 MB RAM. Boots in <2 ms. Runs on anything with a CPU.</strong>
+  <strong>~2.7 MB minimal binary. ~1 MB RAM. Boots in <2 ms. Runs on anything with a CPU.</strong>
 </p>
 
 <p align="center">
@@ -25,20 +25,20 @@ The smallest fully autonomous AI assistant infrastructure — a static Zig binar
 Docs: [English](docs/en/README.md) · [中文](docs/zh/README.md) · [Contributing](CONTRIBUTING.md) · [Discord](https://discord.gg/Bfmdua22Ud)
 
 ```
-678 KB binary · <2 ms startup · 5,300+ tests · 50+ providers · 19 channels · Pluggable everything
+~2.7 MB binary · <2 ms startup · 6,300+ tests · 100+ providers · 24 channels · Pluggable everything
 ```
 
 ### Features
 
-- **Impossibly Small:** 678 KB static binary — no runtime, no VM, no framework overhead.
+- **Impossibly Small:** ~2.7 MB minimal static binary — no runtime, no VM, no framework overhead.
 - **Near-Zero Memory:** ~1 MB peak RSS. Runs comfortably on the cheapest ARM SBCs and microcontrollers.
 - **Instant Startup:** <2 ms on Apple Silicon, <8 ms on a 0.8 GHz edge core.
 - **True Portability:** Single self-contained binary across ARM, x86, and RISC-V. Drop it anywhere, it just runs.
-- **Feature-Complete:** 50+ providers, 19 channels, 35+ tools, 10 memory engines, multi-layer sandbox, tunnels, hardware peripherals, MCP, subagents, streaming, voice — the full stack.
+- **Feature-Complete:** 100+ providers, 24 channels, 38+ tools, 10 memory engines, multi-layer sandbox, tunnels, hardware peripherals, MCP, subagents, streaming, voice — the full stack.
 
 ### Why nullclaw
 
-- **Lean by default:** Zig compiles to a tiny static binary. No allocator overhead, no garbage collector, no runtime.
+- **Lean by default:** Zig compiles to a small static binary. No allocator overhead, no garbage collector, no runtime.
 - **Secure by design:** pairing, strict sandboxing (landlock, firejail, bubblewrap, docker), explicit allowlists, workspace scoping, encrypted secrets.
 - **Fully swappable:** core systems are vtable interfaces (providers, channels, tools, memory, tunnels, peripherals, observers, runtimes).
 - **No lock-in:** OpenAI-compatible provider support + pluggable custom endpoints.
@@ -52,9 +52,9 @@ Local machine benchmark (macOS arm64, Feb 2026), normalized for 0.8 GHz edge har
 | **Language** | TypeScript | Python | Go | Rust | **Zig** |
 | **RAM** | > 1 GB | > 100 MB | < 10 MB | < 5 MB | **~1 MB** |
 | **Startup (0.8 GHz)** | > 500 s | > 30 s | < 1 s | < 10 ms | **< 8 ms** |
-| **Binary Size** | ~28 MB (dist) | N/A (Scripts) | ~8 MB | ~8.8 MB | **678 KB** |
-| **Tests** | — | — | — | 1,017 | **5,300+** |
-| **Source Files** | ~400+ | — | — | ~120 | **~230** |
+| **Binary Size** | ~28 MB (dist) | N/A (Scripts) | ~8 MB | ~8.8 MB | **~2.7 MB** |
+| **Tests** | — | — | — | 1,017 | **6,300+** |
+| **Source Files** | ~400+ | — | — | ~120 | **~260** |
 | **Cost** | Mac Mini $599 | Linux SBC ~$50 | Linux Board $10 | Any $10 hardware | **Any $5 hardware** |
 
 > Measured with `/usr/bin/time -l` on ReleaseSmall builds. nullclaw is a static binary with zero runtime dependencies.
@@ -216,8 +216,8 @@ Every subsystem is a **vtable interface** — swap implementations with a config
 
 | Subsystem | Interface | Ships with | Extend |
 |-----------|-----------|------------|--------|
-| **AI Models** | `Provider` | 50+ providers (OpenRouter, Anthropic, OpenAI, Azure OpenAI, Gemini, Vertex AI, Ollama, Venice, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, and many OpenAI-compatible endpoints) | `custom:https://your-api.com` — any OpenAI-compatible API |
-| **Channels** | `Channel` | CLI, Telegram, Signal, Discord, Slack, iMessage, Matrix, WhatsApp, Webhook, IRC, Lark/Feishu, OneBot, Line, DingTalk, Email, Nostr, QQ, MaixCam, Mattermost | Any messaging API |
+| **AI Models** | `Provider` | 100+ providers (OpenRouter, Anthropic, OpenAI, Azure OpenAI, Gemini, Vertex AI, Ollama, Venice, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, and 92+ OpenAI-compatible endpoints) | `custom:https://your-api.com` — any OpenAI-compatible API |
+| **Channels** | `Channel` | CLI, Telegram, Signal, Discord, Slack, iMessage, Matrix, WhatsApp, Webhook, IRC, Lark/Feishu, OneBot, Line, DingTalk, Email, Nostr, QQ, MaixCam, Mattermost, Web, Teams, Max, WeChat, WeCom | Any messaging API |
 | **Memory** | `Memory` | SQLite with hybrid search (FTS5 + vector cosine similarity), Markdown, ClickHouse, PostgreSQL, Redis, LanceDB, Lucid, LRU, API | Any persistence backend |
 | **Tools** | `Tool` | shell, file_read, file_write, file_edit, file_edit_hashed, file_read_hashed, file_append, memory_store, memory_recall, memory_forget, memory_list, browser_open, screenshot, composio, http_request, web_fetch, web_search, delegate, schedule, hardware_info, hardware_memory, pushover, message, spawn, git, image, i2c, spi, and more | Any capability |
 | **Observability** | `Observer` | Noop, Log, File, Multi | Prometheus, OTel |
@@ -786,8 +786,8 @@ Build and tests are pinned to **Zig 0.15.2**.
 
 ```bash
 zig build                          # Dev build
-zig build -Doptimize=ReleaseSmall  # Release build (678 KB)
-zig build test --summary all       # 5,300+ tests
+zig build -Doptimize=ReleaseSmall  # Release build (~2.7 MB)
+zig build test --summary all       # 6,300+ tests
 ```
 
 ### Channel Flow Coverage
@@ -804,10 +804,10 @@ Channel CJM coverage (ingress parsing/filtering, session key routing, account pr
 
 ```
 Language:     Zig 0.15.2
-Source files: ~250
-Lines of code: ~249,000
-Tests:        5,300+
-Binary:       678 KB (ReleaseSmall)
+Source files: ~260
+Lines of code: ~237,000
+Tests:        6,300+
+Binary:       ~2.7 MB (ReleaseSmall minimal) / ~4.1 MB (full)
 Peak RSS:     ~1 MB
 Startup:      <2 ms (Apple Silicon)
 Dependencies: 0 (besides libc + optional SQLite)
@@ -823,10 +823,10 @@ src/
   agent.zig             Agent loop, auto-compaction, tool dispatch
   daemon.zig            Daemon supervisor with exponential backoff
   gateway.zig           HTTP gateway (rate limiting, idempotency, pairing)
-  channels/             19 channel implementations (telegram, signal, discord, slack, nostr, matrix, whatsapp, line, lark, onebot, mattermost, qq, ...)
-  providers/            50+ AI provider integrations
+  channels/             24 channel implementations (telegram, signal, discord, slack, nostr, matrix, whatsapp, line, lark, onebot, mattermost, qq, web, teams, max, wechat, wecom, ...)
+  providers/            100+ AI provider integrations (12 core + 92+ compatible services)
   memory/               SQLite backend, embeddings, vector search, hygiene, snapshots
-  tools/                35+ tool implementations
+  tools/                38+ tool implementations
   security/             Secrets (ChaCha20), sandbox backends (landlock, firejail, ...)
   cron.zig              Cron scheduler with JSON persistence
   health.zig            Component health registry

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -32,8 +32,8 @@ NullClaw uses a vtable-driven pluggable architecture. Most capabilities are exte
 
 | Subsystem | Interface | Built-in implementations (partial) | Extension approach |
 |---|---|---|---|
-| AI Models | `Provider` | OpenRouter, Anthropic, OpenAI, Azure OpenAI, Gemini, Vertex AI, Ollama, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, Venice, and 41+ OpenAI-compatible endpoints | Add provider implementation + register |
-| Channels | `Channel` | CLI, Telegram, Signal, Discord, Slack, Matrix, WhatsApp, Nostr, IRC, Lark, Line, DingTalk, Email, OneBot, QQ, MaixCam, Mattermost, iMessage, Web, Teams, Max | Add channel implementation + register |
+| AI Models | `Provider` | OpenRouter, Anthropic, OpenAI, Azure OpenAI, Gemini, Vertex AI, Ollama, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, Venice, and 92+ OpenAI-compatible endpoints | Add provider implementation + register |
+| Channels | `Channel` | CLI, Telegram, Signal, Discord, Slack, Matrix, WhatsApp, Nostr, IRC, Lark, Line, DingTalk, Email, OneBot, QQ, MaixCam, Mattermost, iMessage, Web, Teams, Max, WeChat, WeCom, External | Add channel implementation + register |
 | Memory | `Memory` | SQLite (hybrid retrieval), Markdown, ClickHouse, PostgreSQL, Redis, LanceDB, Lucid, LRU, API, None | Add memory backend |
 | Tools | `Tool` | shell, file_read, file_write, file_edit, file_edit_hashed, file_read_hashed, file_append, http_request, web_fetch, web_search, delegate, screenshot, browser_open, and 20+ more | Add tool implementation |
 | Observability | `Observer` | Noop, Log, File, Multi | Add observer backend |

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -18,10 +18,10 @@ NullClaw 采用 vtable 可插拔架构。多数能力通过接口实现并在工
 
 | 子系统 | 接口 | 内置实现（节选） | 扩展方式 |
 |---|---|---|---|
-| AI Models | `Provider` | OpenRouter、Anthropic、OpenAI、Azure OpenAI、Gemini、Vertex AI、Ollama、Groq、Mistral、xAI、DeepSeek、Together、Fireworks、Perplexity、Cohere、Bedrock、Venice 等 50+ | 添加 provider 实现并注册 |
-| Channels | `Channel` | CLI、Telegram、Signal、Discord、Slack、Matrix、WhatsApp、Nostr、IRC、Lark、Line、DingTalk、Email、OneBot、QQ、MaixCam、Mattermost、iMessage、Web | 添加 channel 实现并注册 |
+| AI Models | `Provider` | OpenRouter、Anthropic、OpenAI、Azure OpenAI、Gemini、Vertex AI、Ollama、Groq、Mistral、xAI、DeepSeek、Together、Fireworks、Perplexity、Cohere、Bedrock、Venice 等 100+ | 添加 provider 实现并注册 |
+| Channels | `Channel` | CLI、Telegram、Signal、Discord、Slack、Matrix、WhatsApp、Nostr、IRC、Lark、Line、DingTalk、Email、OneBot、QQ、MaixCam、Mattermost、iMessage、Web、Teams、Max、WeChat、WeCom、External | 添加 channel 实现并注册 |
 | Memory | `Memory` | SQLite（hybrid 检索）、Markdown、ClickHouse、PostgreSQL、Redis、LanceDB、Lucid、LRU、API、None | 新增 memory backend |
-| Tools | `Tool` | shell、file_read、file_write、file_edit、file_edit_hashed、file_read_hashed、file_append、http_request、web_fetch、web_search、delegate、screenshot、browser_open 等 35+ | 新增 tool 实现 |
+| Tools | `Tool` | shell、file_read、file_write、file_edit、file_edit_hashed、file_read_hashed、file_append、http_request、web_fetch、web_search、delegate、screenshot、browser_open 等 38+ | 新增 tool 实现 |
 | Observability | `Observer` | Noop、Log、File、Multi | 对接监控系统 |
 | Runtime | `RuntimeAdapter` | Native、Docker、WASM | 新增 runtime adapter |
 | Security | `Sandbox` | Landlock、Firejail、Bubblewrap、Docker(auto) | 新增 sandbox backend |


### PR DESCRIPTION
## Problem

Documentation across README.md, CLAUDE.md, AGENTS.md, and architecture docs contains outdated numbers that no longer match the actual codebase.

## Changes

All numbers verified against source code:

| Metric | Old | New | Verified by |
|--------|-----|-----|-------------|
| Binary size | 678 KB | ~2.7 MB (minimal) / ~4.1 MB (full) | `zig build -Doptimize=ReleaseSmall && stat zig-out/bin/nullclaw` |
| Tests | 5,300+ / 5,640+ | 6,300+ | `zig build test --summary all` → 6,337 passed |
| Channels | 19 / 17 | 24 | `ChannelId` enum in `src/channel_catalog.zig` |
| Providers | 50+ (9+41) | 100+ (12+92) | `compat_providers` table + core factory |
| Tools | 35+ / 30+ | 38+ | `src/tools/` file count |
| Source files | ~230 / 245 | ~260 | `find src/ -name '*.zig' \| wc -l` → 259 |
| Lines of code | ~249K / ~204K | ~237K | `wc -l` across all .zig files |

## Files Modified

- `README.md` — 7+ stat locations updated
- `CLAUDE.md` — binary size, test count, provider count
- `AGENTS.md` — source files, LOC, test count, provider count, channel count
- `docs/en/architecture.md` — provider/channel counts and lists
- `docs/zh/architecture.md` — provider/channel counts and lists (Chinese)