### PR TITLE
fix(agent): stabilize named-agent provider lifetimes | 修复(agent): 稳定命名子代理提供方生命周期

### DIFF
--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -40,15 +40,11 @@ const CliStreamCtx = struct {
 };
 
 const CliProviderContext = struct {
-    provider: Provider,
-    holder: ?providers.ProviderHolder = null,
+    holder: providers.ProviderHolder,
     owned_api_key: ?[]u8 = null,
 
     fn deinit(self: *CliProviderContext, allocator: std.mem.Allocator) void {
-        if (self.holder) |*holder| {
-            holder.deinit();
-            self.holder = null;
-        }
+        self.holder.deinit();
         if (self.owned_api_key) |api_key| {
             allocator.free(api_key);
             self.owned_api_key = null;
@@ -240,7 +236,7 @@ fn resolveProfileProvider(
         break :blk owned_api_key;
     };
 
-    var holder = providers.ProviderHolder.fromConfigWithApiMode(
+    const holder = providers.ProviderHolder.fromConfigWithApiMode(
         allocator,
         profile.provider,
         provider_api_key,
@@ -253,7 +249,6 @@ fn resolveProfileProvider(
         cfg.getProviderExtraBodyParams(profile.provider),
     );
     return .{
-        .provider = holder.provider(),
         .holder = holder,
         .owned_api_key = owned_api_key,
     };
@@ -466,7 +461,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         tools_mod.bindMemoryRuntime(tools, rt);
     }
 
-    const provider_i: Provider = if (provider_ctx) |ctx| ctx.provider else runtime_provider.?.provider();
+    const provider_i: Provider = if (provider_ctx) |*ctx| ctx.holder.provider() else runtime_provider.?.provider();
 
     const supports_streaming = provider_i.supportsStreaming();
 
@@ -913,6 +908,33 @@ test "parseAgentArgs parses provider and model overrides" {
     try std.testing.expectEqualStrings("ollama", parsed.provider_override.?);
     try std.testing.expectEqualStrings("llama3.2:latest", parsed.model_override.?);
     try std.testing.expectApproxEqAbs(@as(f64, 0.25), parsed.temperature_override.?, 0.000001);
+}
+
+test "resolveProfileProvider returns provider from returned holder storage" {
+    var cfg = Config{
+        .allocator = std.testing.allocator,
+        .workspace_dir = "/tmp/nullclaw-cli-test",
+        .config_path = "/tmp/nullclaw-cli-test/config.json",
+        .providers = &.{
+            .{
+                .name = "custom:dmr",
+                .base_url = "http://127.0.0.1:8080/v1",
+            },
+        },
+    };
+    const profile = config_types.NamedAgentConfig{
+        .name = "sub",
+        .provider = "custom:dmr",
+        .model = "smollm2",
+        .api_key = "placeholder",
+    };
+
+    var ctx = try resolveProfileProvider(std.testing.allocator, &cfg, profile);
+    defer ctx.deinit(std.testing.allocator);
+
+    const provider = ctx.holder.provider();
+    try std.testing.expect(@intFromPtr(provider.ptr) != 0);
+    try std.testing.expect(@intFromPtr(provider.vtable) != 0);
 }
 
 test "shouldPrintTurnResponse prints fallback when streaming emits no text" {

--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -265,6 +265,14 @@ fn resolveProfileProvider(
     };
 }
 
+/// Resolve the provider only after any holder-backed override reaches stable storage.
+fn activeCliProvider(
+    provider_ctx: ?*CliProviderContext,
+    runtime_provider: ?*providers.runtime_bundle.RuntimeProviderBundle,
+) Provider {
+    return if (provider_ctx) |ctx| ctx.holder.provider() else runtime_provider.?.provider();
+}
+
 /// Run the agent in single-message or interactive REPL mode.
 /// This is the main entry point called by `nullclaw agent`.
 pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
@@ -472,7 +480,10 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         tools_mod.bindMemoryRuntime(tools, rt);
     }
 
-    const provider_i: Provider = if (provider_ctx) |*ctx| ctx.holder.provider() else runtime_provider.?.provider();
+    const provider_i = activeCliProvider(
+        if (provider_ctx) |*ctx| ctx else null,
+        if (runtime_provider) |*bundle| bundle else null,
+    );
 
     const supports_streaming = provider_i.supportsStreaming();
 
@@ -932,7 +943,7 @@ test "parseAgentArgs parses provider and model overrides" {
     try std.testing.expectApproxEqAbs(@as(f64, 0.25), parsed.temperature_override.?, 0.000001);
 }
 
-test "resolveProfileProvider returns provider from returned holder storage" {
+test "activeCliProvider uses returned holder storage for named agents" {
     var cfg = Config{
         .allocator = std.testing.allocator,
         .workspace_dir = "/tmp/nullclaw-cli-test",
@@ -951,12 +962,21 @@ test "resolveProfileProvider returns provider from returned holder storage" {
         .api_key = "placeholder",
     };
 
-    var ctx = try resolveProfileProvider(std.testing.allocator, &cfg, profile);
-    defer ctx.deinit(std.testing.allocator);
+    // Regression: issue #811 requires the runtime Provider to be derived from
+    // the returned holder storage, not from resolveProfileProvider's stack frame.
+    var provider_ctx = try resolveProfileProvider(std.testing.allocator, &cfg, profile);
+    defer provider_ctx.deinit(std.testing.allocator);
 
-    const provider = ctx.holder.provider();
-    try std.testing.expect(@intFromPtr(provider.ptr) != 0);
-    try std.testing.expect(@intFromPtr(provider.vtable) != 0);
+    const provider = activeCliProvider(&provider_ctx, null);
+    const holder_provider = provider_ctx.holder.provider();
+    try std.testing.expectEqual(@intFromPtr(holder_provider.ptr), @intFromPtr(provider.ptr));
+    try std.testing.expectEqual(@intFromPtr(holder_provider.vtable), @intFromPtr(provider.vtable));
+    switch (provider_ctx.holder) {
+        .compatible => |*compatible_provider| {
+            try std.testing.expectEqual(@intFromPtr(compatible_provider), @intFromPtr(provider.ptr));
+        },
+        else => unreachable,
+    }
 }
 
 test "shouldPrintTurnResponse prints fallback when streaming emits no text" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -142,7 +142,7 @@ fn findProfileForSessionKey(config: *const Config, session_key: []const u8) ?con
 }
 
 const SessionProviderContext = struct {
-    provider: Provider,
+    provider: ?Provider = null,
     holder: ?providers.ProviderHolder = null,
     owned_api_key: ?[]u8 = null,
 
@@ -1340,7 +1340,7 @@ pub const SessionManager = struct {
         const session_provider = if (session.provider_holder) |*holder|
             holder.provider()
         else
-            provider_ctx.provider;
+            provider_ctx.provider.?;
 
         var agent = try Agent.fromConfigWithProfile(
             self.allocator,
@@ -1427,7 +1427,7 @@ pub const SessionManager = struct {
             break :blk owned_api_key;
         };
 
-        var holder = providers.ProviderHolder.fromConfigWithApiMode(
+        const holder = providers.ProviderHolder.fromConfigWithApiMode(
             self.allocator,
             profile.provider,
             provider_api_key,
@@ -1440,7 +1440,6 @@ pub const SessionManager = struct {
             self.config.getProviderExtraBodyParams(profile.provider),
         );
         return .{
-            .provider = holder.provider(),
             .holder = holder,
             .owned_api_key = owned_api_key,
         };
@@ -2390,6 +2389,35 @@ test "probeVision uses vision route model ref and gateway timeout" {
     try testing.expectEqual(@as(usize, 1), mock.chat_calls);
     try testing.expectEqualStrings("openrouter/openai/gpt-4.1", mock.lastChatModel());
     try testing.expectEqual(@as(u64, 77), mock.last_request_timeout_secs);
+}
+
+test "resolveProviderForSession returns provider from returned holder storage" {
+    var mock = MockProvider{ .response = "ok" };
+    var cfg = testConfig();
+    cfg.providers = &.{
+        .{
+            .name = "custom:dmr",
+            .base_url = "http://127.0.0.1:8080/v1",
+        },
+    };
+    var sm = testSessionManager(testing.allocator, &mock, &cfg);
+    defer sm.deinit();
+
+    const profile = config_types.NamedAgentConfig{
+        .name = "sub",
+        .provider = "custom:dmr",
+        .model = "smollm2",
+        .api_key = "placeholder",
+    };
+
+    var ctx = try sm.resolveProviderForSession(profile);
+    defer ctx.deinit(testing.allocator);
+
+    try testing.expect(ctx.provider == null);
+    try testing.expect(ctx.holder != null);
+    const holder_provider = ctx.holder.?.provider();
+    try testing.expect(@intFromPtr(holder_provider.ptr) != 0);
+    try testing.expect(@intFromPtr(holder_provider.vtable) != 0);
 }
 
 fn testBuildClaimToken(

--- a/src/session.zig
+++ b/src/session.zig
@@ -2366,35 +2366,6 @@ test "probeVision uses vision route model ref and gateway timeout" {
     try testing.expectEqual(@as(u64, 77), mock.last_request_timeout_secs);
 }
 
-test "resolveProviderForSession returns provider from returned holder storage" {
-    var mock = MockProvider{ .response = "ok" };
-    var cfg = testConfig();
-    cfg.providers = &.{
-        .{
-            .name = "custom:dmr",
-            .base_url = "http://127.0.0.1:8080/v1",
-        },
-    };
-    var sm = testSessionManager(testing.allocator, &mock, &cfg);
-    defer sm.deinit();
-
-    const profile = config_types.NamedAgentConfig{
-        .name = "sub",
-        .provider = "custom:dmr",
-        .model = "smollm2",
-        .api_key = "placeholder",
-    };
-
-    var ctx = try sm.resolveProviderForSession(profile);
-    defer ctx.deinit(testing.allocator);
-
-    try testing.expect(ctx.provider == null);
-    try testing.expect(ctx.holder != null);
-    const holder_provider = ctx.holder.?.provider();
-    try testing.expect(@intFromPtr(holder_provider.ptr) != 0);
-    try testing.expect(@intFromPtr(holder_provider.vtable) != 0);
-}
-
 fn testBuildClaimToken(
     allocator: Allocator,
     secret: []const u8,
@@ -2772,17 +2743,26 @@ test "getOrCreate stores named agent provider interface from session-owned holde
     var mock = MockProvider{ .response = "ok" };
     var cfg = testConfig();
     cfg.default_provider = "openrouter";
+    cfg.providers = &.{
+        .{
+            .name = "custom:dmr",
+            .base_url = "http://127.0.0.1:8080/v1",
+        },
+    };
     cfg.agents = &.{
         .{
             .name = "Coder Agent",
-            .provider = "ollama",
-            .model = "qwen2.5-coder:14b",
+            .provider = "custom:dmr",
+            .model = "smollm2",
+            .api_key = "placeholder",
         },
     };
 
     var sm = testSessionManager(testing.allocator, &mock, &cfg);
     defer sm.deinit();
 
+    // Regression: issue #811 requires holder-backed custom providers to bind
+    // Agent.provider to the session-owned holder rather than transient storage.
     const session = try sm.getOrCreate("agent:coder-agent:telegram:group:-100123");
     try testing.expect(session.provider_holder != null);
 
@@ -2790,6 +2770,12 @@ test "getOrCreate stores named agent provider interface from session-owned holde
     const holder_provider = holder.provider();
     try testing.expect(session.agent.provider.ptr == holder_provider.ptr);
     try testing.expect(session.agent.provider.vtable == holder_provider.vtable);
+    switch (session.provider_holder.?) {
+        .compatible => |*compatible_provider| {
+            try testing.expectEqual(@intFromPtr(compatible_provider), @intFromPtr(session.agent.provider.ptr));
+        },
+        else => unreachable,
+    }
 }
 
 test "getOrCreate uses named agent workspace namespace when workspace_path is set" {


### PR DESCRIPTION
## Summary

### EN:
   - Fixed a lifetime bug in named-agent provider resolution where a vtable `Provider` could outlive the stack storage used to derive it.
   - Simplified the CLI named-agent provider context to keep only the owned `ProviderHolder` and derive the runtime `Provider` from stable storage at the call site.
   - Updated the session manager's named-agent provider resolution path to keep inherited providers separate from holder-backed providers.
   - Added regression tests covering both CLI and session resolution paths for named agents using custom OpenAI-compatible providers.

### ZH:
   - 修复了命名子代理模型提供方解析中的生命周期漏洞：基于栈上临时存储构造的 vtable `Provider` 可能在返回后悬空。
   - 简化了 CLI 的命名子代理提供方上下文，仅保留自有的 `ProviderHolder`，并在调用点从稳定存储中派生运行时 `Provider`。
   - 更新了 Session Manager 的命名子代理提供方解析路径，将继承得到的提供方与由 holder 驱动的提供方明确分离。
   - 为使用自定义 OpenAI 兼容提供方的命名子代理补充了 CLI 和会话解析两条路径的回归测试。

## Validation
   - `zig build test --summary all`: passed in `/tmp/nullclaw-issue-811`.

## Root Cause
   - The resolved `Provider` interface was being materialized before the final storage location of the corresponding `ProviderHolder` was stable.
   - Returning that interface by value allowed the embedded pointer to reference stale stack memory once the context struct was copied again by the caller.

## Notes
   - Closes #811.