### PR TITLE
docs: add MCP, subagents, skills, voice, and hardware documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,11 @@ This directory is the documentation index for nullclaw.
 
 ## Topical Docs
 
+- MCP integration: [`en/mcp.md`](./en/mcp.md) / [`zh/mcp.md`](./zh/mcp.md)
+- Subagents: [`en/subagents.md`](./en/subagents.md) / [`zh/subagents.md`](./zh/subagents.md)
+- Skills: [`en/skills.md`](./en/skills.md) / [`zh/skills.md`](./zh/skills.md)
+- Voice: [`en/voice.md`](./en/voice.md) / [`zh/voice.md`](./zh/voice.md)
+- Hardware & peripherals: [`en/hardware.md`](./en/hardware.md) / [`zh/hardware.md`](./zh/hardware.md)
 - External channel plugins: [`en/external-channels.md`](./en/external-channels.md) / [`zh/external-channels.md`](./zh/external-channels.md)
 - Ops runbooks:
   - [`en/ops/dingtalk-ops-readiness.md`](./en/ops/dingtalk-ops-readiness.md)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -76,6 +76,11 @@ Focus on:
 - [Security](./security.md)
 - [Gateway API](./gateway-api.md)
 - [External Channel Plugins](./external-channels.md)
+- [MCP Integration](./mcp.md)
+- [Subagents](./subagents.md)
+- [Skills](./skills.md)
+- [Voice](./voice.md)
+- [Hardware & Peripherals](./hardware.md)
 - [Commands](./commands.md)
 - [Development](./development.md)
 

--- a/docs/en/hardware.md
+++ b/docs/en/hardware.md
@@ -1,0 +1,101 @@
+# Hardware & Peripherals
+
+NullClaw can discover, flash, and interact with microcontroller boards over USB.
+
+## CLI Commands
+
+```bash
+nullclaw hardware scan             # Discover connected boards
+nullclaw hardware flash <path>     # Flash firmware to a board
+nullclaw hardware monitor          # Monitor USB hotplug events (Linux)
+```
+
+## Configuration
+
+```json
+{
+  "hardware": {
+    "enabled": true,
+    "transport": "serial",
+    "serial_port": "/dev/ttyACM0",
+    "baud_rate": 115200,
+    "workspace_datasheets": false
+  },
+  "peripherals": {
+    "enabled": true,
+    "boards": [
+      {
+        "board": "nucleo-f401re",
+        "transport": "serial",
+        "path": "/dev/ttyACM0",
+        "baud": 115200
+      }
+    ]
+  }
+}
+```
+
+## Supported Boards
+
+| Board | VID:PID | Flash | GPIO |
+|-------|---------|-------|------|
+| STM32 Nucleo-F401RE | 0483:374b | 512 KB | PA0-PC15, ADC |
+| STM32 Nucleo-F411RE | 0483:3748 | 512 KB | PA0-PC15, ADC |
+| Arduino Uno | 2341:0043 | 32 KB | D0-D13, A0-A5 |
+| Arduino Mega | 2341:0042 | 256 KB | D0-D53, A0-A15 |
+| ESP32 (CH340) | 1a86:7523 | 4 MB | GPIO0-GPIO39, ADC |
+| Raspberry Pi GPIO | — | — | GPIO 2-27 (sysfs) |
+
+## Peripheral Drivers
+
+### Serial (Arduino, ESP32)
+
+Communicates via newline-delimited JSON over USB CDC:
+
+```json
+{"id": "1", "cmd": "gpio_read", "args": {"pin": 13}}
+→ {"id": "1", "ok": true, "result": "1"}
+```
+
+### Arduino
+
+Uses `arduino-cli` for compilation and upload. Boards are auto-detected via `arduino-cli board list`.
+
+### STM32/Nucleo
+
+Uses `probe-rs` for flash and debug operations:
+
+```bash
+probe-rs run --chip STM32F401RETx firmware.elf
+```
+
+### Raspberry Pi GPIO
+
+Direct sysfs interface (`/sys/class/gpio/`). No flash support — GPIO read/write only.
+
+## Agent Tools
+
+When hardware is enabled, the agent gains access to:
+
+| Tool | Description |
+|------|-------------|
+| `hardware_info` | List discovered boards and capabilities |
+| `hardware_memory` | Read board memory/registers |
+| `i2c` | I2C bus read/write operations |
+| `spi` | SPI bus read/write operations |
+
+## Security
+
+Serial port access is restricted to known device paths:
+- `/dev/ttyACM*`, `/dev/ttyUSB*` (Linux)
+- `/dev/tty.usbmodem*`, `/dev/cu.usbmodem*` (macOS)
+- `/dev/tty.usbserial*`, `/dev/cu.usbserial*` (macOS)
+
+## Hotplug Monitoring (Linux)
+
+`nullclaw hardware monitor` uses `udevadm` to watch for USB device events in real time. Events include device add, remove, and change with VID/PID identification.
+
+## Related
+
+- [Architecture](./architecture.md) — Peripheral vtable design
+- [Configuration](./configuration.md) — Full config reference

--- a/docs/en/mcp.md
+++ b/docs/en/mcp.md
@@ -1,0 +1,94 @@
+# MCP (Model Context Protocol)
+
+NullClaw supports the [Model Context Protocol](https://modelcontextprotocol.io/) to extend agent capabilities with external tools and services.
+
+## Transports
+
+- **stdio**: Launch MCP servers as child processes. Best for local tools and npm packages.
+- **http**: Connect to remote MCP servers over HTTPS (or localhost HTTP). Supports custom headers and timeouts.
+
+## Configuration
+
+Add MCP servers to `~/.nullclaw/config.json` under `mcp_servers`:
+
+```json
+{
+  "mcp_servers": {
+    "filesystem": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem"]
+    },
+    "remote": {
+      "transport": "http",
+      "url": "https://mcp.example.com/rpc",
+      "timeout_ms": 10000,
+      "headers": {
+        "Authorization": "Bearer token-here"
+      }
+    }
+  }
+}
+```
+
+### Config Fields
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `transport` | string | `stdio` | `stdio` or `http` |
+| `command` | string | — | Executable for stdio transport |
+| `args` | array | `[]` | Command arguments |
+| `env` | array | `[]` | Environment variables: `[{"key": "K", "value": "V"}]` |
+| `url` | string | — | HTTP endpoint URL (required for http transport) |
+| `timeout_ms` | number | `10000` | Per-request timeout in milliseconds |
+| `headers` | array | `[]` | Custom HTTP headers: `[{"key": "K", "value": "V"}]` |
+
+## How It Works
+
+On startup, nullclaw:
+
+1. Connects to each configured MCP server (stdio: spawns process; http: connects to endpoint)
+2. Performs the MCP `initialize` handshake
+3. Discovers available tools via `tools/list`
+4. Wraps each tool with prefix `mcp_<server>_<tool>` (e.g., `mcp_filesystem_read_file`)
+5. Exposes them to the agent alongside built-in tools
+
+Tool discovery happens once at startup — there is no hot-reload. Restart nullclaw to pick up new MCP tools.
+
+## Security
+
+- **HTTP URLs**: Must be HTTPS for remote hosts. Plain HTTP is allowed only for localhost and private IPs (127.0.0.1, 10.x, 192.168.x, 172.16-31.x, ::1, fd00::/8, Tailscale 100.64-127.x).
+- **Headers**: Validated to prevent injection — no CR/LF allowed in values.
+- **Timeouts**: Enforced per-request (default 10s). Adjust `timeout_ms` for slow tools.
+- **Failures**: Individual server connection errors are logged and skipped. The agent continues with remaining tools.
+
+## Tool Filtering
+
+Use `agent.tool_filter_groups` to control which MCP tools are included per turn:
+
+```json
+{
+  "agent": {
+    "tool_filter_groups": [
+      {
+        "mode": "always",
+        "tools": ["mcp_filesystem_*"]
+      },
+      {
+        "mode": "dynamic",
+        "tools": ["mcp_jira_*"],
+        "keywords": ["ticket", "jira", "issue"]
+      }
+    ]
+  }
+}
+```
+
+- `always`: Tools matching the pattern are always included.
+- `dynamic`: Tools are included only when the user message contains a keyword.
+
+## Related
+
+- [Configuration](./configuration.md) — Full config reference
+- [Architecture](./architecture.md) — Subsystem overview
+- [Security](./security.md) — Security model

--- a/docs/en/skills.md
+++ b/docs/en/skills.md
@@ -1,0 +1,80 @@
+# Skills
+
+NullClaw supports extensible skill packs — self-contained modules that add new capabilities to the agent.
+
+## CLI Commands
+
+```bash
+nullclaw skills list              # List installed skills
+nullclaw skills install <url>     # Install from GitHub URL
+nullclaw skills remove <name>     # Remove an installed skill
+nullclaw skills info <name>       # Show skill metadata
+```
+
+## Skill Structure
+
+Skills live in `~/.nullclaw/workspace/skills/<name>/` and must contain a manifest:
+
+```
+skills/
+  my-skill/
+    SKILL.md          # YAML frontmatter + description (preferred)
+    skill.json        # or JSON manifest
+    build.zig         # optional Zig build (enhanced compatibility scoring)
+    root.zig          # optional Zig entry point
+```
+
+### SKILL.md Format
+
+```markdown
+---
+name: my-skill
+version: 1.0.0
+description: Does something useful
+---
+
+Detailed skill documentation here.
+```
+
+### skill.json Format
+
+```json
+{
+  "name": "my-skill",
+  "version": "1.0.0",
+  "description": "Does something useful"
+}
+```
+
+## SkillForge (Auto-Discovery)
+
+SkillForge can automatically discover and evaluate skills from GitHub.
+
+```json
+{
+  "skillforge": {
+    "enabled": true,
+    "auto_integrate": true,
+    "scan_interval_hours": 24,
+    "min_score": 0.7,
+    "output_dir": "./skills"
+  }
+}
+```
+
+### Scoring
+
+Skills are evaluated on a weighted scale:
+
+| Factor | Weight | Scoring |
+|--------|--------|---------|
+| Compatibility | 30% | Zig/Rust = 1.0, Python/TS/JS = 0.6, others = 0.3 |
+| Quality | 35% | Log-scale based on GitHub stars |
+| Security | 35% | +0.3 for license, -0.5 for suspicious patterns |
+
+Recommendations: `auto` (score >= 0.7), `manual` (0.4-0.7), `skip` (< 0.4).
+
+## Related
+
+- [Commands](./commands.md) — Full CLI reference
+- [Configuration](./configuration.md) — Config reference

--- a/docs/en/subagents.md
+++ b/docs/en/subagents.md
@@ -1,0 +1,73 @@
+# Subagents
+
+NullClaw can spawn isolated background agents to handle tasks concurrently without blocking the main conversation.
+
+## Overview
+
+Subagents run in separate OS threads with their own tool loop, security policy, and memory backend. They have a restricted tool set — `message`, `spawn`, and `delegate` are excluded to prevent infinite loops.
+
+## Spawning
+
+Subagents are spawned via the `spawn` tool or the `/subagents spawn` command:
+
+```
+/subagents spawn --agent researcher "Summarize the latest CVEs for Log4j"
+```
+
+The `delegate` tool also spawns subagents internally when the agent decides to offload work.
+
+## Configuration
+
+Subagent limits are controlled in `~/.nullclaw/config.json`:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "subagent_max_iterations": 15,
+      "subagent_max_concurrent": 4
+    }
+  }
+}
+```
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `subagent_max_iterations` | 15 | Max tool loop iterations per subagent |
+| `subagent_max_concurrent` | 4 | Max concurrent subagents |
+
+## Workspace Isolation
+
+Each named agent can have its own `workspace_path`:
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "researcher",
+        "provider": "openrouter",
+        "model": "anthropic/claude-sonnet-4",
+        "workspace_path": "./workspaces/researcher"
+      }
+    ]
+  }
+}
+```
+
+Relative paths resolve from the config directory. The workspace is scaffolded on first use, and the agent gets a durable memory namespace `agent:<agent-id>`.
+
+## Result Routing
+
+When a subagent completes, its result is published back to the originating session:
+
+- Success: `[Subagent 'label' completed]\nRESULT`
+- Failure: `[Subagent 'label' failed]\nERROR`
+
+## Query
+
+Check subagent status via the `spawn` tool or agent commands:
+
+- `getTaskStatus(task_id)` — running, completed, or failed
+- `getTaskResult(task_id)` — result text
+- `getRunningCount()` — number of active subagents

--- a/docs/en/voice.md
+++ b/docs/en/voice.md
@@ -1,0 +1,57 @@
+# Voice
+
+NullClaw supports audio transcription via OpenAI-compatible Whisper endpoints, enabling voice input from messaging channels.
+
+## Configuration
+
+```json
+{
+  "tools": {
+    "media": {
+      "audio": {
+        "enabled": true,
+        "provider": "groq",
+        "model": "whisper-large-v3",
+        "language": "en"
+      }
+    }
+  }
+}
+```
+
+### Config Fields
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `enabled` | bool | `true` | Enable audio transcription |
+| `provider` | string | `groq` | STT provider name |
+| `model` | string | `whisper-large-v3` | Whisper model variant |
+| `base_url` | string | — | Custom endpoint override |
+| `language` | string | — | ISO 639-1 code (e.g., `en`, `ru`, `zh`) |
+
+## Supported Providers
+
+| Provider | Endpoint |
+|----------|----------|
+| Groq | `https://api.groq.com/openai/v1/audio/transcriptions` |
+| OpenAI | `https://api.openai.com/v1/audio/transcriptions` |
+| Telnyx | `https://api.telnyx.com/v2/ai/audio/transcriptions` |
+| Custom | Set `base_url` to any OpenAI-compatible STT endpoint |
+
+The provider's API key is resolved from `models.providers.<name>.api_key`.
+
+## How It Works
+
+1. Audio file is received (e.g., Telegram voice message)
+2. File is streamed to a temp file to minimize memory usage
+3. Multipart POST to the Whisper endpoint with model and language params
+4. JSON response `{"text": "transcribed text"}` is parsed
+5. Transcribed text replaces the audio attachment in the conversation
+
+## Channel Integration
+
+Telegram voice messages are automatically transcribed when audio is enabled. The agent sees the transcribed text instead of an audio file reference.
+
+## Related
+
+- [Configuration](./configuration.md) — Full config reference

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -76,6 +76,11 @@
 - [安全机制](./security.md)
 - [Gateway API](./gateway-api.md)
 - [外部渠道插件](./external-channels.md)
+- [MCP 集成](./mcp.md)
+- [子 Agent](./subagents.md)
+- [技能包](./skills.md)
+- [语音](./voice.md)
+- [硬件与外设](./hardware.md)
 - [命令参考](./commands.md)
 - [开发指南](./development.md)
 

--- a/docs/zh/hardware.md
+++ b/docs/zh/hardware.md
@@ -1,0 +1,55 @@
+# 硬件与外设（Hardware & Peripherals）
+
+NullClaw 可以发现、烧录和操控通过 USB 连接的微控制器开发板。
+
+## CLI 命令
+
+```bash
+nullclaw hardware scan             # 发现已连接的开发板
+nullclaw hardware flash <path>     # 烧录固件
+nullclaw hardware monitor          # 监控 USB 热插拔事件（Linux）
+```
+
+## 配置
+
+```json
+{
+  "hardware": {
+    "enabled": true,
+    "transport": "serial",
+    "serial_port": "/dev/ttyACM0",
+    "baud_rate": 115200
+  },
+  "peripherals": {
+    "enabled": true,
+    "boards": [
+      { "board": "nucleo-f401re", "transport": "serial", "path": "/dev/ttyACM0" }
+    ]
+  }
+}
+```
+
+## 支持的开发板
+
+| 开发板 | 类型 | Flash | GPIO |
+|--------|------|-------|------|
+| STM32 Nucleo-F401RE/F411RE | ARM Cortex-M4 | 512 KB | PA0-PC15 |
+| Arduino Uno/Mega | AVR | 32-256 KB | D0-D53 |
+| ESP32 (CH340) | Xtensa | 4 MB | GPIO0-GPIO39 |
+| Raspberry Pi GPIO | ARM | — | GPIO 2-27 (sysfs) |
+
+## 外设驱动
+
+- **Serial**：通过 USB CDC 的 JSON 协议通信
+- **Arduino**：使用 `arduino-cli` 编译和上传
+- **STM32/Nucleo**：使用 `probe-rs` 烧录和调试
+- **Raspberry Pi**：sysfs GPIO 接口
+
+## Agent 工具
+
+启用硬件后，agent 可使用 `hardware_info`、`hardware_memory`、`i2c`、`spi` 工具。
+
+## 相关页面
+
+- [架构总览](./architecture.md)
+- [配置指南](./configuration.md)

--- a/docs/zh/mcp.md
+++ b/docs/zh/mcp.md
@@ -1,0 +1,50 @@
+# MCP（模型上下文协议）
+
+NullClaw 支持 [Model Context Protocol](https://modelcontextprotocol.io/)，通过外部工具和服务扩展 agent 能力。
+
+## 传输方式
+
+- **stdio**：以子进程方式启动 MCP 服务器，适合本地工具和 npm 包。
+- **http**：通过 HTTPS（或 localhost HTTP）连接远程 MCP 服务器，支持自定义 headers 和超时。
+
+## 配置
+
+在 `~/.nullclaw/config.json` 的 `mcp_servers` 下添加：
+
+```json
+{
+  "mcp_servers": {
+    "filesystem": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem"]
+    },
+    "remote": {
+      "transport": "http",
+      "url": "https://mcp.example.com/rpc",
+      "timeout_ms": 10000,
+      "headers": {
+        "Authorization": "Bearer token-here"
+      }
+    }
+  }
+}
+```
+
+## 工作原理
+
+启动时，nullclaw 连接每个 MCP 服务器，执行 `initialize` 握手，通过 `tools/list` 发现工具，以 `mcp_<服务器>_<工具>` 前缀暴露给 agent。
+
+工具发现仅在启动时执行一次，重启 nullclaw 以加载新工具。
+
+## 安全
+
+- HTTP URL 必须为 HTTPS（localhost 和私有 IP 除外）
+- Header 值禁止换行符
+- 单个服务器连接失败不影响其他工具
+
+## 相关页面
+
+- [配置指南](./configuration.md)
+- [架构总览](./architecture.md)
+- [安全机制](./security.md)

--- a/docs/zh/skills.md
+++ b/docs/zh/skills.md
@@ -1,0 +1,40 @@
+# 技能包（Skills）
+
+NullClaw 支持可扩展的技能包，为 agent 添加新能力。
+
+## CLI 命令
+
+```bash
+nullclaw skills list              # 列出已安装技能
+nullclaw skills install <url>     # 从 GitHub URL 安装
+nullclaw skills remove <name>     # 移除技能
+nullclaw skills info <name>       # 查看技能元数据
+```
+
+## 技能结构
+
+技能位于 `~/.nullclaw/workspace/skills/<name>/`，需包含 manifest：
+
+- `SKILL.md` — YAML frontmatter + 描述（推荐）
+- `skill.json` — JSON manifest
+- `build.zig` / `root.zig` — 可选 Zig 构建文件
+
+## SkillForge（自动发现）
+
+```json
+{
+  "skillforge": {
+    "enabled": true,
+    "auto_integrate": true,
+    "scan_interval_hours": 24,
+    "min_score": 0.7
+  }
+}
+```
+
+自动从 GitHub 发现并评估技能，按兼容性（30%）、质量（35%）、安全性（35%）加权评分。
+
+## 相关页面
+
+- [命令参考](./commands.md)
+- [配置指南](./configuration.md)

--- a/docs/zh/subagents.md
+++ b/docs/zh/subagents.md
@@ -1,0 +1,43 @@
+# 子 Agent（Subagents）
+
+NullClaw 可以派生隔离的后台 agent 来并发处理任务。
+
+## 概述
+
+子 agent 在独立线程中运行，拥有独立的工具循环、安全策略和 memory backend。为防止无限循环，`message`、`spawn`、`delegate` 工具被排除。
+
+## 派生
+
+通过 `spawn` 工具或 `/subagents spawn` 命令：
+
+```
+/subagents spawn --agent researcher "总结 Log4j 最新 CVE"
+```
+
+## 配置
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "subagent_max_iterations": 15,
+      "subagent_max_concurrent": 4
+    }
+  }
+}
+```
+
+## 工作空间隔离
+
+每个命名 agent 可配置独立 `workspace_path`，相对路径从配置目录解析，首次使用时自动创建。
+
+## 结果路由
+
+子 agent 完成后，结果发布回原始会话：
+- 成功：`[Subagent 'label' completed]\nRESULT`
+- 失败：`[Subagent 'label' failed]\nERROR`
+
+## 相关页面
+
+- [配置指南](./configuration.md)
+- [命令参考](./commands.md)

--- a/docs/zh/voice.md
+++ b/docs/zh/voice.md
@@ -1,0 +1,43 @@
+# 语音（Voice）
+
+NullClaw 支持通过 OpenAI 兼容的 Whisper 端点进行音频转录，实现消息渠道的语音输入。
+
+## 配置
+
+```json
+{
+  "tools": {
+    "media": {
+      "audio": {
+        "enabled": true,
+        "provider": "groq",
+        "model": "whisper-large-v3",
+        "language": "zh"
+      }
+    }
+  }
+}
+```
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `enabled` | bool | `true` | 启用音频转录 |
+| `provider` | string | `groq` | STT 提供商 |
+| `model` | string | `whisper-large-v3` | Whisper 模型 |
+| `base_url` | string | — | 自定义端点 |
+| `language` | string | — | ISO 639-1 语言代码 |
+
+## 支持的提供商
+
+- Groq、OpenAI、Telnyx，或任何 OpenAI 兼容的 STT 端点（通过 `base_url`）
+
+## 工作原理
+
+1. 接收音频文件（如 Telegram 语音消息）
+2. 流式写入临时文件以节省内存
+3. Multipart POST 到 Whisper 端点
+4. 解析转录文本，替换对话中的音频附件
+
+## 相关页面
+
+- [配置指南](./configuration.md)


### PR DESCRIPTION
## Problem

Five subsystems have substantial code implementations but no user-facing documentation:

| Subsystem | Source | Lines | Previous docs |
|-----------|--------|-------|---------------|
| MCP | `src/mcp.zig` | 915 | Config example in README only |
| Subagents | `src/subagent.zig` + `src/subagent_runner.zig` | 868+ | Brief mention in configuration.md |
| Skills | `src/skillforge.zig` | 974 | None |
| Voice | `src/voice.zig` | 603 | None |
| Hardware | `src/hardware.zig` + `src/peripherals.zig` | substantial | README architecture table only |

## Changes

### New English docs (`docs/en/`)
- `mcp.md` (94 lines) — transports, config fields, tool discovery, security, tool filtering
- `subagents.md` (73 lines) — spawning, workspace isolation, result routing, query API
- `skills.md` (80 lines) — CLI commands, manifest formats, SkillForge auto-discovery scoring
- `voice.md` (57 lines) — Whisper config, supported providers, transcription pipeline
- `hardware.md` (101 lines) — board discovery, peripheral drivers, agent tools, security

### Chinese stubs (`docs/zh/`)
- `mcp.md`, `subagents.md`, `skills.md`, `voice.md`, `hardware.md` — translated structure with key terms, ready for full translation

### Navigation updates
- `docs/README.md` — 5 new topical doc links
- `docs/en/README.md` — added to navigation
- `docs/zh/README.md` — added to navigation

## Files

13 files changed, +651 lines