### PR TITLE
fix(agent): persist cli turns into sqlite session history | 修复(agent): 将 CLI 对话持久化到 SQLite 会话历史

### DIFF
--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -32,6 +32,7 @@ const streaming = @import("../streaming.zig");
 const verbose = @import("../verbose.zig");
 
 const Agent = @import("root.zig").Agent;
+const commands = @import("commands.zig");
 
 const CliStreamCtx = struct {
     sink: streaming.Sink,
@@ -58,6 +59,35 @@ const CliProviderContext = struct {
 
 fn shouldPrintTurnResponse(supports_streaming: bool, emitted_text: bool) bool {
     return !supports_streaming or !emitted_text;
+}
+
+fn persistedAssistantReply(agent: anytype, response: []const u8) []const u8 {
+    if (agent.history.items.len == 0) return response;
+    const last = agent.history.items[agent.history.items.len - 1];
+    if (last.role != .assistant) return response;
+    return last.content;
+}
+
+fn persistCliTurn(agent: anytype, session_key: ?[]const u8, content: []const u8, response: []const u8) void {
+    const store = agent.session_store orelse return;
+    const sid = session_key orelse return;
+    const turn_input = commands.planTurnInput(content);
+
+    if (turn_input.clear_session) {
+        store.clearMessages(sid) catch {};
+        store.clearAutoSaved(sid) catch {};
+    }
+
+    if (commands.persistedRuntimeCommand(content)) |runtime_command| {
+        store.saveMessage(sid, memory_mod.RUNTIME_COMMAND_ROLE, runtime_command) catch {};
+    }
+
+    if (turn_input.llm_user_message) |persisted_user| {
+        const persisted_assistant = persistedAssistantReply(agent, response);
+        store.saveMessage(sid, "user", persisted_user) catch {};
+        store.saveMessage(sid, "assistant", persisted_assistant) catch {};
+        store.saveUsage(sid, agent.total_tokens) catch {};
+    }
 }
 
 fn cliStreamSinkCallback(ctx_ptr: *anyopaque, event: streaming.Event) void {
@@ -533,6 +563,8 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         };
         defer allocator.free(response);
 
+        persistCliTurn(&agent, agent.memory_session_id, message, response);
+
         if (shouldPrintTurnResponse(supports_streaming, stream_ctx.emitted_text)) {
             try w.print("{s}\n", .{response});
         } else {
@@ -682,6 +714,8 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
             continue;
         };
         defer allocator.free(response);
+
+        persistCliTurn(&agent, agent.memory_session_id, debounced_input.current, response);
 
         if (shouldPrintTurnResponse(supports_streaming, stream_ctx.emitted_text)) {
             try w.print("\n{s}\n\n", .{response});
@@ -1012,4 +1046,88 @@ test "writeRateLimitHint mentions reliability knobs and logs" {
     try std.testing.expect(std.mem.indexOf(u8, rendered, "reliability.provider_backoff_ms") != null);
     try std.testing.expect(std.mem.indexOf(u8, rendered, "~/.nullclaw/logs/daemon.stdout.log") != null);
     try std.testing.expect(std.mem.indexOf(u8, rendered, "kimi appears rate-limited or quota-constrained") != null);
+}
+
+test "persistCliTurn stores user and assistant messages in session history" {
+    const allocator = std.testing.allocator;
+    var mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
+    defer mem.deinit();
+
+    const store = mem.sessionStore();
+    var dummy = struct {
+        session_store: ?memory_mod.SessionStore,
+        history: std.ArrayListUnmanaged(Agent.OwnedMessage),
+        total_tokens: u64,
+    }{
+        .session_store = store,
+        .history = .empty,
+        .total_tokens = 42,
+    };
+    defer {
+        for (dummy.history.items) |msg| msg.deinit(allocator);
+        dummy.history.deinit(allocator);
+    }
+
+    try dummy.history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "pong"),
+    });
+
+    persistCliTurn(&dummy, "test-cli-session", "ping", "pong");
+
+    const sessions = try store.listSessions(allocator, 10, 0);
+    defer memory_mod.freeSessionInfos(allocator, sessions);
+    try std.testing.expectEqual(@as(usize, 1), sessions.len);
+    try std.testing.expectEqualStrings("test-cli-session", sessions[0].session_id);
+    try std.testing.expectEqual(@as(u64, 2), sessions[0].message_count);
+
+    const detailed = try store.loadMessagesDetailed(allocator, "test-cli-session", 10, 0);
+    defer memory_mod.freeDetailedMessages(allocator, detailed);
+    try std.testing.expectEqual(@as(usize, 2), detailed.len);
+    try std.testing.expectEqualStrings("user", detailed[0].role);
+    try std.testing.expectEqualStrings("ping", detailed[0].content);
+    try std.testing.expectEqualStrings("assistant", detailed[1].role);
+    try std.testing.expectEqualStrings("pong", detailed[1].content);
+    try std.testing.expectEqual(@as(?u64, 42), try store.loadUsage("test-cli-session"));
+}
+
+test "persistCliTurn clears prior session history on reset" {
+    const allocator = std.testing.allocator;
+    var mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
+    defer mem.deinit();
+
+    const store = mem.sessionStore();
+    try store.saveMessage("test-cli-session", "user", "old");
+    try store.saveMessage("test-cli-session", "assistant", "history");
+
+    var dummy = struct {
+        session_store: ?memory_mod.SessionStore,
+        history: std.ArrayListUnmanaged(Agent.OwnedMessage),
+        total_tokens: u64,
+    }{
+        .session_store = store,
+        .history = .empty,
+        .total_tokens = 7,
+    };
+    defer {
+        for (dummy.history.items) |msg| msg.deinit(allocator);
+        dummy.history.deinit(allocator);
+    }
+
+    try dummy.history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "fresh reply"),
+    });
+
+    // Regression: CLI turns with explicit session ids must update the session-store
+    // history tables, not just the memories table, so `history list/show` stays populated.
+    persistCliTurn(&dummy, "test-cli-session", "/reset", "fresh reply");
+
+    const detailed = try store.loadMessagesDetailed(allocator, "test-cli-session", 10, 0);
+    defer memory_mod.freeDetailedMessages(allocator, detailed);
+    try std.testing.expectEqual(@as(usize, 2), detailed.len);
+    try std.testing.expectEqualStrings("user", detailed[0].role);
+    try std.testing.expectEqualStrings(commands.BARE_SESSION_RESET_PROMPT, detailed[0].content);
+    try std.testing.expectEqualStrings("assistant", detailed[1].role);
+    try std.testing.expectEqualStrings("fresh reply", detailed[1].content);
 }

--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -33,7 +33,7 @@ const streaming = @import("../streaming.zig");
 const verbose = @import("../verbose.zig");
 
 const Agent = @import("root.zig").Agent;
-const commands = @import("commands.zig");
+const turn_persistence = @import("turn_persistence.zig");
 
 const CliStreamCtx = struct {
     sink: streaming.Sink,
@@ -62,33 +62,13 @@ fn shouldPrintTurnResponse(supports_streaming: bool, emitted_text: bool) bool {
     return !supports_streaming or !emitted_text;
 }
 
-fn persistedAssistantReply(agent: anytype, response: []const u8) []const u8 {
-    if (agent.history.items.len == 0) return response;
-    const last = agent.history.items[agent.history.items.len - 1];
-    if (last.role != .assistant) return response;
-    return last.content;
-}
-
-fn persistCliTurn(agent: anytype, session_key: ?[]const u8, content: []const u8, response: []const u8) void {
+fn persistCliTurn(agent: *const Agent, content: []const u8, response: []const u8) void {
     const store = agent.session_store orelse return;
-    const sid = session_key orelse return;
-    const turn_input = commands.planTurnInput(content);
-
-    if (turn_input.clear_session) {
-        store.clearMessages(sid) catch {};
-        store.clearAutoSaved(sid) catch {};
-    }
-
-    if (commands.persistedRuntimeCommand(content)) |runtime_command| {
-        store.saveMessage(sid, memory_mod.RUNTIME_COMMAND_ROLE, runtime_command) catch {};
-    }
-
-    if (turn_input.llm_user_message) |persisted_user| {
-        const persisted_assistant = persistedAssistantReply(agent, response);
-        store.saveMessage(sid, "user", persisted_user) catch {};
-        store.saveMessage(sid, "assistant", persisted_assistant) catch {};
-        store.saveUsage(sid, agent.total_tokens) catch {};
-    }
+    const session_key = agent.memory_session_id orelse return;
+    turn_persistence.persistTurn(store, .{
+        .history = agent.history.items,
+        .total_tokens = agent.total_tokens,
+    }, session_key, content, response);
 }
 
 fn cliStreamSinkCallback(ctx_ptr: *anyopaque, event: streaming.Event) void {
@@ -564,7 +544,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         };
         defer allocator.free(response);
 
-        persistCliTurn(&agent, agent.memory_session_id, message, response);
+        persistCliTurn(&agent, message, response);
 
         if (shouldPrintTurnResponse(supports_streaming, stream_ctx.emitted_text)) {
             try w.print("{s}\n", .{response});
@@ -716,7 +696,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         };
         defer allocator.free(response);
 
-        persistCliTurn(&agent, agent.memory_session_id, debounced_input.current, response);
+        persistCliTurn(&agent, debounced_input.current, response);
 
         if (shouldPrintTurnResponse(supports_streaming, stream_ctx.emitted_text)) {
             try w.print("\n{s}\n\n", .{response});
@@ -1054,88 +1034,4 @@ test "writeRateLimitHint mentions reliability knobs and logs" {
     try std.testing.expect(std.mem.indexOf(u8, rendered, "reliability.provider_backoff_ms") != null);
     try std.testing.expect(std.mem.indexOf(u8, rendered, "~/.nullclaw/logs/daemon.stdout.log") != null);
     try std.testing.expect(std.mem.indexOf(u8, rendered, "kimi appears rate-limited or quota-constrained") != null);
-}
-
-test "persistCliTurn stores user and assistant messages in session history" {
-    const allocator = std.testing.allocator;
-    var mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
-    defer mem.deinit();
-
-    const store = mem.sessionStore();
-    var dummy = struct {
-        session_store: ?memory_mod.SessionStore,
-        history: std.ArrayListUnmanaged(Agent.OwnedMessage),
-        total_tokens: u64,
-    }{
-        .session_store = store,
-        .history = .empty,
-        .total_tokens = 42,
-    };
-    defer {
-        for (dummy.history.items) |msg| msg.deinit(allocator);
-        dummy.history.deinit(allocator);
-    }
-
-    try dummy.history.append(allocator, .{
-        .role = .assistant,
-        .content = try allocator.dupe(u8, "pong"),
-    });
-
-    persistCliTurn(&dummy, "test-cli-session", "ping", "pong");
-
-    const sessions = try store.listSessions(allocator, 10, 0);
-    defer memory_mod.freeSessionInfos(allocator, sessions);
-    try std.testing.expectEqual(@as(usize, 1), sessions.len);
-    try std.testing.expectEqualStrings("test-cli-session", sessions[0].session_id);
-    try std.testing.expectEqual(@as(u64, 2), sessions[0].message_count);
-
-    const detailed = try store.loadMessagesDetailed(allocator, "test-cli-session", 10, 0);
-    defer memory_mod.freeDetailedMessages(allocator, detailed);
-    try std.testing.expectEqual(@as(usize, 2), detailed.len);
-    try std.testing.expectEqualStrings("user", detailed[0].role);
-    try std.testing.expectEqualStrings("ping", detailed[0].content);
-    try std.testing.expectEqualStrings("assistant", detailed[1].role);
-    try std.testing.expectEqualStrings("pong", detailed[1].content);
-    try std.testing.expectEqual(@as(?u64, 42), try store.loadUsage("test-cli-session"));
-}
-
-test "persistCliTurn clears prior session history on reset" {
-    const allocator = std.testing.allocator;
-    var mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
-    defer mem.deinit();
-
-    const store = mem.sessionStore();
-    try store.saveMessage("test-cli-session", "user", "old");
-    try store.saveMessage("test-cli-session", "assistant", "history");
-
-    var dummy = struct {
-        session_store: ?memory_mod.SessionStore,
-        history: std.ArrayListUnmanaged(Agent.OwnedMessage),
-        total_tokens: u64,
-    }{
-        .session_store = store,
-        .history = .empty,
-        .total_tokens = 7,
-    };
-    defer {
-        for (dummy.history.items) |msg| msg.deinit(allocator);
-        dummy.history.deinit(allocator);
-    }
-
-    try dummy.history.append(allocator, .{
-        .role = .assistant,
-        .content = try allocator.dupe(u8, "fresh reply"),
-    });
-
-    // Regression: CLI turns with explicit session ids must update the session-store
-    // history tables, not just the memories table, so `history list/show` stays populated.
-    persistCliTurn(&dummy, "test-cli-session", "/reset", "fresh reply");
-
-    const detailed = try store.loadMessagesDetailed(allocator, "test-cli-session", 10, 0);
-    defer memory_mod.freeDetailedMessages(allocator, detailed);
-    try std.testing.expectEqual(@as(usize, 2), detailed.len);
-    try std.testing.expectEqualStrings("user", detailed[0].role);
-    try std.testing.expectEqualStrings(commands.BARE_SESSION_RESET_PROMPT, detailed[0].content);
-    try std.testing.expectEqualStrings("assistant", detailed[1].role);
-    try std.testing.expectEqualStrings("fresh reply", detailed[1].content);
 }

--- a/src/agent/turn_persistence.zig
+++ b/src/agent/turn_persistence.zig
@@ -1,0 +1,141 @@
+const std = @import("std");
+const commands = @import("commands.zig");
+const memory_mod = @import("../memory/root.zig");
+const Agent = @import("root.zig").Agent;
+
+pub const TurnPersistenceState = struct {
+    history: []const Agent.OwnedMessage,
+    total_tokens: u64,
+};
+
+fn persistedAssistantReply(history: []const Agent.OwnedMessage, response: []const u8) []const u8 {
+    if (history.len == 0) return response;
+    const last = history[history.len - 1];
+    if (last.role != .assistant) return response;
+    return last.content;
+}
+
+pub fn persistTurn(
+    store: memory_mod.SessionStore,
+    state: TurnPersistenceState,
+    session_key: []const u8,
+    content: []const u8,
+    response: []const u8,
+) void {
+    const turn_input = commands.planTurnInput(content);
+
+    if (turn_input.clear_session) {
+        store.clearMessages(session_key) catch {};
+        store.clearAutoSaved(session_key) catch {};
+    }
+
+    if (commands.persistedRuntimeCommand(content)) |runtime_command| {
+        store.saveMessage(session_key, memory_mod.RUNTIME_COMMAND_ROLE, runtime_command) catch {};
+    }
+
+    if (turn_input.llm_user_message) |persisted_user| {
+        // Persist canonical conversation history.
+        // Local-only slash commands are skipped, but any input that
+        // reached the LLM must persist with the exact same routing
+        // decision used by Agent.turn().
+        // When the turn ends with an assistant history message, prefer
+        // that canonical text over the rendered reply so restored
+        // sessions do not replay /usage footers or reasoning blocks.
+        // Some degraded turns return a fallback response without
+        // appending a final assistant history entry; in that case we
+        // must persist the actual response instead of stale tool-step
+        // assistant text from earlier in the turn.
+        const persisted_assistant = persistedAssistantReply(state.history, response);
+        store.saveMessage(session_key, "user", persisted_user) catch {};
+        store.saveMessage(session_key, "assistant", persisted_assistant) catch {};
+        store.saveUsage(session_key, state.total_tokens) catch {};
+    }
+}
+
+test "persistTurn stores user and assistant messages in session history" {
+    const allocator = std.testing.allocator;
+    var mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
+    defer mem.deinit();
+
+    const store = mem.sessionStore();
+    var history: std.ArrayListUnmanaged(Agent.OwnedMessage) = .empty;
+    defer {
+        for (history.items) |msg| msg.deinit(allocator);
+        history.deinit(allocator);
+    }
+
+    try history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "pong"),
+    });
+
+    persistTurn(store, .{ .history = history.items, .total_tokens = 42 }, "test-cli-session", "ping", "pong");
+
+    const sessions = try store.listSessions(allocator, 10, 0);
+    defer memory_mod.freeSessionInfos(allocator, sessions);
+    try std.testing.expectEqual(@as(usize, 1), sessions.len);
+    try std.testing.expectEqualStrings("test-cli-session", sessions[0].session_id);
+    try std.testing.expectEqual(@as(u64, 2), sessions[0].message_count);
+
+    const detailed = try store.loadMessagesDetailed(allocator, "test-cli-session", 10, 0);
+    defer memory_mod.freeDetailedMessages(allocator, detailed);
+    try std.testing.expectEqual(@as(usize, 2), detailed.len);
+    try std.testing.expectEqualStrings("user", detailed[0].role);
+    try std.testing.expectEqualStrings("ping", detailed[0].content);
+    try std.testing.expectEqualStrings("assistant", detailed[1].role);
+    try std.testing.expectEqualStrings("pong", detailed[1].content);
+    try std.testing.expectEqual(@as(?u64, 42), try store.loadUsage("test-cli-session"));
+}
+
+test "persistTurn clears prior session history on reset" {
+    const allocator = std.testing.allocator;
+    var mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
+    defer mem.deinit();
+
+    const store = mem.sessionStore();
+    try store.saveMessage("test-cli-session", "user", "old");
+    try store.saveMessage("test-cli-session", "assistant", "history");
+
+    var history: std.ArrayListUnmanaged(Agent.OwnedMessage) = .empty;
+    defer {
+        for (history.items) |msg| msg.deinit(allocator);
+        history.deinit(allocator);
+    }
+
+    try history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "fresh reply"),
+    });
+
+    // Regression: CLI turns with explicit session ids must update the session-store
+    // history tables, not just the memories table, so `history list/show` stays populated.
+    persistTurn(store, .{ .history = history.items, .total_tokens = 7 }, "test-cli-session", "/reset", "fresh reply");
+
+    const detailed = try store.loadMessagesDetailed(allocator, "test-cli-session", 10, 0);
+    defer memory_mod.freeDetailedMessages(allocator, detailed);
+    try std.testing.expectEqual(@as(usize, 2), detailed.len);
+    try std.testing.expectEqualStrings("user", detailed[0].role);
+    try std.testing.expectEqualStrings(commands.BARE_SESSION_RESET_PROMPT, detailed[0].content);
+    try std.testing.expectEqualStrings("assistant", detailed[1].role);
+    try std.testing.expectEqualStrings("fresh reply", detailed[1].content);
+}
+
+test "persistTurn falls back to rendered response when assistant history is absent" {
+    const allocator = std.testing.allocator;
+    var mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
+    defer mem.deinit();
+
+    const store = mem.sessionStore();
+    var history: std.ArrayListUnmanaged(Agent.OwnedMessage) = .empty;
+    defer history.deinit(allocator);
+
+    // Regression: degraded turns can return a response without appending a final
+    // assistant history message, so persistence must keep the rendered reply.
+    persistTurn(store, .{ .history = history.items, .total_tokens = 9 }, "fallback-session", "hello", "fallback reply");
+
+    const detailed = try store.loadMessagesDetailed(allocator, "fallback-session", 10, 0);
+    defer memory_mod.freeDetailedMessages(allocator, detailed);
+    try std.testing.expectEqual(@as(usize, 2), detailed.len);
+    try std.testing.expectEqualStrings("assistant", detailed[1].role);
+    try std.testing.expectEqualStrings("fallback reply", detailed[1].content);
+}

--- a/src/session.zig
+++ b/src/session.zig
@@ -15,6 +15,7 @@ const Config = @import("config.zig").Config;
 const fs_compat = @import("fs_compat.zig");
 const agent_routing = @import("agent_routing.zig");
 const agent_mod = @import("agent/root.zig");
+const turn_persistence = @import("agent/turn_persistence.zig");
 const Agent = agent_mod.Agent;
 const NamedAgentConfig = @import("config_types.zig").NamedAgentConfig;
 const ConversationContext = @import("agent/prompt.zig").ConversationContext;
@@ -84,13 +85,6 @@ fn estimateRestoredSessionTokens(entries: []const memory_mod.MessageEntry) u64 {
         total += agent_mod.estimate_text_tokens(entry.content);
     }
     return total;
-}
-
-fn persistedAssistantReply(agent: *const Agent, response: []const u8) []const u8 {
-    if (agent.history.items.len == 0) return response;
-    const last = agent.history.items[agent.history.items.len - 1];
-    if (last.role != .assistant) return response;
-    return last.content;
 }
 
 fn restorePersistedSessionState(session: *Session, entries: []const memory_mod.MessageEntry) void {
@@ -1677,8 +1671,6 @@ pub const SessionManager = struct {
             session.agent.stream_ctx = null;
         }
 
-        const turn_input = agent_mod.commands.planTurnInput(content);
-
         // Record agent start event with channel attribution
         const start_event = @import("observability.zig").ObserverEvent{ .agent_start = .{
             .provider = session.agent.provider.getName(),
@@ -1699,34 +1691,10 @@ pub const SessionManager = struct {
 
         // Persist messages via session store
         if (session.agent.session_store) |store| {
-            if (turn_input.clear_session) {
-                // Clear persisted messages on session reset
-                store.clearMessages(session_key) catch {};
-                // Clear stale auto-saved memories
-                store.clearAutoSaved(session_key) catch {};
-            }
-
-            if (agent_mod.commands.persistedRuntimeCommand(content)) |runtime_command| {
-                store.saveMessage(session_key, RUNTIME_COMMAND_ROLE, runtime_command) catch {};
-            }
-
-            if (turn_input.llm_user_message) |persisted_user| {
-                // Persist canonical conversation history.
-                // Local-only slash commands are skipped, but any input that
-                // reached the LLM must persist with the exact same routing
-                // decision used by Agent.turn().
-                // When the turn ends with an assistant history message, prefer
-                // that canonical text over the rendered reply so restored
-                // sessions do not replay /usage footers or reasoning blocks.
-                // Some degraded turns return a fallback response without
-                // appending a final assistant history entry; in that case we
-                // must persist the actual response instead of stale tool-step
-                // assistant text from earlier in the turn.
-                const persisted_assistant = persistedAssistantReply(&session.agent, response);
-                store.saveMessage(session_key, "user", persisted_user) catch {};
-                store.saveMessage(session_key, "assistant", persisted_assistant) catch {};
-                store.saveUsage(session_key, session.agent.total_tokens) catch {};
-            }
+            turn_persistence.persistTurn(store, .{
+                .history = session.agent.history.items,
+                .total_tokens = session.agent.total_tokens,
+            }, session_key, content, response);
         }
 
         if (self.config.diagnostics.log_message_payloads) {


### PR DESCRIPTION
Closes #797

## Summary

### EN:
- Fixed a bug where `nullclaw agent` could return successful replies while SQLite-backed `history list/show` remained empty for the same session.
- Updated the CLI agent path to persist canonical user/assistant turns into the session store, matching the existing `SessionManager` persistence flow.
- Ensured CLI session resets also clear previously persisted session history before storing the new reset turn.
- Added regression tests covering both normal CLI turn persistence and reset behavior.

### ZH:
- 修复了一个问题：`nullclaw agent` 即使成功返回回复，基于 SQLite 的 `history list/show` 仍然可能在同一会话下显示为空。
- 更新了 CLI agent 路径，使其像现有的 `SessionManager` 一样，将规范化后的 user/assistant 对话写入 session store。
- 确保 CLI 会话在执行 reset 时，会先清除之前持久化的会话历史，再写入新的 reset 对话。
- 新增回归测试，覆盖普通 CLI 对话持久化和 reset 行为。

## Validation
- `zig build test --summary all` — 6451 passed, 13 skipped, 0 failed.
- `zig build -Doptimize=ReleaseSmall` — success.

## Notes
- This change is intentionally limited to the CLI path and does not alter the existing `SessionManager` persistence behavior.
- The fix keeps `history list/show` aligned with the canonical persisted conversation rather than autosaved memory entries.