### PR TITLE
service: add SysVinit fallback for nullclaw service install

### DIFF
--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -71,9 +71,9 @@ nullclaw gateway
 For long-running deployments:
 
 - macOS uses `launchctl`.
-- Linux uses `systemd --user` when available and falls back to OpenRC on Alpine/OpenRC systems.
+- Linux uses `systemd --user` when available and falls back to OpenRC or SysVinit when the required runtime is present.
 - Windows uses the Service Control Manager.
-- If Linux has neither working `systemd --user` nor the required OpenRC commands, service subcommands fail; use foreground `nullclaw gateway` or another supervisor instead.
+- If Linux has neither working `systemd --user` nor the required OpenRC/SysVinit support, service subcommands fail; use foreground `nullclaw gateway` or another supervisor instead.
 
 ```bash
 nullclaw service install

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -57,9 +57,9 @@ nullclaw gateway
 建议在长期运行场景使用 service 子命令：
 
 - macOS 走 `launchctl`。
-- Linux 环境会优先使用 `systemd --user`，在 Alpine / OpenRC 系统上会自动切换为 OpenRC。
+- Linux 环境会优先使用 `systemd --user`，在检测到 OpenRC 或 SysVinit 运行环境时自动切换到对应实现。
 - Windows 走 Service Control Manager。
-- 如果 Linux 上既没有可用的 `systemd --user`，也缺少必需的 OpenRC 命令，这组子命令会失败；此时应改用前台 `nullclaw gateway` 或其他外部 supervisor。
+- 如果 Linux 上既没有可用的 `systemd --user`，也缺少必需的 OpenRC / SysVinit 支持，这组子命令会失败；此时应改用前台 `nullclaw gateway` 或其他外部 supervisor。
 
 ```bash
 nullclaw service install

--- a/src/main.zig
+++ b/src/main.zig
@@ -444,8 +444,8 @@ fn runService(allocator: std.mem.Allocator, sub_args: []const []const u8) !void 
                 std.debug.print("Verify `rc-service`, `rc-update`, and `openrc-run` are installed.\n", .{});
             },
             error.SystemctlUnavailable => {
-                std.debug.print("`systemctl` is not available; Linux service commands require systemd user services.\n", .{});
-                std.debug.print("Run `nullclaw gateway` in the foreground or use another supervisor.\n", .{});
+                std.debug.print("`systemctl` is not available and no supported Linux fallback service manager was detected.\n", .{});
+                std.debug.print("Install OpenRC or SysVinit support, or run `nullclaw gateway` in the foreground.\n", .{});
             },
             error.SystemdUserUnavailable => {
                 std.debug.print("systemd user services are unavailable (`systemctl --user`).\n", .{});

--- a/src/service.zig
+++ b/src/service.zig
@@ -1,7 +1,7 @@
-//! Service management — launchd (macOS), systemd/OpenRC (Linux), and SCM (Windows).
+//! Service management — launchd (macOS), systemd/OpenRC/SysVinit (Linux), and SCM (Windows).
 //!
 //! Mirrors ZeroClaw's service module: install, start, stop, restart, status, uninstall.
-//! Uses child process execution to interact with launchctl / systemctl / rc-service / sc.exe.
+//! Uses child process execution to interact with launchctl / systemctl / init scripts / sc.exe.
 
 const std = @import("std");
 const std_compat = @import("compat");
@@ -19,7 +19,10 @@ const WINDOWS_SERVICE_NAME = "nullclaw";
 const WINDOWS_SERVICE_DISPLAY_NAME = "nullclaw gateway runtime";
 const OPENRC_SERVICE_NAME = "nullclaw";
 const OPENRC_SERVICE_FILE = "/etc/init.d/nullclaw";
-const SYSVINIT_SERVICE_FILE = "/etc/init.d/nullclaw";
+const SYSVINIT_SERVICE_FILE = OPENRC_SERVICE_FILE;
+const SYSVINIT_SERVICE_DIR = "/etc/init.d";
+const SYSVINIT_PID_FILE = "/var/run/nullclaw.pid";
+const SYSVINIT_LOG_FILE = "/var/log/nullclaw.log";
 pub const WINDOWS_SERVICE_GATEWAY_ARG = "__windows-service-gateway";
 
 const windows = std.os.windows;
@@ -163,7 +166,7 @@ fn startService(allocator: std.mem.Allocator) !void {
                 try runChecked(allocator, &.{ "systemctl", "--user", "start", "nullclaw.service" });
             },
             .openrc => try openRcRunChecked(allocator, &.{ OPENRC_SERVICE_NAME, "start" }),
-            .sysvinit => try runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, "start" }),
+            .sysvinit => try sysvinitRunChecked(allocator, "start"),
         }
     } else if (comptime builtin.os.tag == .windows) {
         try runChecked(allocator, &.{ "sc.exe", "start", WINDOWS_SERVICE_NAME });
@@ -185,7 +188,7 @@ fn stopService(allocator: std.mem.Allocator) !void {
                 try runChecked(allocator, &.{ "systemctl", "--user", "stop", "nullclaw.service" });
             },
             .openrc => try openRcRunChecked(allocator, &.{ OPENRC_SERVICE_NAME, "stop" }),
-            .sysvinit => runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, "stop" }) catch {},
+            .sysvinit => try sysvinitRunChecked(allocator, "stop"),
         }
     } else if (comptime builtin.os.tag == .windows) {
         try runChecked(allocator, &.{ "sc.exe", "stop", WINDOWS_SERVICE_NAME });
@@ -199,7 +202,7 @@ fn restartService(allocator: std.mem.Allocator) !void {
     if (comptime builtin.os.tag == .linux) {
         if (detectLinuxServiceManager(allocator) catch null) |mgr| {
             if (mgr == .sysvinit) {
-                try runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, "restart" });
+                try sysvinitRunChecked(allocator, "restart");
                 return;
             }
         }
@@ -302,11 +305,12 @@ fn serviceStatus(allocator: std.mem.Allocator) !void {
                     try w.flush();
                     return;
                 }
-                const status = try runCaptureStatus(allocator, &.{ SYSVINIT_SERVICE_FILE, "status" });
+                const status = try sysvinitRunCaptureStatus(allocator, "status");
                 defer allocator.free(status.stdout);
                 defer allocator.free(status.stderr);
-                const out_trimmed = std.mem.trim(u8, status.stdout, " \t\n\r");
-                try w.print("Service state: {s}\n", .{if (out_trimmed.len > 0) out_trimmed else "unknown"});
+                const detail = captureStatusDetail(&status);
+                if (!status.success and !isSysvinitInactiveDetail(detail)) return error.CommandFailed;
+                try w.print("Service state: {s}\n", .{sysvinitServiceState(detail)});
                 try w.print("Script: {s}\n", .{SYSVINIT_SERVICE_FILE});
                 try w.flush();
             },
@@ -545,70 +549,49 @@ fn installLinuxOpenRc(allocator: std.mem.Allocator) !void {
 }
 
 fn installLinuxSysvinit(allocator: std.mem.Allocator) !void {
-    var exe_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const exe_path = try std.fs.selfExePath(&exe_buf);
+    const start_stop_daemon_path = getSysvinitStartStopDaemonPath() orelse return error.CommandFailed;
+
+    var exe_buf: [std_compat.fs.max_path_bytes]u8 = undefined;
+    const exe_path = try std_compat.fs.selfExePath(&exe_buf);
     const service_exe_path = try resolveServiceExecutablePath(allocator, exe_path);
     defer allocator.free(service_exe_path);
 
-    const script = try std.fmt.allocPrint(allocator,
-        \\#!/bin/sh
-        \\### BEGIN INIT INFO
-        \\# Provides:          nullclaw
-        \\# Required-Start:    $network $remote_fs
-        \\# Required-Stop:     $network $remote_fs
-        \\# Default-Start:     2 3 4 5
-        \\# Default-Stop:      0 1 6
-        \\# Description:       NullClaw AI assistant gateway
-        \\### END INIT INFO
-        \\
-        \\DAEMON="{s}"
-        \\PIDFILE=/var/run/nullclaw.pid
-        \\LOGFILE=/var/log/nullclaw.log
-        \\
-        \\case "$1" in
-        \\  start)
-        \\    echo "Starting nullclaw..."
-        \\    start-stop-daemon --start --background --make-pidfile --pidfile $PIDFILE \
-        \\      --startas /bin/sh -- -c "exec $DAEMON gateway >> $LOGFILE 2>&1"
-        \\    ;;
-        \\  stop)
-        \\    echo "Stopping nullclaw..."
-        \\    start-stop-daemon --stop --pidfile $PIDFILE --retry 5
-        \\    rm -f $PIDFILE
-        \\    ;;
-        \\  restart)
-        \\    $0 stop
-        \\    sleep 1
-        \\    $0 start
-        \\    ;;
-        \\  status)
-        \\    if [ -f $PIDFILE ] && kill -0 $(cat $PIDFILE) 2>/dev/null; then
-        \\      echo "nullclaw is running (PID $(cat $PIDFILE))"
-        \\    else
-        \\      echo "nullclaw is not running"
-        \\    fi
-        \\    ;;
-        \\  *)
-        \\    echo "Usage: $0 {{start|stop|restart|status}}"
-        \\    exit 1
-        \\    ;;
-        \\esac
-    , .{service_exe_path});
+    const service_user = getServiceUser(allocator);
+    defer if (service_user) |user| allocator.free(user);
+
+    const service_home = try getServiceHomeDir(allocator);
+    defer allocator.free(service_home);
+
+    const config_dir = try std_compat.fs.path.join(allocator, &.{ service_home, ".nullclaw" });
+    defer allocator.free(config_dir);
+
+    const script = try buildSysvinitScript(allocator, .{
+        .start_stop_daemon_path = start_stop_daemon_path,
+        .service_exe_path = service_exe_path,
+        .service_user = service_user,
+        .service_home = service_home,
+        .config_dir = config_dir,
+    });
     defer allocator.free(script);
 
-    const file = try std.fs.createFileAbsolute(SYSVINIT_SERVICE_FILE, .{});
+    const file = try std_compat.fs.createFileAbsolute(SYSVINIT_SERVICE_FILE, .{});
     defer file.close();
     try file.writeAll(script);
     try file.chmod(0o755);
 
-    // Enable at boot via update-rc.d if available.
-    runChecked(allocator, &.{ "update-rc.d", "nullclaw", "defaults" }) catch {};
+    sysvinitUpdateChecked(allocator, &.{ "nullclaw", "defaults" }) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
 }
 
 fn uninstallSysvinit(allocator: std.mem.Allocator) !void {
-    runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, "stop" }) catch {};
-    runChecked(allocator, &.{ "update-rc.d", "-f", "nullclaw", "remove" }) catch {};
-    std.fs.deleteFileAbsolute(SYSVINIT_SERVICE_FILE) catch |err| switch (err) {
+    sysvinitRunChecked(allocator, "stop") catch {};
+    sysvinitUpdateChecked(allocator, &.{ "-f", "nullclaw", "remove" }) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+    std_compat.fs.deleteFileAbsolute(SYSVINIT_SERVICE_FILE) catch |err| switch (err) {
         error.FileNotFound => {},
         else => return err,
     };
@@ -753,6 +736,14 @@ const OpenRcScriptConfig = struct {
     config_dir: []const u8,
 };
 
+const SysvinitScriptConfig = struct {
+    start_stop_daemon_path: []const u8,
+    service_exe_path: []const u8,
+    service_user: ?[]const u8,
+    service_home: []const u8,
+    config_dir: []const u8,
+};
+
 fn captureStatusDetail(status: *const CaptureStatus) []const u8 {
     const stderr_trimmed = std.mem.trim(u8, status.stderr, " \t\r\n");
     if (stderr_trimmed.len > 0) return stderr_trimmed;
@@ -795,6 +786,20 @@ const openrc_run_candidates = [_][]const u8{
     "/usr/bin/openrc-run",
 };
 
+const sysvinit_start_stop_daemon_candidates = [_][]const u8{
+    "/sbin/start-stop-daemon",
+    "/usr/sbin/start-stop-daemon",
+    "/bin/start-stop-daemon",
+    "/usr/bin/start-stop-daemon",
+};
+
+const sysvinit_update_candidates = [_][]const u8{
+    "/sbin/update-rc.d",
+    "/usr/sbin/update-rc.d",
+    "/bin/update-rc.d",
+    "/usr/bin/update-rc.d",
+};
+
 fn hasAnyMatchingPath(candidate_paths: []const []const u8, existing_paths: []const []const u8) bool {
     for (candidate_paths) |candidate| {
         for (existing_paths) |path| {
@@ -811,6 +816,10 @@ fn hasOpenRcMarkerInPaths(existing_paths: []const []const u8) bool {
 fn hasOpenRcCommandInPaths(existing_paths: []const []const u8) bool {
     return hasAnyMatchingPath(&openrc_command_candidates, existing_paths) and
         hasAnyMatchingPath(&openrc_run_candidates, existing_paths);
+}
+
+fn hasSysvinitCommandInPaths(existing_paths: []const []const u8) bool {
+    return hasAnyMatchingPath(&sysvinit_start_stop_daemon_candidates, existing_paths);
 }
 
 fn firstExistingAbsolutePath(paths: []const []const u8) ?[]const u8 {
@@ -836,6 +845,14 @@ fn getOpenRcRunPath() ?[]const u8 {
     return firstExistingAbsolutePath(&openrc_run_candidates);
 }
 
+fn getSysvinitStartStopDaemonPath() ?[]const u8 {
+    return firstExistingAbsolutePath(&sysvinit_start_stop_daemon_candidates);
+}
+
+fn getSysvinitUpdatePath() ?[]const u8 {
+    return firstExistingAbsolutePath(&sysvinit_update_candidates);
+}
+
 fn linuxHasOpenRcRuntime() bool {
     return hasAnyExistingAbsolutePath(&openrc_markers);
 }
@@ -853,7 +870,7 @@ fn detectLinuxServiceManager(allocator: std.mem.Allocator) !LinuxServiceManager 
     }
 
     assertLinuxSystemdUserAvailable(allocator) catch |err| switch (err) {
-        error.SystemctlUnavailable, error.SystemdUserUnavailable, error.FileNotFound => {
+        error.SystemctlUnavailable, error.SystemdUserUnavailable => {
             if (linuxHasOpenRcSupport()) return .openrc;
             if (linuxHasSysvinitSupport()) return .sysvinit;
             return err;
@@ -866,13 +883,7 @@ fn detectLinuxServiceManager(allocator: std.mem.Allocator) !LinuxServiceManager 
 
 /// SysVinit fallback: check for /etc/init.d/ and start-stop-daemon.
 fn linuxHasSysvinitSupport() bool {
-    std.fs.accessAbsolute("/etc/init.d", .{}) catch return false;
-    // start-stop-daemon is the portable SysVinit process manager.
-    for ([_][]const u8{ "/sbin/start-stop-daemon", "/usr/sbin/start-stop-daemon" }) |path| {
-        std.fs.accessAbsolute(path, .{}) catch continue;
-        return true;
-    }
-    return false;
+    return fileExistsAbsolute(SYSVINIT_SERVICE_DIR) and getSysvinitStartStopDaemonPath() != null;
 }
 
 fn shellDoubleQuoted(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
@@ -926,6 +937,107 @@ fn buildOpenRcScript(allocator: std.mem.Allocator, cfg: OpenRcScriptConfig) ![]u
     , .{ cfg.openrc_run_path, exe_quoted, home_quoted, home_quoted, config_quoted, user_line });
 }
 
+fn buildSysvinitScript(allocator: std.mem.Allocator, cfg: SysvinitScriptConfig) ![]u8 {
+    const start_stop_daemon_quoted = try shellDoubleQuoted(allocator, cfg.start_stop_daemon_path);
+    defer allocator.free(start_stop_daemon_quoted);
+    const daemon_quoted = try shellDoubleQuoted(allocator, cfg.service_exe_path);
+    defer allocator.free(daemon_quoted);
+    const home_quoted = try shellDoubleQuoted(allocator, cfg.service_home);
+    defer allocator.free(home_quoted);
+    const config_quoted = try shellDoubleQuoted(allocator, cfg.config_dir);
+    defer allocator.free(config_quoted);
+    const pidfile_quoted = try shellDoubleQuoted(allocator, SYSVINIT_PID_FILE);
+    defer allocator.free(pidfile_quoted);
+    const logfile_quoted = try shellDoubleQuoted(allocator, SYSVINIT_LOG_FILE);
+    defer allocator.free(logfile_quoted);
+
+    const user_line = if (cfg.service_user) |service_user| blk: {
+        const user_quoted = try shellDoubleQuoted(allocator, service_user);
+        defer allocator.free(user_quoted);
+        break :blk try std.fmt.allocPrint(allocator, "    export USER={s}\n", .{user_quoted});
+    } else try allocator.dupe(u8, "");
+    defer allocator.free(user_line);
+
+    const chuid_args = if (cfg.service_user) |service_user| blk: {
+        const user_quoted = try shellDoubleQuoted(allocator, service_user);
+        defer allocator.free(user_quoted);
+        break :blk try std.fmt.allocPrint(allocator, " --chuid {s}", .{user_quoted});
+    } else try allocator.dupe(u8, "");
+    defer allocator.free(chuid_args);
+
+    return std.fmt.allocPrint(allocator,
+        \\#!/bin/sh
+        \\### BEGIN INIT INFO
+        \\# Provides:          nullclaw
+        \\# Required-Start:    $network $remote_fs
+        \\# Required-Stop:     $network $remote_fs
+        \\# Default-Start:     2 3 4 5
+        \\# Default-Stop:      0 1 6
+        \\# Description:       nullclaw gateway runtime
+        \\### END INIT INFO
+        \\
+        \\set -e
+        \\
+        \\DAEMON={s}
+        \\SERVICE_HOME={s}
+        \\NULLCLAW_HOME={s}
+        \\PIDFILE={s}
+        \\LOGFILE={s}
+        \\
+        \\case "$1" in
+        \\  start)
+        \\    echo "Starting nullclaw..."
+        \\    export HOME="$SERVICE_HOME"
+        \\    export NULLCLAW_HOME="$NULLCLAW_HOME"
+        \\{s}
+        \\    {s} --start --background --make-pidfile --pidfile "$PIDFILE"{s} --chdir "$SERVICE_HOME" --startas /bin/sh -- -c "exec \\"$DAEMON\\" gateway >> \\"$LOGFILE\\" 2>&1"
+        \\    ;;
+        \\  stop)
+        \\    echo "Stopping nullclaw..."
+        \\    if {s} --stop --pidfile "$PIDFILE" --retry 5; then
+        \\      rm -f "$PIDFILE"
+        \\    else
+        \\      status=$?
+        \\      if [ "$status" -eq 1 ]; then
+        \\        echo "nullclaw is not running"
+        \\        exit 0
+        \\      fi
+        \\      exit "$status"
+        \\    fi
+        \\    ;;
+        \\  restart)
+        \\    "$0" stop
+        \\    sleep 1
+        \\    "$0" start
+        \\    ;;
+        \\  status)
+        \\    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+        \\      echo "nullclaw is running (PID $(cat "$PIDFILE"))"
+        \\      exit 0
+        \\    fi
+        \\    echo "nullclaw is not running"
+        \\    exit 3
+        \\    ;;
+        \\  *)
+        \\    echo "Usage: $0 {{start|stop|restart|status}}"
+        \\    exit 1
+        \\    ;;
+        \\esac
+        \\
+        \\exit 0
+    , .{
+        daemon_quoted,
+        home_quoted,
+        config_quoted,
+        pidfile_quoted,
+        logfile_quoted,
+        user_line,
+        start_stop_daemon_quoted,
+        chuid_args,
+        start_stop_daemon_quoted,
+    });
+}
+
 fn isSystemdUnitNotLoadedDetail(detail: []const u8) bool {
     return std.ascii.indexOfIgnoreCase(detail, "unit nullclaw.service not loaded") != null or
         std.ascii.indexOfIgnoreCase(detail, "could not be found") != null or
@@ -953,6 +1065,22 @@ fn openRcServiceState(detail: []const u8) []const u8 {
     if (std.ascii.indexOfIgnoreCase(detail, "crashed") != null) return "crashed";
     if (isOpenRcInactiveDetail(detail)) return "stopped";
     if (isOpenRcServiceMissingDetail(detail)) return "not installed";
+    return "unknown";
+}
+
+fn isSysvinitInactiveDetail(detail: []const u8) bool {
+    return std.ascii.indexOfIgnoreCase(detail, "not running") != null or
+        std.ascii.indexOfIgnoreCase(detail, "no process in pidfile") != null or
+        std.ascii.indexOfIgnoreCase(detail, "not started") != null;
+}
+
+fn sysvinitServiceState(detail: []const u8) []const u8 {
+    if (std.ascii.indexOfIgnoreCase(detail, "is running") != null or
+        std.ascii.indexOfIgnoreCase(detail, "running (pid") != null)
+    {
+        return "running";
+    }
+    if (isSysvinitInactiveDetail(detail)) return "stopped";
     return "unknown";
 }
 
@@ -1057,6 +1185,29 @@ fn openRcUpdateChecked(allocator: std.mem.Allocator, argv: []const []const u8) !
     var full: std.ArrayListUnmanaged([]const u8) = .empty;
     defer full.deinit(allocator);
     try full.append(allocator, rc_update);
+    try full.appendSlice(allocator, argv);
+    try runChecked(allocator, full.items);
+}
+
+fn sysvinitRunChecked(allocator: std.mem.Allocator, action: []const u8) !void {
+    runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, action }) catch |err| switch (err) {
+        error.FileNotFound => return error.CommandFailed,
+        else => return err,
+    };
+}
+
+fn sysvinitRunCaptureStatus(allocator: std.mem.Allocator, action: []const u8) !CaptureStatus {
+    return runCaptureStatus(allocator, &.{ SYSVINIT_SERVICE_FILE, action }) catch |err| switch (err) {
+        error.FileNotFound => return error.CommandFailed,
+        else => return err,
+    };
+}
+
+fn sysvinitUpdateChecked(allocator: std.mem.Allocator, argv: []const []const u8) !void {
+    const update_rc = getSysvinitUpdatePath() orelse return error.FileNotFound;
+    var full: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer full.deinit(allocator);
+    try full.append(allocator, update_rc);
     try full.appendSlice(allocator, argv);
     try runChecked(allocator, full.items);
 }
@@ -1317,6 +1468,11 @@ test "hasOpenRcCommandInPaths detects required OpenRC commands" {
     try std.testing.expect(!hasOpenRcCommandInPaths(&.{"/sbin/rc-service"}));
 }
 
+test "hasSysvinitCommandInPaths detects start-stop-daemon" {
+    try std.testing.expect(hasSysvinitCommandInPaths(&.{"/usr/sbin/start-stop-daemon"}));
+    try std.testing.expect(!hasSysvinitCommandInPaths(&.{"/usr/sbin/update-rc.d"}));
+}
+
 test "hasAnyExistingAbsolutePath checks actual filesystem state" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1358,11 +1514,37 @@ test "buildOpenRcScript includes user and config env" {
     try std.testing.expect(std.mem.indexOf(u8, script, "export NULLCLAW_HOME=\"/home/alice/.nullclaw\"") != null);
 }
 
+test "buildSysvinitScript includes user and config env" {
+    const script = try buildSysvinitScript(std.testing.allocator, .{
+        .start_stop_daemon_path = "/usr/sbin/start-stop-daemon",
+        .service_exe_path = "/usr/local/bin/nullclaw",
+        .service_user = "alice",
+        .service_home = "/home/alice",
+        .config_dir = "/home/alice/.nullclaw",
+    });
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(std.mem.indexOf(u8, script, "DAEMON=\"/usr/local/bin/nullclaw\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "NULLCLAW_HOME=\"/home/alice/.nullclaw\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "export USER=\"alice\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "\"/usr/sbin/start-stop-daemon\" --start") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "--chuid \"alice\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "--startas /bin/sh -- -c") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "$DAEMON") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "$LOGFILE") != null);
+}
+
 test "openRcServiceState classifies common states" {
     try std.testing.expectEqualStrings("running", openRcServiceState("status: started"));
     try std.testing.expectEqualStrings("stopped", openRcServiceState("status: stopped"));
     try std.testing.expectEqualStrings("crashed", openRcServiceState("status: crashed"));
     try std.testing.expectEqualStrings("not installed", openRcServiceState("service `nullclaw' does not exist"));
+}
+
+test "sysvinitServiceState classifies common states" {
+    try std.testing.expectEqualStrings("running", sysvinitServiceState("nullclaw is running (PID 42)"));
+    try std.testing.expectEqualStrings("stopped", sysvinitServiceState("nullclaw is not running"));
+    try std.testing.expectEqualStrings("unknown", sysvinitServiceState("unexpected output"));
 }
 
 test "isSystemdUnitNotLoadedDetail detects stop-not-loaded patterns" {

--- a/src/service.zig
+++ b/src/service.zig
@@ -18,6 +18,7 @@ const WINDOWS_SERVICE_NAME = "nullclaw";
 const WINDOWS_SERVICE_DISPLAY_NAME = "nullclaw gateway runtime";
 const OPENRC_SERVICE_NAME = "nullclaw";
 const OPENRC_SERVICE_FILE = "/etc/init.d/nullclaw";
+const SYSVINIT_SERVICE_FILE = "/etc/init.d/nullclaw";
 pub const WINDOWS_SERVICE_GATEWAY_ARG = "__windows-service-gateway";
 
 const windows = std.os.windows;
@@ -91,6 +92,7 @@ pub const ServiceError = error{
 const LinuxServiceManager = enum {
     systemd_user,
     openrc,
+    sysvinit,
 };
 
 pub fn isWindowsServiceGatewayArg(arg: []const u8) bool {
@@ -160,6 +162,7 @@ fn startService(allocator: std.mem.Allocator) !void {
                 try runChecked(allocator, &.{ "systemctl", "--user", "start", "nullclaw.service" });
             },
             .openrc => try openRcRunChecked(allocator, &.{ OPENRC_SERVICE_NAME, "start" }),
+            .sysvinit => try runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, "start" }),
         }
     } else if (comptime builtin.os.tag == .windows) {
         try runChecked(allocator, &.{ "sc.exe", "start", WINDOWS_SERVICE_NAME });
@@ -181,6 +184,7 @@ fn stopService(allocator: std.mem.Allocator) !void {
                 try runChecked(allocator, &.{ "systemctl", "--user", "stop", "nullclaw.service" });
             },
             .openrc => try openRcRunChecked(allocator, &.{ OPENRC_SERVICE_NAME, "stop" }),
+            .sysvinit => runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, "stop" }) catch {},
         }
     } else if (comptime builtin.os.tag == .windows) {
         try runChecked(allocator, &.{ "sc.exe", "stop", WINDOWS_SERVICE_NAME });
@@ -190,6 +194,15 @@ fn stopService(allocator: std.mem.Allocator) !void {
 }
 
 fn restartService(allocator: std.mem.Allocator) !void {
+    // SysVinit: delegate to the init script's own restart (includes sleep).
+    if (comptime builtin.os.tag == .linux) {
+        if (detectLinuxServiceManager(allocator) catch null) |mgr| {
+            if (mgr == .sysvinit) {
+                try runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, "restart" });
+                return;
+            }
+        }
+    }
     // Restart should still proceed when stop reports "already stopped"/"not loaded",
     // but should not mask unrelated stop failures.
     try stopServiceForRestart(allocator);
@@ -225,6 +238,7 @@ fn stopServiceForRestart(allocator: std.mem.Allocator) !void {
                 if (isOpenRcServiceMissingDetail(detail) or isOpenRcInactiveDetail(detail)) return;
                 return error.CommandFailed;
             },
+            .sysvinit => unreachable, // restartService delegates to init script directly
         }
     } else if (comptime builtin.os.tag == .windows) {
         const status = try runCaptureStatus(allocator, &.{ "sc.exe", "stop", WINDOWS_SERVICE_NAME });
@@ -280,6 +294,21 @@ fn serviceStatus(allocator: std.mem.Allocator) !void {
                 try w.print("Script: {s}\n", .{OPENRC_SERVICE_FILE});
                 try w.flush();
             },
+            .sysvinit => {
+                if (!fileExistsAbsolute(SYSVINIT_SERVICE_FILE)) {
+                    try w.print("Service: not installed\n", .{});
+                    try w.print("Script: {s}\n", .{SYSVINIT_SERVICE_FILE});
+                    try w.flush();
+                    return;
+                }
+                const status = try runCaptureStatus(allocator, &.{ SYSVINIT_SERVICE_FILE, "status" });
+                defer allocator.free(status.stdout);
+                defer allocator.free(status.stderr);
+                const out_trimmed = std.mem.trim(u8, status.stdout, " \t\n\r");
+                try w.print("Service state: {s}\n", .{if (out_trimmed.len > 0) out_trimmed else "unknown"});
+                try w.print("Script: {s}\n", .{SYSVINIT_SERVICE_FILE});
+                try w.flush();
+            },
         }
     } else if (comptime builtin.os.tag == .windows) {
         const status = try runCaptureStatus(allocator, &.{ "sc.exe", "query", WINDOWS_SERVICE_NAME });
@@ -323,6 +352,7 @@ fn uninstall(allocator: std.mem.Allocator) !void {
                 try runChecked(allocator, &.{ "systemctl", "--user", "daemon-reload" });
             },
             .openrc => try uninstallOpenRc(allocator),
+            .sysvinit => try uninstallSysvinit(allocator),
         }
     } else if (comptime builtin.os.tag == .windows) {
         try uninstallWindows(allocator);
@@ -430,6 +460,7 @@ fn installLinux(allocator: std.mem.Allocator) !void {
     switch (try detectLinuxServiceManager(allocator)) {
         .systemd_user => try installLinuxSystemd(allocator),
         .openrc => try installLinuxOpenRc(allocator),
+        .sysvinit => try installLinuxSysvinit(allocator),
     }
 }
 
@@ -510,6 +541,76 @@ fn installLinuxOpenRc(allocator: std.mem.Allocator) !void {
     try file.chmod(0o755);
 
     try openRcUpdateChecked(allocator, &.{ "add", OPENRC_SERVICE_NAME, "default" });
+}
+
+fn installLinuxSysvinit(allocator: std.mem.Allocator) !void {
+    var exe_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const exe_path = try std.fs.selfExePath(&exe_buf);
+    const service_exe_path = try resolveServiceExecutablePath(allocator, exe_path);
+    defer allocator.free(service_exe_path);
+
+    const script = try std.fmt.allocPrint(allocator,
+        \\#!/bin/sh
+        \\### BEGIN INIT INFO
+        \\# Provides:          nullclaw
+        \\# Required-Start:    $network $remote_fs
+        \\# Required-Stop:     $network $remote_fs
+        \\# Default-Start:     2 3 4 5
+        \\# Default-Stop:      0 1 6
+        \\# Description:       NullClaw AI assistant gateway
+        \\### END INIT INFO
+        \\
+        \\DAEMON="{s}"
+        \\PIDFILE=/var/run/nullclaw.pid
+        \\LOGFILE=/var/log/nullclaw.log
+        \\
+        \\case "$1" in
+        \\  start)
+        \\    echo "Starting nullclaw..."
+        \\    start-stop-daemon --start --background --make-pidfile --pidfile $PIDFILE \
+        \\      --startas /bin/sh -- -c "exec $DAEMON gateway >> $LOGFILE 2>&1"
+        \\    ;;
+        \\  stop)
+        \\    echo "Stopping nullclaw..."
+        \\    start-stop-daemon --stop --pidfile $PIDFILE --retry 5
+        \\    rm -f $PIDFILE
+        \\    ;;
+        \\  restart)
+        \\    $0 stop
+        \\    sleep 1
+        \\    $0 start
+        \\    ;;
+        \\  status)
+        \\    if [ -f $PIDFILE ] && kill -0 $(cat $PIDFILE) 2>/dev/null; then
+        \\      echo "nullclaw is running (PID $(cat $PIDFILE))"
+        \\    else
+        \\      echo "nullclaw is not running"
+        \\    fi
+        \\    ;;
+        \\  *)
+        \\    echo "Usage: $0 {{start|stop|restart|status}}"
+        \\    exit 1
+        \\    ;;
+        \\esac
+    , .{service_exe_path});
+    defer allocator.free(script);
+
+    const file = try std.fs.createFileAbsolute(SYSVINIT_SERVICE_FILE, .{});
+    defer file.close();
+    try file.writeAll(script);
+    try file.chmod(0o755);
+
+    // Enable at boot via update-rc.d if available.
+    runChecked(allocator, &.{ "update-rc.d", "nullclaw", "defaults" }) catch {};
+}
+
+fn uninstallSysvinit(allocator: std.mem.Allocator) !void {
+    runChecked(allocator, &.{ SYSVINIT_SERVICE_FILE, "stop" }) catch {};
+    runChecked(allocator, &.{ "update-rc.d", "-f", "nullclaw", "remove" }) catch {};
+    std.fs.deleteFileAbsolute(SYSVINIT_SERVICE_FILE) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
 }
 
 fn installWindows(allocator: std.mem.Allocator) !void {
@@ -751,14 +852,26 @@ fn detectLinuxServiceManager(allocator: std.mem.Allocator) !LinuxServiceManager 
     }
 
     assertLinuxSystemdUserAvailable(allocator) catch |err| switch (err) {
-        error.SystemctlUnavailable, error.SystemdUserUnavailable => {
+        error.SystemctlUnavailable, error.SystemdUserUnavailable, error.FileNotFound => {
             if (linuxHasOpenRcSupport()) return .openrc;
+            if (linuxHasSysvinitSupport()) return .sysvinit;
             return err;
         },
         else => return err,
     };
 
     return .systemd_user;
+}
+
+/// SysVinit fallback: check for /etc/init.d/ and start-stop-daemon.
+fn linuxHasSysvinitSupport() bool {
+    std.fs.accessAbsolute("/etc/init.d", .{}) catch return false;
+    // start-stop-daemon is the portable SysVinit process manager.
+    for ([_][]const u8{ "/sbin/start-stop-daemon", "/usr/sbin/start-stop-daemon" }) |path| {
+        std.fs.accessAbsolute(path, .{}) catch continue;
+        return true;
+    }
+    return false;
 }
 
 fn shellDoubleQuoted(allocator: std.mem.Allocator, input: []const u8) ![]u8 {


### PR DESCRIPTION
## Summary

Adds SysVinit as a third Linux service manager fallback when neither systemd nor OpenRC is available.

## Changes

- Add `sysvinit` variant to `LinuxServiceManager` enum
- Detect SysVinit by checking for `/etc/init.d/` + `start-stop-daemon`
- Generate LSB-compliant init script via `installLinuxSysvinit()`
- Handle all service lifecycle commands: install, start, stop, restart, status, uninstall
- Catch `error.FileNotFound` when `systemctl` binary is missing (previously aborted instead of falling through)
- Register/deregister via `update-rc.d` when available

## Motivation

Devices running Debian without systemd or OpenRC (e.g. stripped-down Debian Bookworm on Kirkwood/Pogoplug ARM boards) had no way to use `nullclaw service install`. The only option was manually writing an init script.

## Testing

Tested on Pogoplug V4 (ARMv5TE, Debian Bookworm, SysVinit):
- `nullclaw service install` — generates `/etc/init.d/nullclaw`, registers with `update-rc.d`
- `nullclaw service start` / `stop` / `restart` / `status` — all working
- `nullclaw service uninstall` — removes script and boot registration
- No changes to systemd, OpenRC, macOS, or Windows paths