### PR TITLE
fix(agent): keep unbound sessions on the main agent | 修复(agent): 让未绑定会话始终落到主代理 main

### DIFF
--- a/src/agent_routing.zig
+++ b/src/agent_routing.zig
@@ -218,10 +218,9 @@ pub fn resolveThreadParentSessionKey(key: []const u8) ?[]const u8 {
     return null;
 }
 
-/// Find the default agent from a named agents list.
-/// Returns the first agent's name, or "main" if the list is empty.
-pub fn findDefaultAgent(agents: []const NamedAgentConfig) []const u8 {
-    if (agents.len > 0) return agents[0].name;
+/// Find the default agent when no binding matches.
+/// The fallback must always remain the reserved root agent id `main`.
+pub fn findDefaultAgent(_: []const NamedAgentConfig) []const u8 {
     return "main";
 }
 
@@ -503,7 +502,9 @@ test "resolveRoute — no bindings returns default agent" {
     defer allocator.free(route.session_key);
     defer allocator.free(route.main_session_key);
 
-    try std.testing.expectEqualStrings("helper", route.agent_id);
+    // Regression: unbound traffic must stay on the reserved root agent
+    // instead of implicitly routing to the first named subagent.
+    try std.testing.expectEqualStrings("main", route.agent_id);
     try std.testing.expectEqual(MatchedBy.default, route.matched_by);
     try std.testing.expectEqualStrings("discord", route.channel);
     try std.testing.expectEqualStrings("acct1", route.account_id);
@@ -792,13 +793,13 @@ test "findDefaultAgent — empty list returns main" {
     try std.testing.expectEqualStrings("main", result);
 }
 
-test "findDefaultAgent — returns first agent name" {
+test "findDefaultAgent — ignores named agents and returns main" {
     const agents = [_]NamedAgentConfig{
         .{ .name = "alpha", .provider = "openai", .model = "gpt-4" },
         .{ .name = "beta", .provider = "anthropic", .model = "claude-3" },
     };
     const result = findDefaultAgent(&agents);
-    try std.testing.expectEqualStrings("alpha", result);
+    try std.testing.expectEqualStrings("main", result);
 }
 
 test "peerMatches — both present and equal" {
@@ -1146,8 +1147,8 @@ test "resolveRoute — defaultAgentId used when no binding matches" {
     }, &.{}, &agents);
     defer allocator.free(route.session_key);
     defer allocator.free(route.main_session_key);
-    try std.testing.expectEqualStrings("home", route.agent_id);
-    try std.testing.expectEqualStrings("agent:home:main", route.main_session_key);
+    try std.testing.expectEqualStrings("main", route.agent_id);
+    try std.testing.expectEqualStrings("agent:main:main", route.main_session_key);
 }
 
 test "resolveRoute — peer+guild binding requires guild match" {


### PR DESCRIPTION
Closes #793

## Summary

### EN:
- Fixed a routing bug where sessions with no matching binding could fall through to the first named agent in `agents.list` instead of staying on the reserved root agent `main`.
- Restored the documented routing contract: when no binding matches, the default agent is always `main`.
- Prevented the main session prompt from being replaced by the first subagent profile and system prompt.
- Updated routing regression tests to lock in the `main` fallback behavior.

### ZH:
- 修复了一个路由问题：当会话没有匹配到任何 binding 时，系统会错误地落到 `agents.list` 中的第一个具名代理，而不是保留在保留的根代理 `main` 上。
- 恢复了文档中声明的路由约定：当没有 binding 命中时，默认代理始终是 `main`。
- 避免主会话的 prompt 被第一个子代理的 profile 和 system prompt 错误替换。
- 更新了路由回归测试，确保 `main` 作为默认回退目标的行为不会再次回归。

## Validation
- `zig build test --summary all` — 6449 passed, 13 skipped, 0 failed.
- `zig build -Doptimize=ReleaseSmall` — success.

## Notes
- This change is intentionally limited to the unbound fallback path and does not alter explicit agent bindings.
- Named agents still work as before when selected through routing or direct session keys.