### PR TITLE
fix(security): initialize docker sandbox mount args via factory | 修复(安全): 通过工厂初始化 Docker 沙箱挂载参数

### DIFF
--- a/src/security/detect.zig
+++ b/src/security/detect.zig
@@ -5,7 +5,9 @@ const NoopSandbox = @import("sandbox.zig").NoopSandbox;
 const LandlockSandbox = @import("landlock.zig").LandlockSandbox;
 const FirejailSandbox = @import("firejail.zig").FirejailSandbox;
 const BubblewrapSandbox = @import("bubblewrap.zig").BubblewrapSandbox;
-const DockerSandbox = @import("docker.zig").DockerSandbox;
+const docker = @import("docker.zig");
+const DockerSandbox = docker.DockerSandbox;
+const createDockerSandbox = docker.createDockerSandbox;
 
 /// Sandbox backend preference.
 pub const SandboxBackend = enum {
@@ -60,7 +62,7 @@ pub fn createSandbox(
             return storage.noop.sandbox();
         },
         .docker => {
-            storage.docker = .{ .allocator = allocator, .workspace_dir = workspace_dir, .image = DockerSandbox.default_image };
+            storage.docker = createDockerSandbox(allocator, workspace_dir, null);
             return storage.docker.sandbox();
         },
         .auto => {
@@ -101,7 +103,7 @@ fn detectBest(allocator: std.mem.Allocator, workspace_dir: []const u8, storage: 
     }
 
     // Docker works on any platform if installed
-    storage.docker = .{ .allocator = allocator, .workspace_dir = workspace_dir, .image = DockerSandbox.default_image };
+    storage.docker = createDockerSandbox(allocator, workspace_dir, null);
     if (storage.docker.sandbox().isAvailable()) {
         return storage.docker.sandbox();
     }
@@ -132,7 +134,7 @@ pub fn detectAvailable(allocator: std.mem.Allocator, workspace_dir: []const u8) 
     storage.bubblewrap = .{ .workspace_dir = workspace_dir };
     const bw_avail = storage.bubblewrap.sandbox().isAvailable();
 
-    storage.docker = .{ .allocator = allocator, .workspace_dir = workspace_dir, .image = DockerSandbox.default_image };
+    storage.docker = createDockerSandbox(allocator, workspace_dir, null);
     const dk_avail = storage.docker.sandbox().isAvailable();
 
     return .{
@@ -182,6 +184,15 @@ test "create sandbox with docker returns docker" {
     var storage: SandboxStorage = .{};
     const sb = createSandbox(std.testing.allocator, .docker, "/tmp/workspace", &storage);
     try std.testing.expectEqualStrings("docker", sb.name());
+}
+
+test "create sandbox with docker prebuilds mount arg" {
+    var storage: SandboxStorage = .{};
+    _ = createSandbox(std.testing.allocator, .docker, "/tmp/workspace", &storage);
+
+    // Regression: detect.zig must use the Docker sandbox factory so wrapCommand
+    // never passes an empty -v argument to docker.
+    try std.testing.expectEqualStrings("/tmp/workspace:/tmp/workspace", storage.docker.mount_arg_buf[0..storage.docker.mount_arg_len]);
 }
 
 test "sandbox storage default initialization" {

--- a/src/security/docker.zig
+++ b/src/security/docker.zig
@@ -38,6 +38,7 @@ pub const DockerSandbox = struct {
 
     fn wrapCommand(ptr: *anyopaque, argv: []const []const u8, buf: [][]const u8) anyerror![]const []const u8 {
         const self = resolve(ptr);
+        if (self.workspace_dir.len == 0 or self.mount_arg_len == 0) return error.EmptyWorkspaceDir;
         // docker run --rm --memory 512m --cpus 1.0 --network none -v WORKSPACE:WORKSPACE -w WORKSPACE IMAGE <argv...>
         const prefix = [_][]const u8{
             "docker",   "run",       "--rm",
@@ -326,6 +327,20 @@ test "docker buffer too small returns error" {
     var buf: [5][]const u8 = undefined;
     const result = sb.wrapCommand(&argv, &buf);
     try std.testing.expectError(error.BufferTooSmall, result);
+}
+
+test "docker wrap rejects empty workspace state" {
+    var dk = DockerSandbox{
+        .allocator = std.testing.allocator,
+        .workspace_dir = "",
+        .image = DockerSandbox.default_image,
+    };
+    const sb = dk.sandbox();
+
+    const argv = [_][]const u8{"echo"};
+    var buf: [16][]const u8 = undefined;
+    const result = sb.wrapCommand(&argv, &buf);
+    try std.testing.expectError(error.EmptyWorkspaceDir, result);
 }
 
 test "docker sandbox workspace is mounted correctly" {


### PR DESCRIPTION
Closes #799
Closes #779
Closes #784

## Summary

### EN:
- Fixed a bug where Docker sandbox instances created by detection logic skipped the mount-argument factory and passed an empty `-v` value to `docker run`.
- Updated all Docker sandbox construction paths in `src/security/detect.zig` to use `createDockerSandbox(...)`.
- Added a defensive guard in `src/security/docker.zig` so invalid sandbox state returns `error.EmptyWorkspaceDir` instead of invoking Docker with an empty volume spec.
- Added regression tests for both the detect-time initialization path and the empty-workspace guard.

### ZH:
- 修复了一个问题：检测逻辑创建 Docker 沙箱实例时绕过了挂载参数构造逻辑，导致传给 `docker run` 的 `-v` 参数为空。
- 更新了 `src/security/detect.zig` 中所有创建 Docker 沙箱的路径，统一改为使用 `createDockerSandbox(...)`。
- 在 `src/security/docker.zig` 中加入防御性校验，使无效的沙箱状态返回 `error.EmptyWorkspaceDir`，而不是带着空的 volume spec 调用 Docker。
- 为检测阶段的初始化路径以及空工作区保护新增了回归测试。

## Validation
- `zig build test --summary all` — 6451 passed, 13 skipped, 0 failed.
- `zig build -Doptimize=ReleaseSmall` — success.

## Notes
- This change is intentionally minimal and does not alter sandbox selection priority or Docker runtime flags.
- The new guard prevents malformed wrapper argv even if a future caller bypasses the factory again.