### PR TITLE
fix(provider): fall back to responses on chat endpoint 404 | 修复(provider): chat 端点返回 404 时回退到 responses

### DIFF
--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -132,8 +132,26 @@ fn isResponsesFallbackMessage(message: []const u8) bool {
         containsAsciiFold(trimmed, "/chat/completions");
 }
 
+fn isPlainTextResponsesFallbackMessage(body: []const u8) bool {
+    const trimmed = std.mem.trim(u8, body, " \t\r\n");
+    if (trimmed.len == 0) return false;
+
+    // Some compatible gateways return a plain-text 404 instead of a JSON error
+    // envelope when /chat/completions is missing.
+    return containsAsciiFold(trimmed, "/chat/completions") and
+        (containsAsciiFold(trimmed, "404") or
+            containsAsciiFold(trimmed, "not found") or
+            containsAsciiFold(trimmed, "unknown endpoint") or
+            containsAsciiFold(trimmed, "endpoint not found"));
+}
+
 fn shouldFallbackToResponses(allocator: std.mem.Allocator, body: []const u8) bool {
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch return false;
+    const trimmed = std.mem.trim(u8, body, " \t\r\n");
+    if (trimmed.len == 0) return false;
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch {
+        return isPlainTextResponsesFallbackMessage(trimmed);
+    };
     defer parsed.deinit();
     if (parsed.value != .object) return false;
 
@@ -146,15 +164,6 @@ fn shouldFallbackToResponses(allocator: std.mem.Allocator, body: []const u8) boo
 
     const message = lookupFallbackMessage(parsed.value.object) orelse return false;
     return isResponsesFallbackMessage(message);
-}
-
-fn shouldFallbackChatCompletionsError(
-    allocator: std.mem.Allocator,
-    err: anyerror,
-    body: []const u8,
-) bool {
-    if (err != error.SyntaxError) return false;
-    return shouldFallbackToResponses(allocator, body);
 }
 
 /// How the provider expects the API key to be sent.
@@ -1489,7 +1498,7 @@ pub const OpenAiCompatibleProvider = struct {
 
         return parseTextResponse(allocator, resp_body) catch |err| {
             // Only switch protocols when chat-completions explicitly reports endpoint absence.
-            if (self.supports_responses_fallback and shouldFallbackChatCompletionsError(allocator, err, resp_body)) {
+            if (self.supports_responses_fallback and shouldFallbackToResponses(allocator, resp_body)) {
                 const fallback_messages = try buildSingleTurnMessages(allocator, eff_system, merged_msg orelse message, false);
                 defer freeSingleTurnMessages(allocator, fallback_messages);
                 const fallback_request = ChatRequest{
@@ -1580,7 +1589,7 @@ pub const OpenAiCompatibleProvider = struct {
         defer allocator.free(resp_body);
 
         return parseNativeResponse(allocator, resp_body) catch |err| {
-            if (self.supports_responses_fallback and shouldFallbackChatCompletionsError(allocator, err, resp_body)) {
+            if (self.supports_responses_fallback and shouldFallbackToResponses(allocator, resp_body)) {
                 return self.chatViaResponses(
                     allocator,
                     capped_request,
@@ -2546,23 +2555,29 @@ test "shouldFallbackToResponses accepts msg fallback fields" {
     try std.testing.expect(!shouldFallbackToResponses(std.testing.allocator, "{\"error\":{\"msg\":\"No endpoints found that support image input\",\"code\":404}}"));
 }
 
-test "shouldFallbackChatCompletionsError only accepts syntax 404 endpoint errors" {
-    // Regression: #766 — the normal chatImpl path must fall back to Responses
-    // when chat/completions returns an endpoint-level 404 payload.
-    try std.testing.expect(shouldFallbackChatCompletionsError(
+test "structured chat endpoint 404 payloads surface as ApiError" {
+    // Regression: #766 follow-up — structured endpoint 404s are still generic
+    // API errors, so the fallback must key off the body instead of parser errors.
+    const body = "{\"error\":{\"message\":\"https://integrate.api.nvidia.com/v1/chat/completions 404 page not found\",\"code\":404}}";
+
+    try std.testing.expectError(error.ApiError, OpenAiCompatibleProvider.parseTextResponse(std.testing.allocator, body));
+    try std.testing.expectError(error.ApiError, OpenAiCompatibleProvider.parseNativeResponse(std.testing.allocator, body));
+}
+
+test "shouldFallbackToResponses accepts plain text chat endpoint 404" {
+    // Regression: #766 — some gateways return the missing endpoint as plain
+    // text instead of a JSON error envelope.
+    try std.testing.expect(shouldFallbackToResponses(
         std.testing.allocator,
-        error.SyntaxError,
-        "{\"error\":{\"message\":\"https://integrate.api.nvidia.com/v1/chat/completions 404 page not found\",\"code\":404}}",
+        "https://integrate.api.nvidia.com/v1/chat/completions 404 page not found",
     ));
-    try std.testing.expect(!shouldFallbackChatCompletionsError(
+    try std.testing.expect(!shouldFallbackToResponses(
         std.testing.allocator,
-        error.NoResponseContent,
-        "{\"error\":{\"message\":\"https://integrate.api.nvidia.com/v1/chat/completions 404 page not found\",\"code\":404}}",
+        "https://integrate.api.nvidia.com/v1/responses 404 page not found",
     ));
-    try std.testing.expect(!shouldFallbackChatCompletionsError(
+    try std.testing.expect(!shouldFallbackToResponses(
         std.testing.allocator,
-        error.SyntaxError,
-        "{\"error\":{\"message\":\"temporary overload\",\"code\":503}}",
+        "temporary overload",
     ));
 }
 

--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -148,6 +148,15 @@ fn shouldFallbackToResponses(allocator: std.mem.Allocator, body: []const u8) boo
     return isResponsesFallbackMessage(message);
 }
 
+fn shouldFallbackChatCompletionsError(
+    allocator: std.mem.Allocator,
+    err: anyerror,
+    body: []const u8,
+) bool {
+    if (err != error.SyntaxError) return false;
+    return shouldFallbackToResponses(allocator, body);
+}
+
 /// How the provider expects the API key to be sent.
 pub const AuthStyle = enum {
     /// `Authorization: Bearer <key>`
@@ -1480,7 +1489,7 @@ pub const OpenAiCompatibleProvider = struct {
 
         return parseTextResponse(allocator, resp_body) catch |err| {
             // Only switch protocols when chat-completions explicitly reports endpoint absence.
-            if (self.supports_responses_fallback and shouldFallbackToResponses(allocator, resp_body)) {
+            if (self.supports_responses_fallback and shouldFallbackChatCompletionsError(allocator, err, resp_body)) {
                 const fallback_messages = try buildSingleTurnMessages(allocator, eff_system, merged_msg orelse message, false);
                 defer freeSingleTurnMessages(allocator, fallback_messages);
                 const fallback_request = ChatRequest{
@@ -1571,6 +1580,17 @@ pub const OpenAiCompatibleProvider = struct {
         defer allocator.free(resp_body);
 
         return parseNativeResponse(allocator, resp_body) catch |err| {
+            if (self.supports_responses_fallback and shouldFallbackChatCompletionsError(allocator, err, resp_body)) {
+                return self.chatViaResponses(
+                    allocator,
+                    capped_request,
+                    effective_model,
+                    temperature,
+                    capped_request.timeout_secs,
+                ) catch |fallback_err| {
+                    return returnLoggedCompatibleApiError(ChatResponse, allocator, self.name, fallback_err, url, resp_body);
+                };
+            }
             logCompatibleApiError(allocator, self.name, err, url, resp_body);
             return err;
         };
@@ -2524,6 +2544,26 @@ test "shouldFallbackToResponses accepts msg fallback fields" {
     try std.testing.expect(shouldFallbackToResponses(std.testing.allocator, "{\"error\":{\"msg\":\"Not found\",\"code\":404}}"));
     try std.testing.expect(shouldFallbackToResponses(std.testing.allocator, "{\"status\":404,\"msg\":\"unknown endpoint\"}"));
     try std.testing.expect(!shouldFallbackToResponses(std.testing.allocator, "{\"error\":{\"msg\":\"No endpoints found that support image input\",\"code\":404}}"));
+}
+
+test "shouldFallbackChatCompletionsError only accepts syntax 404 endpoint errors" {
+    // Regression: #766 — the normal chatImpl path must fall back to Responses
+    // when chat/completions returns an endpoint-level 404 payload.
+    try std.testing.expect(shouldFallbackChatCompletionsError(
+        std.testing.allocator,
+        error.SyntaxError,
+        "{\"error\":{\"message\":\"https://integrate.api.nvidia.com/v1/chat/completions 404 page not found\",\"code\":404}}",
+    ));
+    try std.testing.expect(!shouldFallbackChatCompletionsError(
+        std.testing.allocator,
+        error.NoResponseContent,
+        "{\"error\":{\"message\":\"https://integrate.api.nvidia.com/v1/chat/completions 404 page not found\",\"code\":404}}",
+    ));
+    try std.testing.expect(!shouldFallbackChatCompletionsError(
+        std.testing.allocator,
+        error.SyntaxError,
+        "{\"error\":{\"message\":\"temporary overload\",\"code\":503}}",
+    ));
 }
 
 test "returnLoggedCompatibleApiError preserves fallback error" {


### PR DESCRIPTION
Closes #766

## Summary

### EN:
- Fixed a bug where OpenAI-compatible custom providers could still fail with `.../chat/completions 404 page not found` even though NullClaw already knew how to fall back to the Responses API.
- Reused the same endpoint-fallback decision in the normal `chatImpl` path that was already present in `chatWithSystemImpl`.
- Restricted the fallback to explicit chat-endpoint 404 payloads, so unrelated syntax or provider errors still surface normally.
- Added a regression test covering the exact 404 endpoint-mismatch condition reported in this issue.

### ZH:
- 修复了一个问题：对于 OpenAI 兼容的自定义 provider，即使 NullClaw 已经具备回退到 Responses API 的能力，仍然可能因为 `.../chat/completions 404 page not found` 而失败。
- 将 `chatWithSystemImpl` 中已有的端点回退判定逻辑复用到了普通的 `chatImpl` 路径中。
- 这次回退仅限于明确的 chat 端点 404 响应，因此其他无关的语法错误或 provider 错误仍会按原样返回。
- 新增了回归测试，覆盖本 issue 中报告的这类 404 端点不匹配情况。

## Validation
- `zig build test --summary all` — 6450 passed, 13 skipped, 0 failed.
- `zig build -Doptimize=ReleaseSmall` — success.

## Notes
- This change does not alter providers explicitly configured with `api_mode = "responses"`.
- The fallback still requires the error payload to clearly indicate that the chat-completions endpoint is missing.
