### PR TITLE
fix: update build.zig.zon2json-lock for wasm3 and websocket

### DIFF
--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -8,7 +8,7 @@
   "wasm3-0.5.1-hrMdNS09BQAWSU0TI6mVS8KfW4hxexjFvyOQINgphwKu": {
     "name": "wasm3",
     "url": "git+https://github.com/nullclaw/wasm3#8a29b0080f1f65dbbe8b8f8c4d8148480feff377",
-    "hash": "sha256-np4DFGYqKd+IHbZnZzPfZdlKlvVJ9HMJGVUJp8PQ+C4=",
+    "hash": "sha256-3GFMnAqfNk6lDClNpgz1BqGCEJ2hJlhdecfunsgipPo=",
     "rev": "8a29b0080f1f65dbbe8b8f8c4d8148480feff377"
   }
 }

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -1,9 +1,9 @@
 {
-  "websocket-0.1.0-ZPISdXp4AwB5_c0jHAA9mZXqJFuOC_dtpVRRFPBbRaNO": {
+  "websocket-0.1.0-ZPISdRt7AwCgmiEnDNUp_kwBgzTEyVeLAPhTHZ7UZhMI": {
     "name": "websocket",
-    "url": "git+https://github.com/nullclaw/websocket#4b2c70da94d2dd0cca93d8eecb771633f609424b",
-    "hash": "sha256-b9SJEK+5ssOrEoTbuoiR7pbA3kNQmYq0u2TqDt0846U=",
-    "rev": "4b2c70da94d2dd0cca93d8eecb771633f609424b"
+    "url": "git+https://github.com/nullclaw/websocket#6a62e67405d883206a526cb25d667cf2e6fc4b2c",
+    "hash": "sha256-+PjC0N/+kQtVjy2PMW+pKNoza6kYvZhysdf3T6Lkr40=",
+    "rev": "6a62e67405d883206a526cb25d667cf2e6fc4b2c"
   },
   "wasm3-0.5.1-hrMdNS09BQAWSU0TI6mVS8KfW4hxexjFvyOQINgphwKu": {
     "name": "wasm3",


### PR DESCRIPTION
## Summary

- **wasm3**: nar hash was stale (`sha256-np4D...` → `sha256-3GFM...`). The `nullclaw/wasm3` repo appears to have been force-pushed at some point, causing Nix to fail hash verification even though the rev matches.
- **websocket**: rev in lock file (`4b2c70da`) was outdated; bumped to current HEAD (`6a62e67405d883206a526cb25d667cf2e6fc4b2c`) with updated key and nar hash.

Without these fixes, `nix build` fails with a hash mismatch error when fetching either dependency.

## Test plan

- [x] `nix build` completes without hash mismatch errors for wasm3 or websocket
- [x] nullclaw binary builds and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)