### PR TITLE
Add Weixin QR auth flow and channel support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -178,7 +178,7 @@ fn parseChannelsOption(raw: []const u8) !ChannelSelection {
             selection.enable_channel_lark = true;
         } else if (std.mem.eql(u8, token, "dingtalk")) {
             selection.enable_channel_dingtalk = true;
-        } else if (std.mem.eql(u8, token, "wechat")) {
+        } else if (std.mem.eql(u8, token, "wechat") or std.mem.eql(u8, token, "weixin")) {
             selection.enable_channel_wechat = true;
         } else if (std.mem.eql(u8, token, "wecom")) {
             selection.enable_channel_wecom = true;
@@ -380,7 +380,7 @@ pub fn build(b: *std.Build) void {
     const channels_raw = b.option(
         []const u8,
         "channels",
-        "Channels list. Tokens: all|none|cli|telegram|discord|slack|whatsapp|matrix|mattermost|irc|imessage|email|lark|dingtalk|wechat|wecom|line|onebot|qq|maixcam|signal|nostr|web|max (default: all)",
+        "Channels list. Tokens: all|none|cli|telegram|discord|slack|whatsapp|matrix|mattermost|irc|imessage|email|lark|dingtalk|wechat|weixin|wecom|line|onebot|qq|maixcam|signal|nostr|web|max (default: all)",
     );
     const channels = if (channels_raw) |raw| blk: {
         const parsed = parseChannelsOption(raw) catch {
@@ -615,4 +615,12 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&b.addRunArtifact(lib_tests).step);
         test_step.dependOn(&b.addRunArtifact(exe_tests).step);
     }
+}
+
+test "parse channels option accepts weixin alias" {
+    // Regression: `-Dchannels=weixin` must enable the shared WeChat build flag.
+    const parsed = try parseChannelsOption("weixin");
+
+    try std.testing.expect(parsed.enable_channel_wechat);
+    try std.testing.expect(!parsed.enable_channel_wecom);
 }

--- a/src/channel_adapters.zig
+++ b/src/channel_adapters.zig
@@ -4,6 +4,7 @@ const channel_loop = @import("channel_loop.zig");
 const channels_root = @import("channels/root.zig");
 const telegram = @import("channels/telegram.zig");
 const signal = @import("channels/signal.zig");
+const weixin = @import("channels/weixin.zig");
 const max_mod = @import("channels/max.zig");
 const agent_routing = @import("agent_routing.zig");
 
@@ -35,6 +36,11 @@ fn signalPollingSourceKey(allocator: std.mem.Allocator, channel: channels_root.C
     return std.fmt.allocPrint(allocator, "{s}|{s}", .{ sg_ptr.http_url, sg_ptr.account }) catch null;
 }
 
+fn weixinPollingSourceKey(allocator: std.mem.Allocator, channel: channels_root.Channel) ?[]u8 {
+    const wx_ptr: *const weixin.WeixinChannel = @ptrCast(@alignCast(channel.ptr));
+    return std.fmt.allocPrint(allocator, "{s}|{s}", .{ wx_ptr.config.base_url, wx_ptr.config.token }) catch null;
+}
+
 pub const polling_descriptors = [_]PollingDescriptor{
     .{
         .channel_name = "telegram",
@@ -45,6 +51,11 @@ pub const polling_descriptors = [_]PollingDescriptor{
         .channel_name = "signal",
         .spawn = channel_loop.spawnSignalPolling,
         .source_key = signalPollingSourceKey,
+    },
+    .{
+        .channel_name = "weixin",
+        .spawn = channel_loop.spawnWeixinPolling,
+        .source_key = weixinPollingSourceKey,
     },
     .{
         .channel_name = "matrix",
@@ -362,6 +373,7 @@ pub fn findInboundRouteDescriptor(config: *const Config, channel_name: []const u
 test "findPollingDescriptor returns known polling adapters" {
     try std.testing.expect(findPollingDescriptor("telegram") != null);
     try std.testing.expect(findPollingDescriptor("signal") != null);
+    try std.testing.expect(findPollingDescriptor("weixin") != null);
     try std.testing.expect(findPollingDescriptor("matrix") != null);
     try std.testing.expect(findPollingDescriptor("max") != null);
     try std.testing.expect(findPollingDescriptor("discord") == null);

--- a/src/channel_catalog.zig
+++ b/src/channel_catalog.zig
@@ -18,6 +18,7 @@ pub const ChannelId = enum {
     dingtalk,
     wechat,
     wecom,
+    weixin,
     signal,
     email,
     line,
@@ -62,6 +63,7 @@ pub const known_channels = [_]ChannelMeta{
     .{ .id = .dingtalk, .key = "dingtalk", .label = "DingTalk", .configured_message = "DingTalk configured", .listener_mode = .gateway_loop },
     .{ .id = .wechat, .key = "wechat", .label = "WeChat", .configured_message = "WeChat configured", .listener_mode = .webhook_only },
     .{ .id = .wecom, .key = "wecom", .label = "WeCom", .configured_message = "WeCom configured", .listener_mode = .webhook_only },
+    .{ .id = .weixin, .key = "weixin", .label = "Weixin", .configured_message = "Weixin (iLink) configured", .listener_mode = .polling },
     .{ .id = .signal, .key = "signal", .label = "Signal", .configured_message = "Signal configured", .listener_mode = .polling },
     .{ .id = .email, .key = "email", .label = "Email", .configured_message = "Email configured", .listener_mode = .send_only },
     .{ .id = .line, .key = "line", .label = "Line", .configured_message = "Line configured", .listener_mode = .webhook_only },
@@ -91,6 +93,7 @@ pub fn isBuildEnabled(channel_id: ChannelId) bool {
         .dingtalk => build_options.enable_channel_dingtalk,
         .wechat => build_options.enable_channel_wechat,
         .wecom => build_options.enable_channel_wecom,
+        .weixin => build_options.enable_channel_wechat,
         .signal => build_options.enable_channel_signal,
         .email => build_options.enable_channel_email,
         .line => build_options.enable_channel_line,
@@ -120,6 +123,7 @@ pub fn isBuildEnabledByKey(comptime key: []const u8) bool {
     if (comptime std.mem.eql(u8, key, "dingtalk")) return build_options.enable_channel_dingtalk;
     if (comptime std.mem.eql(u8, key, "wechat")) return build_options.enable_channel_wechat;
     if (comptime std.mem.eql(u8, key, "wecom")) return build_options.enable_channel_wecom;
+    if (comptime std.mem.eql(u8, key, "weixin")) return build_options.enable_channel_wechat;
     if (comptime std.mem.eql(u8, key, "signal")) return build_options.enable_channel_signal;
     if (comptime std.mem.eql(u8, key, "email")) return build_options.enable_channel_email;
     if (comptime std.mem.eql(u8, key, "line")) return build_options.enable_channel_line;
@@ -150,6 +154,7 @@ pub fn configuredCount(cfg: *const Config, channel_id: ChannelId) usize {
         .dingtalk => cfg.channels.dingtalk.len,
         .wechat => cfg.channels.wechat.len,
         .wecom => cfg.channels.wecom.len,
+        .weixin => cfg.channels.weixin.len,
         .signal => cfg.channels.signal.len,
         .email => cfg.channels.email.len,
         .line => cfg.channels.line.len,

--- a/src/channel_loop.zig
+++ b/src/channel_loop.zig
@@ -32,6 +32,7 @@ const fs_compat = @import("fs_compat.zig");
 const provider_probe = @import("provider_probe.zig");
 
 const signal = @import("channels/signal.zig");
+const weixin = @import("channels/weixin.zig");
 const matrix = @import("channels/matrix.zig");
 const max_mod = @import("channels/max.zig");
 const channels_mod = @import("channels/root.zig");
@@ -1700,6 +1701,26 @@ pub const SignalLoopState = struct {
 };
 
 // ════════════════════════════════════════════════════════════════════════════
+// WeixinLoopState — shared state between supervisor and polling thread
+// ════════════════════════════════════════════════════════════════════════════
+
+pub const WeixinLoopState = struct {
+    /// Updated after each pollMessages() — epoch seconds.
+    last_activity: Atomic(i64),
+    /// Supervisor sets this to ask the polling thread to stop.
+    stop_requested: Atomic(bool),
+    /// Thread handle for join().
+    thread: ?std.Thread = null,
+
+    pub fn init() WeixinLoopState {
+        return .{
+            .last_activity = Atomic(i64).init(std_compat.time.timestamp()),
+            .stop_requested = Atomic(bool).init(false),
+        };
+    }
+};
+
+// ════════════════════════════════════════════════════════════════════════════
 // runSignalLoop — polling thread function
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -1824,6 +1845,104 @@ pub fn runSignalLoop(
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// runWeixinLoop — polling thread function
+// ════════════════════════════════════════════════════════════════════════════
+
+pub fn runWeixinLoop(
+    allocator: std.mem.Allocator,
+    config: *const Config,
+    runtime: *ChannelRuntime,
+    loop_state: *WeixinLoopState,
+    wx_ptr: *weixin.WeixinChannel,
+) void {
+    loop_state.last_activity.store(std_compat.time.timestamp(), .release);
+
+    var evict_counter: u32 = 0;
+
+    while (!loop_state.stop_requested.load(.acquire) and !daemon.isShutdownRequested()) {
+        const messages = wx_ptr.pollMessages(allocator) catch |err| {
+            log.warn("Weixin poll error: {}", .{err});
+            loop_state.last_activity.store(std_compat.time.timestamp(), .release);
+            std_compat.thread.sleep(5 * std.time.ns_per_s);
+            continue;
+        };
+
+        loop_state.last_activity.store(std_compat.time.timestamp(), .release);
+
+        for (messages) |msg| {
+            const reply_target = msg.reply_target orelse msg.sender;
+            setScheduleToolContext(
+                runtime.tools,
+                "weixin",
+                wx_ptr.config.account_id,
+                reply_target,
+                .direct,
+                msg.sender,
+                null,
+            );
+            defer setScheduleToolContext(runtime.tools, null, null, null, null, null, null);
+
+            var key_buf: [192]u8 = undefined;
+            var routed_session_key: ?[]const u8 = null;
+            defer if (routed_session_key) |key| allocator.free(key);
+
+            const session_key = blk: {
+                const route = agent_routing.resolveRouteWithSession(allocator, .{
+                    .channel = "weixin",
+                    .account_id = wx_ptr.config.account_id,
+                    .peer = .{
+                        .kind = .direct,
+                        .id = msg.sender,
+                    },
+                }, config.agent_bindings, config.agents, config.session) catch break :blk std.fmt.bufPrint(&key_buf, "weixin:{s}:{s}", .{ wx_ptr.config.account_id, msg.sender }) catch msg.sender;
+
+                allocator.free(route.main_session_key);
+                routed_session_key = route.session_key;
+                break :blk route.session_key;
+            };
+
+            const conversation_context = buildConversationContext(.{
+                .channel = "weixin",
+                .account_id = wx_ptr.config.account_id,
+                .sender_id = msg.sender,
+                .delivery_chat_id = reply_target,
+                .peer_id = msg.sender,
+                .is_group = false,
+            });
+
+            const reply = runtime.session_mgr.processMessage(session_key, msg.content, conversation_context) catch |err| {
+                logAgentProcessingError(allocator, "Weixin agent error", err);
+                const owned_err_msg = detailedProviderErrorForDisplay(allocator, err) catch null;
+                defer if (owned_err_msg) |owned_msg| allocator.free(owned_msg);
+                const err_msg = owned_err_msg orelse compactAgentErrorMessage(err);
+                wx_ptr.sendMessage(reply_target, err_msg) catch |send_err| log.err("failed to send weixin error reply: {}", .{send_err});
+                continue;
+            };
+            defer allocator.free(reply);
+
+            wx_ptr.sendMessage(reply_target, reply) catch |err| {
+                log.warn("Weixin send error: {}", .{err});
+            };
+        }
+
+        if (messages.len > 0) {
+            for (messages) |msg| {
+                msg.deinit(allocator);
+            }
+            allocator.free(messages);
+        }
+
+        evict_counter += 1;
+        if (evict_counter >= 100) {
+            evict_counter = 0;
+            _ = runtime.session_mgr.evictIdle(config.agent.session_idle_timeout_secs);
+        }
+
+        health.markComponentOk("weixin");
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // MatrixLoopState — shared state between supervisor and polling thread
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -1866,6 +1985,7 @@ pub const MaxLoopState = struct {
 pub const PollingState = union(enum) {
     telegram: *TelegramLoopState,
     signal: *SignalLoopState,
+    weixin: *WeixinLoopState,
     matrix: *MatrixLoopState,
     max: *MaxLoopState,
 };
@@ -1920,6 +2040,30 @@ pub fn spawnSignalPolling(
     return .{
         .thread = thread,
         .state = .{ .signal = sg_ls },
+    };
+}
+
+pub fn spawnWeixinPolling(
+    allocator: std.mem.Allocator,
+    config: *const Config,
+    runtime: *ChannelRuntime,
+    channel: channels_mod.Channel,
+) !PollingSpawnResult {
+    const wx_ls = try allocator.create(WeixinLoopState);
+    errdefer allocator.destroy(wx_ls);
+    wx_ls.* = WeixinLoopState.init();
+
+    const wx_ptr: *weixin.WeixinChannel = @ptrCast(@alignCast(channel.ptr));
+    const thread = try std.Thread.spawn(
+        .{ .stack_size = thread_stacks.SESSION_TURN_STACK_SIZE },
+        runWeixinLoop,
+        .{ allocator, config, runtime, wx_ls, wx_ptr },
+    );
+    wx_ls.thread = thread;
+
+    return .{
+        .thread = thread,
+        .state = .{ .weixin = wx_ls },
     };
 }
 
@@ -2331,6 +2475,29 @@ test "SignalLoopState stop_requested toggle" {
 
 test "SignalLoopState last_activity update" {
     var state = SignalLoopState.init();
+    const before = state.last_activity.load(.acquire);
+    std_compat.thread.sleep(10 * std.time.ns_per_ms);
+    state.last_activity.store(std_compat.time.timestamp(), .release);
+    const after = state.last_activity.load(.acquire);
+    try std.testing.expect(after >= before);
+}
+
+test "WeixinLoopState init defaults" {
+    const state = WeixinLoopState.init();
+    try std.testing.expect(!state.stop_requested.load(.acquire));
+    try std.testing.expect(state.thread == null);
+    try std.testing.expect(state.last_activity.load(.acquire) > 0);
+}
+
+test "WeixinLoopState stop_requested toggle" {
+    var state = WeixinLoopState.init();
+    try std.testing.expect(!state.stop_requested.load(.acquire));
+    state.stop_requested.store(true, .release);
+    try std.testing.expect(state.stop_requested.load(.acquire));
+}
+
+test "WeixinLoopState last_activity update" {
+    var state = WeixinLoopState.init();
     const before = state.last_activity.load(.acquire);
     std_compat.thread.sleep(10 * std.time.ns_per_ms);
     state.last_activity.store(std_compat.time.timestamp(), .release);

--- a/src/channel_manager.zig
+++ b/src/channel_manager.zig
@@ -96,6 +96,7 @@ pub const ChannelManager = struct {
         return switch (state) {
             .telegram => |ls| ls.last_activity.load(.acquire),
             .signal => |ls| ls.last_activity.load(.acquire),
+            .weixin => |ls| ls.last_activity.load(.acquire),
             .matrix => |ls| ls.last_activity.load(.acquire),
             .max => |ls| ls.last_activity.load(.acquire),
         };
@@ -105,6 +106,7 @@ pub const ChannelManager = struct {
         switch (state) {
             .telegram => |ls| ls.stop_requested.store(true, .release),
             .signal => |ls| ls.stop_requested.store(true, .release),
+            .weixin => |ls| ls.stop_requested.store(true, .release),
             .matrix => |ls| ls.stop_requested.store(true, .release),
             .max => |ls| ls.stop_requested.store(true, .release),
         }
@@ -114,6 +116,7 @@ pub const ChannelManager = struct {
         switch (state) {
             .telegram => |ls| self.allocator.destroy(ls),
             .signal => |ls| self.allocator.destroy(ls),
+            .weixin => |ls| self.allocator.destroy(ls),
             .matrix => |ls| self.allocator.destroy(ls),
             .max => |ls| self.allocator.destroy(ls),
         }
@@ -488,10 +491,12 @@ pub const ChannelManager = struct {
 // Tests
 // ════════════════════════════════════════════════════════════════════════════
 
-test "PollingState has telegram signal matrix and max variants" {
+test "PollingState has telegram signal weixin matrix and max variants" {
     try std.testing.expect(@intFromEnum(@as(std.meta.Tag(PollingState), .telegram)) !=
         @intFromEnum(@as(std.meta.Tag(PollingState), .signal)));
     try std.testing.expect(@intFromEnum(@as(std.meta.Tag(PollingState), .signal)) !=
+        @intFromEnum(@as(std.meta.Tag(PollingState), .weixin)));
+    try std.testing.expect(@intFromEnum(@as(std.meta.Tag(PollingState), .weixin)) !=
         @intFromEnum(@as(std.meta.Tag(PollingState), .matrix)));
     try std.testing.expect(@intFromEnum(@as(std.meta.Tag(PollingState), .matrix)) !=
         @intFromEnum(@as(std.meta.Tag(PollingState), .max)));

--- a/src/channels/root.zig
+++ b/src/channels/root.zig
@@ -290,6 +290,7 @@ pub const lark = @import("lark.zig");
 pub const dingtalk = @import("dingtalk.zig");
 pub const wechat = @import("wechat.zig");
 pub const wecom = @import("wecom.zig");
+pub const weixin = @import("weixin.zig");
 pub const nostr = @import("nostr.zig");
 pub const line = @import("line.zig");
 pub const onebot = @import("onebot.zig");

--- a/src/channels/weixin.zig
+++ b/src/channels/weixin.zig
@@ -1,20 +1,125 @@
 const std = @import("std");
+const std_compat = @import("compat");
 const builtin = @import("builtin");
 const root = @import("root.zig");
 const config_types = @import("../config_types.zig");
 const qr_mod = @import("../qr.zig");
+const url_percent = @import("../url_percent.zig");
 
 const ILINK_BASE_URL = "https://ilinkai.weixin.qq.com/";
 const ILINK_APP_ID = "bot";
 const ILINK_CLIENT_VERSION = "131329"; // 2.1.1 encoded as 0x00020101
 const CHANNEL_VERSION = "2.1.1";
+const WEIXIN_REPLY_TARGET_SEPARATOR: u8 = 0x1f;
+const SEND_TIMEOUT_SECS = "15";
+const GET_UPDATES_TIMEOUT_SECS = "35";
+const GET_UPDATES_ITEM_TYPE_TEXT: u8 = 1;
+const GET_UPDATES_ITEM_TYPE_VOICE: u8 = 3;
+const MESSAGE_TYPE_BOT: u8 = 2;
+const MESSAGE_STATE_FINISH: u8 = 2;
 const QR_POLL_INTERVAL_NS: u64 = 2 * std.time.ns_per_s;
 const LOGIN_TIMEOUT_NS: u64 = 300 * std.time.ns_per_s;
+const log = std.log.scoped(.weixin);
+
+const AuthHeaderSet = struct {
+    authorization: []u8,
+    wechat_uin: []u8,
+    headers: [6][]const u8,
+
+    fn init(allocator: std.mem.Allocator, token: []const u8) !AuthHeaderSet {
+        const authorization = try std.fmt.allocPrint(allocator, "Authorization: Bearer {s}", .{token});
+        errdefer allocator.free(authorization);
+
+        const wechat_uin = try buildWechatUinHeader(allocator);
+        errdefer allocator.free(wechat_uin);
+
+        return .{
+            .authorization = authorization,
+            .wechat_uin = wechat_uin,
+            .headers = .{
+                "iLink-App-Id: " ++ ILINK_APP_ID,
+                "iLink-App-ClientVersion: " ++ ILINK_CLIENT_VERSION,
+                "AuthorizationType: ilink_bot_token",
+                "Content-Type: application/json",
+                authorization,
+                wechat_uin,
+            },
+        };
+    }
+
+    fn deinit(self: *const AuthHeaderSet, allocator: std.mem.Allocator) void {
+        allocator.free(self.authorization);
+        allocator.free(self.wechat_uin);
+    }
+};
+
+const SendTarget = struct {
+    user_id: []const u8,
+    context_token: ?[]const u8 = null,
+};
+
+const InboundTextItem = struct {
+    text: ?[]const u8 = null,
+};
+
+const InboundVoiceItem = struct {
+    text: ?[]const u8 = null,
+};
+
+const InboundItem = struct {
+    type: ?u8 = null,
+    text_item: ?InboundTextItem = null,
+    voice_item: ?InboundVoiceItem = null,
+};
+
+const InboundMessage = struct {
+    message_id: ?u64 = null,
+    from_user_id: ?[]const u8 = null,
+    create_time_ms: ?u64 = null,
+    context_token: ?[]const u8 = null,
+    item_list: ?[]const InboundItem = null,
+};
+
+const GetUpdatesResponse = struct {
+    ret: ?i64 = null,
+    errcode: ?i64 = null,
+    errmsg: ?[]const u8 = null,
+    msgs: ?[]const InboundMessage = null,
+    get_updates_buf: ?[]const u8 = null,
+    longpolling_timeout_ms: ?u64 = null,
+};
+
+const ParsedUpdates = struct {
+    messages: []root.ChannelMessage,
+    next_updates_buf: ?[]u8 = null,
+    longpolling_timeout_ms: ?u64 = null,
+
+    fn deinit(self: *ParsedUpdates, allocator: std.mem.Allocator) void {
+        for (self.messages) |*message| {
+            message.deinit(allocator);
+        }
+        if (self.messages.len > 0) allocator.free(self.messages);
+        if (self.next_updates_buf) |next_updates_buf| allocator.free(next_updates_buf);
+        self.* = .{
+            .messages = &.{},
+            .next_updates_buf = null,
+            .longpolling_timeout_ms = null,
+        };
+    }
+
+    fn takeMessages(self: *ParsedUpdates) []root.ChannelMessage {
+        const messages = self.messages;
+        self.messages = &.{};
+        return messages;
+    }
+};
 
 pub const WeixinChannel = struct {
     allocator: std.mem.Allocator,
     config: config_types.WeixinConfig,
     running: bool = false,
+    updates_buf: []u8 = &.{},
+    context_tokens: std.StringHashMapUnmanaged([]const u8) = .empty,
 
     pub fn init(allocator: std.mem.Allocator, cfg: config_types.WeixinConfig) WeixinChannel {
         return .{ .allocator = allocator, .config = cfg };
@@ -29,7 +134,22 @@ pub const WeixinChannel = struct {
     }
 
     pub fn healthCheck(self: *WeixinChannel) bool {
-        return self.running;
+        return self.running or self.config.token.len > 0;
+    }
+
+    pub fn deinit(self: *WeixinChannel) void {
+        if (self.updates_buf.len > 0) {
+            self.allocator.free(self.updates_buf);
+            self.updates_buf = &.{};
+        }
+
+        var it = self.context_tokens.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            self.allocator.free(entry.value_ptr.*);
+        }
+        self.context_tokens.deinit(self.allocator);
+        self.context_tokens = .empty;
     }
 
     pub fn sendMessage(self: *WeixinChannel, target: []const u8, text: []const u8) !void {
@@ -38,23 +158,106 @@ pub const WeixinChannel = struct {
 
         const token = self.config.token;
         if (token.len == 0) return error.WeixinMissingToken;
+        const parsed_target = parseReplyTarget(target);
+        const context_token = self.lookupContextToken(parsed_target.user_id) orelse parsed_target.context_token;
+        if (context_token == null) {
+            log.warn("sending weixin message without context_token for user {s}", .{parsed_target.user_id});
+        }
 
         var payload: std.ArrayListUnmanaged(u8) = .empty;
         defer payload.deinit(self.allocator);
-        try appendSendMessagePayload(self.allocator, &payload, target, text);
+        try appendSendMessagePayload(self.allocator, &payload, parsed_target.user_id, text, context_token);
 
         const url = try buildUrl(self.allocator, self.config.base_url, "ilink/bot/sendmessage");
         defer self.allocator.free(url);
 
-        const headers = authHeaders(token);
-        const resp = root.http_util.curlPostWithStatus(
+        var headers = try AuthHeaderSet.init(self.allocator, token);
+        defer headers.deinit(self.allocator);
+
+        const resp_body = root.http_util.curlPostWithProxy(
             self.allocator,
             url,
             payload.items,
-            &headers,
+            &headers.headers,
+            self.config.proxy,
+            SEND_TIMEOUT_SECS,
         ) catch return error.WeixinApiError;
-        defer self.allocator.free(resp.body);
-        if (resp.status_code < 200 or resp.status_code >= 300) return error.WeixinApiError;
+        defer self.allocator.free(resp_body);
+
+        try ensureApiResponseOk(self.allocator, resp_body);
+    }
+
+    pub fn pollMessages(self: *WeixinChannel, allocator: std.mem.Allocator) ![]root.ChannelMessage {
+        if (builtin.is_test) return &.{};
+        if (self.config.token.len == 0) return error.WeixinMissingToken;
+
+        var payload: std.ArrayListUnmanaged(u8) = .empty;
+        defer payload.deinit(self.allocator);
+        try appendGetUpdatesPayload(self.allocator, &payload, self.updates_buf);
+
+        const url = try buildUrl(self.allocator, self.config.base_url, "ilink/bot/getupdates");
+        defer self.allocator.free(url);
+
+        var headers = try AuthHeaderSet.init(self.allocator, self.config.token);
+        defer headers.deinit(self.allocator);
+
+        const resp_body = root.http_util.curlPostWithProxy(
+            self.allocator,
+            url,
+            payload.items,
+            &headers.headers,
+            self.config.proxy,
+            GET_UPDATES_TIMEOUT_SECS,
+        ) catch return error.WeixinApiError;
+        defer self.allocator.free(resp_body);
+
+        var parsed = try parseGetUpdatesResponse(allocator, resp_body, self.config.allow_from);
+        errdefer parsed.deinit(allocator);
+
+        if (parsed.next_updates_buf) |next_updates_buf| {
+            try self.setUpdatesBuf(next_updates_buf);
+            allocator.free(next_updates_buf);
+            parsed.next_updates_buf = null;
+        }
+
+        for (parsed.messages) |message| {
+            const reply_target = message.reply_target orelse continue;
+            const parsed_target = parseReplyTarget(reply_target);
+            const context_token = parsed_target.context_token orelse continue;
+            try self.setContextToken(parsed_target.user_id, context_token);
+        }
+
+        return parsed.takeMessages();
+    }
+
+    fn setUpdatesBuf(self: *WeixinChannel, next_updates_buf: []const u8) !void {
+        if (self.updates_buf.len > 0) {
+            self.allocator.free(self.updates_buf);
+            self.updates_buf = &.{};
+        }
+
+        if (next_updates_buf.len == 0) return;
+        self.updates_buf = try self.allocator.dupe(u8, next_updates_buf);
+    }
+
+    fn setContextToken(self: *WeixinChannel, user_id: []const u8, context_token: []const u8) !void {
+        if (user_id.len == 0 or context_token.len == 0) return;
+
+        const owned_context_token = try self.allocator.dupe(u8, context_token);
+        errdefer self.allocator.free(owned_context_token);
+        if (self.context_tokens.getPtr(user_id)) |existing_value| {
+            self.allocator.free(existing_value.*);
+            existing_value.* = owned_context_token;
+            return;
+        }
+
+        const owned_user_id = try self.allocator.dupe(u8, user_id);
+        errdefer self.allocator.free(owned_user_id);
+        try self.context_tokens.put(self.allocator, owned_user_id, owned_context_token);
+    }
+
+    fn lookupContextToken(self: *WeixinChannel, user_id: []const u8) ?[]const u8 {
+        return self.context_tokens.get(user_id);
     }
 
     fn vtableStart(ptr: *anyopaque) anyerror!void {
@@ -143,7 +346,7 @@ pub fn performLogin(allocator: std.mem.Allocator, opts: LoginOptions) !LoginResu
         };
     }
 
-    const qr_resp = try requestQrCode(allocator, opts.base_url);
+    const qr_resp = try requestQrCode(allocator, opts.base_url, opts.proxy);
     defer allocator.free(qr_resp.qrcode);
     defer allocator.free(qr_resp.qrcode_img_content);
 
@@ -155,13 +358,13 @@ pub fn performLogin(allocator: std.mem.Allocator, opts: LoginOptions) !LoginResu
     defer if (poll_base_url) |u| allocator.free(u);
     var scanned_printed = false;
 
-    const deadline = std.time.nanoTimestamp() + @as(i128, opts.timeout_ns);
+    const deadline = std_compat.time.nanoTimestamp() + @as(i128, opts.timeout_ns);
 
-    while (std.time.nanoTimestamp() < deadline) {
-        std.Thread.sleep(QR_POLL_INTERVAL_NS);
+    while (std_compat.time.nanoTimestamp() < deadline) {
+        std_compat.thread.sleep(QR_POLL_INTERVAL_NS);
 
         const effective_base = if (poll_base_url) |u| u else opts.base_url;
-        const status_resp = pollQrStatus(allocator, effective_base, qr_resp.qrcode) catch continue;
+        const status_resp = pollQrStatus(allocator, effective_base, qr_resp.qrcode, opts.proxy) catch continue;
         defer {
             allocator.free(status_resp.status);
             allocator.free(status_resp.bot_token);
@@ -221,14 +424,14 @@ fn displayQrCode(url: []const u8) !void {
     };
 
     var buf: [8192]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&buf);
-    qr_mod.renderTerminal(&qr, fbs.writer()) catch {
+    var writer: std.Io.Writer = .fixed(&buf);
+    qr_mod.renderTerminal(&qr, &writer) catch {
         std.debug.print("(Could not render QR code)\n", .{});
         std.debug.print("QR Code Link: {s}\n\n", .{url});
         return;
     };
 
-    std.debug.print("{s}", .{fbs.getWritten()});
+    std.debug.print("{s}", .{writer.buffered()});
     std.debug.print("\nQR Code Link: {s}\n\n", .{url});
     std.debug.print("Waiting for scan...\n", .{});
 }
@@ -242,23 +445,31 @@ fn ilinkHeaders() [2][]const u8 {
     };
 }
 
-fn authHeaders(token: []const u8) [5][]const u8 {
-    _ = token;
-    return .{
-        "iLink-App-Id: " ++ ILINK_APP_ID,
-        "iLink-App-ClientVersion: " ++ ILINK_CLIENT_VERSION,
-        "AuthorizationType: ilink_bot_token",
-        "Content-Type: application/json",
-        "X-WECHAT-UIN: MTIzNDU2Nzg5MA==",
-    };
+fn buildWechatUinHeader(allocator: std.mem.Allocator) ![]u8 {
+    var random_bytes: [4]u8 = undefined;
+    std_compat.crypto.random.bytes(&random_bytes);
+    const value = std.mem.readInt(u32, &random_bytes, .big);
+
+    var decimal_buf: [16]u8 = undefined;
+    const decimal = try std.fmt.bufPrint(&decimal_buf, "{d}", .{value});
+
+    var encoded_buf: [24]u8 = undefined;
+    const encoded = std.base64.standard.Encoder.encode(
+        encoded_buf[0..std.base64.standard.Encoder.calcSize(decimal.len)],
+        decimal,
+    );
+
+    return std.fmt.allocPrint(allocator, "X-WECHAT-UIN: {s}", .{encoded});
 }
 
 fn buildUrl(allocator: std.mem.Allocator, base_url: []const u8, endpoint: []const u8) ![]u8 {
-    const base = std.mem.trimRight(u8, base_url, "/");
+    var base_end = base_url.len;
+    while (base_end > 0 and base_url[base_end - 1] == '/') : (base_end -= 1) {}
+    const base = base_url[0..base_end];
     return std.fmt.allocPrint(allocator, "{s}/{s}", .{ base, endpoint });
 }
 
-fn requestQrCode(allocator: std.mem.Allocator, base_url: []const u8) !struct { qrcode: []u8, qrcode_img_content: []u8 } {
+fn requestQrCode(allocator: std.mem.Allocator, base_url: []const u8, proxy: ?[]const u8) !struct { qrcode: []u8, qrcode_img_content: []u8 } {
     const url = try std.fmt.allocPrint(allocator, "{s}ilink/bot/get_bot_qrcode?bot_type=3", .{
         if (std.mem.endsWith(u8, base_url, "/")) base_url else blk: {
             // base_url always ends with / from default
@@ -268,7 +479,7 @@ fn requestQrCode(allocator: std.mem.Allocator, base_url: []const u8) !struct { q
     defer allocator.free(url);
 
     const headers = ilinkHeaders();
-    const resp_body = root.http_util.curlGet(allocator, url, &headers, "15") catch return error.WeixinApiError;
+    const resp_body = root.http_util.curlGetWithProxy(allocator, url, &headers, SEND_TIMEOUT_SECS, proxy) catch return error.WeixinApiError;
     defer allocator.free(resp_body);
 
     var parsed = std.json.parseFromSlice(std.json.Value, allocator, resp_body, .{}) catch return error.WeixinApiError;
@@ -288,13 +499,15 @@ fn requestQrCode(allocator: std.mem.Allocator, base_url: []const u8) !struct { q
     };
 }
 
-fn pollQrStatus(allocator: std.mem.Allocator, base_url: []const u8, qrcode: []const u8) !StatusResponse {
+fn pollQrStatus(allocator: std.mem.Allocator, base_url: []const u8, qrcode: []const u8, proxy: ?[]const u8) !StatusResponse {
     const base = if (std.mem.endsWith(u8, base_url, "/")) base_url else base_url;
-    const url = try std.fmt.allocPrint(allocator, "{s}ilink/bot/get_qrcode_status?qrcode={s}", .{ base, qrcode });
+    const encoded_qrcode = try url_percent.encode(allocator, qrcode);
+    defer allocator.free(encoded_qrcode);
+    const url = try std.fmt.allocPrint(allocator, "{s}ilink/bot/get_qrcode_status?qrcode={s}", .{ base, encoded_qrcode });
     defer allocator.free(url);
 
     const headers = ilinkHeaders();
-    const resp_body = root.http_util.curlGet(allocator, url, &headers, "30") catch return error.WeixinApiError;
+    const resp_body = root.http_util.curlGetWithProxy(allocator, url, &headers, GET_UPDATES_TIMEOUT_SECS, proxy) catch return error.WeixinApiError;
     defer allocator.free(resp_body);
 
     return parseStatusResponse(allocator, resp_body);
@@ -326,13 +539,197 @@ fn dupeOptionalString(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key
     return try allocator.dupe(u8, val.string);
 }
 
-fn appendSendMessagePayload(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), to_user: []const u8, text: []const u8) !void {
-    const w = out.writer(allocator);
-    try w.writeAll("{\"base_info\":{\"channel_version\":\"" ++ CHANNEL_VERSION ++ "\"},\"to_user\":");
-    try root.appendJsonStringW(w, to_user);
-    try w.writeAll(",\"content_type\":\"text\",\"content\":{\"text\":");
-    try root.appendJsonStringW(w, text);
-    try w.writeAll("}}");
+fn appendGeneratedClientId(writer: anytype) !void {
+    var random_bytes: [8]u8 = undefined;
+    std_compat.crypto.random.bytes(&random_bytes);
+    const random_id = std.mem.readInt(u64, &random_bytes, .big);
+
+    var client_id_buf: [48]u8 = undefined;
+    const client_id = try std.fmt.bufPrint(&client_id_buf, "nullclaw-weixin-{x}", .{random_id});
+    try root.appendJsonStringW(writer, client_id);
+}
+
+fn appendBaseInfo(writer: anytype) !void {
+    try writer.writeAll("{\"channel_version\":");
+    try root.appendJsonStringW(writer, CHANNEL_VERSION);
+    try writer.writeAll("}");
+}
+
+fn appendGetUpdatesPayload(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), updates_buf: []const u8) !void {
+    var out_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, out);
+    const writer = &out_writer.writer;
+
+    try writer.writeAll("{\"get_updates_buf\":");
+    try root.appendJsonStringW(writer, updates_buf);
+    try writer.writeAll(",\"base_info\":");
+    try appendBaseInfo(writer);
+    try writer.writeAll("}");
+
+    out.* = out_writer.toArrayList();
+}
+
+fn appendSendMessagePayload(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    to_user: []const u8,
+    text: []const u8,
+    context_token: ?[]const u8,
+) !void {
+    var out_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, out);
+    const writer = &out_writer.writer;
+
+    try writer.writeAll("{\"msg\":{\"from_user_id\":\"\",\"to_user_id\":");
+    try root.appendJsonStringW(writer, to_user);
+    try writer.writeAll(",\"client_id\":");
+    try appendGeneratedClientId(writer);
+    try writer.print(",\"message_type\":{d},\"message_state\":{d}", .{ MESSAGE_TYPE_BOT, MESSAGE_STATE_FINISH });
+    if (text.len > 0) {
+        try writer.writeAll(",\"item_list\":[{\"type\":1,\"text_item\":{\"text\":");
+        try root.appendJsonStringW(writer, text);
+        try writer.writeAll("}}]");
+    }
+    if (context_token) |token| {
+        try writer.writeAll(",\"context_token\":");
+        try root.appendJsonStringW(writer, token);
+    }
+    try writer.writeAll("},\"base_info\":");
+    try appendBaseInfo(writer);
+    try writer.writeAll("}");
+
+    out.* = out_writer.toArrayList();
+}
+
+fn parseReplyTarget(target: []const u8) SendTarget {
+    if (std.mem.indexOfScalar(u8, target, WEIXIN_REPLY_TARGET_SEPARATOR)) |separator_index| {
+        if (separator_index == 0) return .{ .user_id = target };
+        const context_token = target[separator_index + 1 ..];
+        return .{
+            .user_id = target[0..separator_index],
+            .context_token = if (context_token.len > 0) context_token else null,
+        };
+    }
+
+    return .{ .user_id = target };
+}
+
+fn encodeReplyTarget(allocator: std.mem.Allocator, user_id: []const u8, context_token: ?[]const u8) ![]u8 {
+    if (context_token) |token| {
+        if (token.len > 0) {
+            return std.fmt.allocPrint(allocator, "{s}{c}{s}", .{ user_id, WEIXIN_REPLY_TARGET_SEPARATOR, token });
+        }
+    }
+    return allocator.dupe(u8, user_id);
+}
+
+fn extractInboundText(item_list: ?[]const InboundItem) ?[]const u8 {
+    const items = item_list orelse return null;
+    for (items) |item| {
+        if (item.type == null or item.type.? == GET_UPDATES_ITEM_TYPE_TEXT) {
+            if (item.text_item) |text_item| {
+                if (text_item.text) |text| {
+                    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+                    if (trimmed.len > 0) return trimmed;
+                }
+            }
+        }
+        if (item.type == null or item.type.? == GET_UPDATES_ITEM_TYPE_VOICE) {
+            if (item.voice_item) |voice_item| {
+                if (voice_item.text) |text| {
+                    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+                    if (trimmed.len > 0) return trimmed;
+                }
+            }
+        }
+    }
+    return null;
+}
+
+fn buildInboundMessageId(allocator: std.mem.Allocator, message: InboundMessage, sender: []const u8) ![]u8 {
+    if (message.message_id) |message_id| {
+        return std.fmt.allocPrint(allocator, "{d}", .{message_id});
+    }
+    return std.fmt.allocPrint(allocator, "{s}:{d}", .{ sender, message.create_time_ms orelse 0 });
+}
+
+fn parseGetUpdatesResponse(
+    allocator: std.mem.Allocator,
+    json_body: []const u8,
+    allow_from: []const []const u8,
+) !ParsedUpdates {
+    var parsed = std.json.parseFromSlice(GetUpdatesResponse, allocator, json_body, .{
+        .ignore_unknown_fields = true,
+    }) catch return error.WeixinApiError;
+    defer parsed.deinit();
+
+    if (parsed.value.ret) |ret| {
+        if (ret != 0) return error.WeixinApiError;
+    }
+    if (parsed.value.errcode) |errcode| {
+        if (errcode != 0) return error.WeixinApiError;
+    }
+
+    var messages: std.ArrayListUnmanaged(root.ChannelMessage) = .empty;
+    errdefer {
+        for (messages.items) |*message| {
+            message.deinit(allocator);
+        }
+        messages.deinit(allocator);
+    }
+
+    const inbound_messages = parsed.value.msgs orelse &.{};
+    for (inbound_messages) |message| {
+        const sender = message.from_user_id orelse continue;
+        if (sender.len == 0) continue;
+        if (allow_from.len > 0 and !root.isAllowedExactScoped("weixin channel", allow_from, sender)) {
+            continue;
+        }
+
+        const text = extractInboundText(message.item_list) orelse continue;
+        const reply_target = try encodeReplyTarget(allocator, sender, message.context_token);
+        errdefer allocator.free(reply_target);
+
+        try messages.append(allocator, .{
+            .id = try buildInboundMessageId(allocator, message, sender),
+            .sender = try allocator.dupe(u8, sender),
+            .content = try allocator.dupe(u8, text),
+            .channel = "weixin",
+            .timestamp = message.create_time_ms orelse 0,
+            .reply_target = reply_target,
+            .message_id = if (message.message_id) |message_id| @intCast(message_id) else null,
+            .is_group = false,
+        });
+    }
+
+    return .{
+        .messages = try messages.toOwnedSlice(allocator),
+        .next_updates_buf = if (parsed.value.get_updates_buf) |next_updates_buf|
+            try allocator.dupe(u8, next_updates_buf)
+        else
+            null,
+        .longpolling_timeout_ms = parsed.value.longpolling_timeout_ms,
+    };
+}
+
+fn ensureApiResponseOk(allocator: std.mem.Allocator, body: []const u8) !void {
+    const trimmed = std.mem.trim(u8, body, " \t\r\n");
+    if (trimmed.len == 0 or std.mem.eql(u8, trimmed, "{}")) return;
+
+    const Response = struct {
+        ret: ?i64 = null,
+        errcode: ?i64 = null,
+    };
+
+    var parsed = std.json.parseFromSlice(Response, allocator, trimmed, .{
+        .ignore_unknown_fields = true,
+    }) catch return error.WeixinApiError;
+    defer parsed.deinit();
+
+    if (parsed.value.ret) |ret| {
+        if (ret != 0) return error.WeixinApiError;
+    }
+    if (parsed.value.errcode) |errcode| {
+        if (errcode != 0) return error.WeixinApiError;
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────
@@ -413,10 +810,69 @@ test "parseStatusResponse rejects missing status field" {
 test "appendSendMessagePayload builds correct JSON" {
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try appendSendMessagePayload(std.testing.allocator, &buf, "user123", "hello");
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"to_user\":\"user123\"") != null);
+    try appendSendMessagePayload(std.testing.allocator, &buf, "user123", "hello", "ctx-456");
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"to_user_id\":\"user123\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"text\":\"hello\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, CHANNEL_VERSION) != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"context_token\":\"ctx-456\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"msg\"") != null);
+}
+
+test "parseReplyTarget round trips embedded context token" {
+    const target = try encodeReplyTarget(std.testing.allocator, "user123", "ctx-456");
+    defer std.testing.allocator.free(target);
+
+    const parsed_target = parseReplyTarget(target);
+    try std.testing.expectEqualStrings("user123", parsed_target.user_id);
+    try std.testing.expectEqualStrings("ctx-456", parsed_target.context_token.?);
+}
+
+test "AuthHeaderSet includes bearer token" {
+    var headers = try AuthHeaderSet.init(std.testing.allocator, "token-123");
+    defer headers.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("AuthorizationType: ilink_bot_token", headers.headers[2]);
+    try std.testing.expect(std.mem.indexOf(u8, headers.headers[4], "Authorization: Bearer token-123") != null);
+    try std.testing.expect(std.mem.indexOf(u8, headers.headers[5], "X-WECHAT-UIN: ") != null);
+}
+
+test "parseGetUpdatesResponse extracts text message and context token" {
+    const json =
+        \\{"ret":0,"msgs":[{"message_id":42,"from_user_id":"user-123","create_time_ms":1712345678901,"context_token":"ctx-456","item_list":[{"type":1,"text_item":{"text":"hello from weixin"}}]}],"get_updates_buf":"next-buf"}
+    ;
+
+    var parsed = try parseGetUpdatesResponse(std.testing.allocator, json, &.{});
+    defer parsed.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), parsed.messages.len);
+    try std.testing.expectEqualStrings("user-123", parsed.messages[0].sender);
+    try std.testing.expectEqualStrings("hello from weixin", parsed.messages[0].content);
+    try std.testing.expectEqualStrings("next-buf", parsed.next_updates_buf.?);
+
+    const parsed_target = parseReplyTarget(parsed.messages[0].reply_target.?);
+    try std.testing.expectEqualStrings("user-123", parsed_target.user_id);
+    try std.testing.expectEqualStrings("ctx-456", parsed_target.context_token.?);
+}
+
+test "parseGetUpdatesResponse filters allow_from when configured" {
+    const json =
+        \\{"ret":0,"msgs":[{"from_user_id":"blocked","item_list":[{"type":1,"text_item":{"text":"nope"}}]},{"from_user_id":"allowed","item_list":[{"type":1,"text_item":{"text":"ok"}}]}]}
+    ;
+
+    var parsed = try parseGetUpdatesResponse(std.testing.allocator, json, &.{"allowed"});
+    defer parsed.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), parsed.messages.len);
+    try std.testing.expectEqualStrings("allowed", parsed.messages[0].sender);
+}
+
+test "weixin channel stores latest context token per user" {
+    var ch = WeixinChannel.init(std.testing.allocator, .{});
+    defer ch.deinit();
+
+    try ch.setContextToken("user-123", "ctx-old");
+    try ch.setContextToken("user-123", "ctx-new");
+    try std.testing.expectEqualStrings("ctx-new", ch.lookupContextToken("user-123").?);
 }
 
 test "buildUrl joins base and endpoint" {

--- a/src/channels/weixin.zig
+++ b/src/channels/weixin.zig
@@ -1,0 +1,449 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const root = @import("root.zig");
+const config_types = @import("../config_types.zig");
+const qr_mod = @import("../qr.zig");
+
+const ILINK_BASE_URL = "https://ilinkai.weixin.qq.com/";
+const ILINK_APP_ID = "bot";
+const ILINK_CLIENT_VERSION = "131329"; // 2.1.1 encoded as 0x00020101
+const CHANNEL_VERSION = "2.1.1";
+const QR_POLL_INTERVAL_NS: u64 = 2 * std.time.ns_per_s;
+const LOGIN_TIMEOUT_NS: u64 = 300 * std.time.ns_per_s;
+
+pub const WeixinChannel = struct {
+    allocator: std.mem.Allocator,
+    config: config_types.WeixinConfig,
+    running: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator, cfg: config_types.WeixinConfig) WeixinChannel {
+        return .{ .allocator = allocator, .config = cfg };
+    }
+
+    pub fn initFromConfig(allocator: std.mem.Allocator, cfg: config_types.WeixinConfig) WeixinChannel {
+        return init(allocator, cfg);
+    }
+
+    pub fn channelName(_: *WeixinChannel) []const u8 {
+        return "weixin";
+    }
+
+    pub fn healthCheck(self: *WeixinChannel) bool {
+        return self.running;
+    }
+
+    pub fn sendMessage(self: *WeixinChannel, target: []const u8, text: []const u8) !void {
+        if (target.len == 0) return error.InvalidTarget;
+        if (builtin.is_test) return;
+
+        const token = self.config.token;
+        if (token.len == 0) return error.WeixinMissingToken;
+
+        var payload: std.ArrayListUnmanaged(u8) = .empty;
+        defer payload.deinit(self.allocator);
+        try appendSendMessagePayload(self.allocator, &payload, target, text);
+
+        const url = try buildUrl(self.allocator, self.config.base_url, "ilink/bot/sendmessage");
+        defer self.allocator.free(url);
+
+        const headers = authHeaders(token);
+        const resp = root.http_util.curlPostWithStatus(
+            self.allocator,
+            url,
+            payload.items,
+            &headers,
+        ) catch return error.WeixinApiError;
+        defer self.allocator.free(resp.body);
+        if (resp.status_code < 200 or resp.status_code >= 300) return error.WeixinApiError;
+    }
+
+    fn vtableStart(ptr: *anyopaque) anyerror!void {
+        const self: *WeixinChannel = @ptrCast(@alignCast(ptr));
+        self.running = true;
+    }
+
+    fn vtableStop(ptr: *anyopaque) void {
+        const self: *WeixinChannel = @ptrCast(@alignCast(ptr));
+        self.running = false;
+    }
+
+    fn vtableSend(ptr: *anyopaque, target: []const u8, message: []const u8, _: []const []const u8) anyerror!void {
+        const self: *WeixinChannel = @ptrCast(@alignCast(ptr));
+        try self.sendMessage(target, message);
+    }
+
+    fn vtableName(ptr: *anyopaque) []const u8 {
+        const self: *WeixinChannel = @ptrCast(@alignCast(ptr));
+        return self.channelName();
+    }
+
+    fn vtableHealthCheck(ptr: *anyopaque) bool {
+        const self: *WeixinChannel = @ptrCast(@alignCast(ptr));
+        return self.healthCheck();
+    }
+
+    pub const vtable = root.Channel.VTable{
+        .start = &vtableStart,
+        .stop = &vtableStop,
+        .send = &vtableSend,
+        .name = &vtableName,
+        .healthCheck = &vtableHealthCheck,
+    };
+
+    pub fn channel(self: *WeixinChannel) root.Channel {
+        return .{ .ptr = @ptrCast(self), .vtable = &vtable };
+    }
+};
+
+// ── iLink API types ────────────────────────────────────────────────
+
+pub const QrCodeResponse = struct {
+    qrcode: []const u8 = "",
+    qrcode_img_content: []const u8 = "",
+};
+
+pub const StatusResponse = struct {
+    status: []const u8 = "",
+    bot_token: []const u8 = "",
+    ilink_bot_id: []const u8 = "",
+    baseurl: []const u8 = "",
+    ilink_user_id: []const u8 = "",
+    redirect_host: []const u8 = "",
+};
+
+pub const LoginResult = struct {
+    bot_token: []u8,
+    user_id: []u8,
+    account_id: []u8,
+    base_url: []u8,
+
+    pub fn deinit(self: *LoginResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.bot_token);
+        allocator.free(self.user_id);
+        allocator.free(self.account_id);
+        allocator.free(self.base_url);
+    }
+};
+
+pub const LoginOptions = struct {
+    base_url: []const u8 = ILINK_BASE_URL,
+    timeout_ns: u64 = LOGIN_TIMEOUT_NS,
+    proxy: ?[]const u8 = null,
+};
+
+// ── QR Login Flow ──────────────────────────────────────────────────
+
+pub fn performLogin(allocator: std.mem.Allocator, opts: LoginOptions) !LoginResult {
+    if (builtin.is_test) {
+        return LoginResult{
+            .bot_token = try allocator.dupe(u8, "test-bot-token"),
+            .user_id = try allocator.dupe(u8, "test-user-id"),
+            .account_id = try allocator.dupe(u8, "test-account-id"),
+            .base_url = try allocator.dupe(u8, "https://test.example.com/"),
+        };
+    }
+
+    const qr_resp = try requestQrCode(allocator, opts.base_url);
+    defer allocator.free(qr_resp.qrcode);
+    defer allocator.free(qr_resp.qrcode_img_content);
+
+    // Display QR code in terminal
+    try displayQrCode(qr_resp.qrcode_img_content);
+
+    // Poll for scan status
+    var poll_base_url: ?[]u8 = null;
+    defer if (poll_base_url) |u| allocator.free(u);
+    var scanned_printed = false;
+
+    const deadline = std.time.nanoTimestamp() + @as(i128, opts.timeout_ns);
+
+    while (std.time.nanoTimestamp() < deadline) {
+        std.Thread.sleep(QR_POLL_INTERVAL_NS);
+
+        const effective_base = if (poll_base_url) |u| u else opts.base_url;
+        const status_resp = pollQrStatus(allocator, effective_base, qr_resp.qrcode) catch continue;
+        defer {
+            allocator.free(status_resp.status);
+            allocator.free(status_resp.bot_token);
+            allocator.free(status_resp.ilink_bot_id);
+            allocator.free(status_resp.baseurl);
+            allocator.free(status_resp.ilink_user_id);
+            allocator.free(status_resp.redirect_host);
+        }
+
+        if (std.mem.eql(u8, status_resp.status, "wait")) {
+            continue;
+        } else if (std.mem.eql(u8, status_resp.status, "scaned")) {
+            if (!scanned_printed) {
+                std.debug.print("QR Code scanned! Please confirm login on your WeChat app...\n", .{});
+                scanned_printed = true;
+            }
+        } else if (std.mem.eql(u8, status_resp.status, "confirmed")) {
+            if (status_resp.bot_token.len == 0 or status_resp.ilink_bot_id.len == 0) {
+                return error.WeixinLoginMissingCredentials;
+            }
+            const result_base = if (status_resp.baseurl.len > 0)
+                try allocator.dupe(u8, status_resp.baseurl)
+            else
+                try allocator.dupe(u8, opts.base_url);
+            errdefer allocator.free(result_base);
+
+            return LoginResult{
+                .bot_token = try allocator.dupe(u8, status_resp.bot_token),
+                .user_id = try allocator.dupe(u8, status_resp.ilink_user_id),
+                .account_id = try allocator.dupe(u8, status_resp.ilink_bot_id),
+                .base_url = result_base,
+            };
+        } else if (std.mem.eql(u8, status_resp.status, "scaned_but_redirect")) {
+            if (status_resp.redirect_host.len > 0) {
+                const new_url = try std.fmt.allocPrint(allocator, "https://{s}/", .{status_resp.redirect_host});
+                if (poll_base_url) |old| allocator.free(old);
+                poll_base_url = new_url;
+                std.debug.print("Switched polling host to {s}\n", .{status_resp.redirect_host});
+            }
+        } else if (std.mem.eql(u8, status_resp.status, "expired")) {
+            return error.WeixinQrCodeExpired;
+        }
+    }
+
+    return error.WeixinLoginTimeout;
+}
+
+fn displayQrCode(url: []const u8) !void {
+    std.debug.print("\n=======================================================\n", .{});
+    std.debug.print("Please scan the following QR code with WeChat to login:\n", .{});
+    std.debug.print("=======================================================\n\n", .{});
+
+    const qr = qr_mod.encode(url) catch {
+        std.debug.print("(Could not generate QR code in terminal)\n", .{});
+        std.debug.print("QR Code Link: {s}\n\n", .{url});
+        return;
+    };
+
+    var buf: [8192]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    qr_mod.renderTerminal(&qr, fbs.writer()) catch {
+        std.debug.print("(Could not render QR code)\n", .{});
+        std.debug.print("QR Code Link: {s}\n\n", .{url});
+        return;
+    };
+
+    std.debug.print("{s}", .{fbs.getWritten()});
+    std.debug.print("\nQR Code Link: {s}\n\n", .{url});
+    std.debug.print("Waiting for scan...\n", .{});
+}
+
+// ── iLink API Client ───────────────────────────────────────────────
+
+fn ilinkHeaders() [2][]const u8 {
+    return .{
+        "iLink-App-Id: " ++ ILINK_APP_ID,
+        "iLink-App-ClientVersion: " ++ ILINK_CLIENT_VERSION,
+    };
+}
+
+fn authHeaders(token: []const u8) [5][]const u8 {
+    _ = token;
+    return .{
+        "iLink-App-Id: " ++ ILINK_APP_ID,
+        "iLink-App-ClientVersion: " ++ ILINK_CLIENT_VERSION,
+        "AuthorizationType: ilink_bot_token",
+        "Content-Type: application/json",
+        "X-WECHAT-UIN: MTIzNDU2Nzg5MA==",
+    };
+}
+
+fn buildUrl(allocator: std.mem.Allocator, base_url: []const u8, endpoint: []const u8) ![]u8 {
+    const base = std.mem.trimRight(u8, base_url, "/");
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ base, endpoint });
+}
+
+fn requestQrCode(allocator: std.mem.Allocator, base_url: []const u8) !struct { qrcode: []u8, qrcode_img_content: []u8 } {
+    const url = try std.fmt.allocPrint(allocator, "{s}ilink/bot/get_bot_qrcode?bot_type=3", .{
+        if (std.mem.endsWith(u8, base_url, "/")) base_url else blk: {
+            // base_url always ends with / from default
+            break :blk base_url;
+        },
+    });
+    defer allocator.free(url);
+
+    const headers = ilinkHeaders();
+    const resp_body = root.http_util.curlGet(allocator, url, &headers, "15") catch return error.WeixinApiError;
+    defer allocator.free(resp_body);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, resp_body, .{}) catch return error.WeixinApiError;
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return error.WeixinApiError;
+
+    const qrcode_val = parsed.value.object.get("qrcode") orelse return error.WeixinApiError;
+    const img_val = parsed.value.object.get("qrcode_img_content") orelse return error.WeixinApiError;
+
+    if (qrcode_val != .string or img_val != .string) return error.WeixinApiError;
+    if (qrcode_val.string.len == 0) return error.WeixinApiError;
+
+    return .{
+        .qrcode = try allocator.dupe(u8, qrcode_val.string),
+        .qrcode_img_content = try allocator.dupe(u8, img_val.string),
+    };
+}
+
+fn pollQrStatus(allocator: std.mem.Allocator, base_url: []const u8, qrcode: []const u8) !StatusResponse {
+    const base = if (std.mem.endsWith(u8, base_url, "/")) base_url else base_url;
+    const url = try std.fmt.allocPrint(allocator, "{s}ilink/bot/get_qrcode_status?qrcode={s}", .{ base, qrcode });
+    defer allocator.free(url);
+
+    const headers = ilinkHeaders();
+    const resp_body = root.http_util.curlGet(allocator, url, &headers, "30") catch return error.WeixinApiError;
+    defer allocator.free(resp_body);
+
+    return parseStatusResponse(allocator, resp_body);
+}
+
+pub fn parseStatusResponse(allocator: std.mem.Allocator, json_body: []const u8) !StatusResponse {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_body, .{}) catch return error.WeixinApiError;
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return error.WeixinApiError;
+    const obj = parsed.value.object;
+
+    const status = obj.get("status") orelse return error.WeixinApiError;
+    if (status != .string) return error.WeixinApiError;
+
+    return StatusResponse{
+        .status = try allocator.dupe(u8, status.string),
+        .bot_token = try dupeOptionalString(allocator, obj, "bot_token"),
+        .ilink_bot_id = try dupeOptionalString(allocator, obj, "ilink_bot_id"),
+        .baseurl = try dupeOptionalString(allocator, obj, "baseurl"),
+        .ilink_user_id = try dupeOptionalString(allocator, obj, "ilink_user_id"),
+        .redirect_host = try dupeOptionalString(allocator, obj, "redirect_host"),
+    };
+}
+
+fn dupeOptionalString(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key: []const u8) ![]u8 {
+    const val = obj.get(key) orelse return try allocator.dupe(u8, "");
+    if (val != .string) return try allocator.dupe(u8, "");
+    return try allocator.dupe(u8, val.string);
+}
+
+fn appendSendMessagePayload(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), to_user: []const u8, text: []const u8) !void {
+    const w = out.writer(allocator);
+    try w.writeAll("{\"base_info\":{\"channel_version\":\"" ++ CHANNEL_VERSION ++ "\"},\"to_user\":");
+    try root.appendJsonStringW(w, to_user);
+    try w.writeAll(",\"content_type\":\"text\",\"content\":{\"text\":");
+    try root.appendJsonStringW(w, text);
+    try w.writeAll("}}");
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test "weixin channel vtable contract" {
+    var ch = WeixinChannel.init(std.testing.allocator, .{});
+    try std.testing.expectEqualStrings("weixin", ch.channel().name());
+    try std.testing.expect(!ch.channel().healthCheck());
+
+    try ch.channel().start();
+    try std.testing.expect(ch.channel().healthCheck());
+
+    ch.channel().stop();
+    try std.testing.expect(!ch.channel().healthCheck());
+}
+
+test "parseStatusResponse parses wait status" {
+    const json =
+        \\{"status":"wait"}
+    ;
+    const resp = try parseStatusResponse(std.testing.allocator, json);
+    defer {
+        std.testing.allocator.free(resp.status);
+        std.testing.allocator.free(resp.bot_token);
+        std.testing.allocator.free(resp.ilink_bot_id);
+        std.testing.allocator.free(resp.baseurl);
+        std.testing.allocator.free(resp.ilink_user_id);
+        std.testing.allocator.free(resp.redirect_host);
+    }
+    try std.testing.expectEqualStrings("wait", resp.status);
+}
+
+test "parseStatusResponse parses confirmed status with credentials" {
+    const json =
+        \\{"status":"confirmed","bot_token":"tk_abc123","ilink_bot_id":"bot_456","ilink_user_id":"user_789","baseurl":"https://region.example.com/"}
+    ;
+    const resp = try parseStatusResponse(std.testing.allocator, json);
+    defer {
+        std.testing.allocator.free(resp.status);
+        std.testing.allocator.free(resp.bot_token);
+        std.testing.allocator.free(resp.ilink_bot_id);
+        std.testing.allocator.free(resp.baseurl);
+        std.testing.allocator.free(resp.ilink_user_id);
+        std.testing.allocator.free(resp.redirect_host);
+    }
+    try std.testing.expectEqualStrings("confirmed", resp.status);
+    try std.testing.expectEqualStrings("tk_abc123", resp.bot_token);
+    try std.testing.expectEqualStrings("bot_456", resp.ilink_bot_id);
+    try std.testing.expectEqualStrings("user_789", resp.ilink_user_id);
+    try std.testing.expectEqualStrings("https://region.example.com/", resp.baseurl);
+}
+
+test "parseStatusResponse parses scaned_but_redirect" {
+    const json =
+        \\{"status":"scaned_but_redirect","redirect_host":"region2.weixin.qq.com"}
+    ;
+    const resp = try parseStatusResponse(std.testing.allocator, json);
+    defer {
+        std.testing.allocator.free(resp.status);
+        std.testing.allocator.free(resp.bot_token);
+        std.testing.allocator.free(resp.ilink_bot_id);
+        std.testing.allocator.free(resp.baseurl);
+        std.testing.allocator.free(resp.ilink_user_id);
+        std.testing.allocator.free(resp.redirect_host);
+    }
+    try std.testing.expectEqualStrings("scaned_but_redirect", resp.status);
+    try std.testing.expectEqualStrings("region2.weixin.qq.com", resp.redirect_host);
+}
+
+test "parseStatusResponse rejects invalid JSON" {
+    try std.testing.expectError(error.WeixinApiError, parseStatusResponse(std.testing.allocator, "not json"));
+}
+
+test "parseStatusResponse rejects missing status field" {
+    try std.testing.expectError(error.WeixinApiError, parseStatusResponse(std.testing.allocator, "{}"));
+}
+
+test "appendSendMessagePayload builds correct JSON" {
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    try appendSendMessagePayload(std.testing.allocator, &buf, "user123", "hello");
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"to_user\":\"user123\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"text\":\"hello\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, CHANNEL_VERSION) != null);
+}
+
+test "buildUrl joins base and endpoint" {
+    const url = try buildUrl(std.testing.allocator, "https://example.com/", "ilink/bot/test");
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings("https://example.com/ilink/bot/test", url);
+}
+
+test "buildUrl handles base without trailing slash" {
+    const url = try buildUrl(std.testing.allocator, "https://example.com", "ilink/bot/test");
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings("https://example.com/ilink/bot/test", url);
+}
+
+test "performLogin returns test data in test mode" {
+    var result = try performLogin(std.testing.allocator, .{});
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("test-bot-token", result.bot_token);
+    try std.testing.expectEqualStrings("test-account-id", result.account_id);
+}
+
+test "sendMessage returns in test mode" {
+    var ch = WeixinChannel.init(std.testing.allocator, .{ .token = "test-token" });
+    try ch.sendMessage("target", "hello");
+}
+
+test "sendMessage rejects empty target" {
+    var ch = WeixinChannel.init(std.testing.allocator, .{ .token = "test-token" });
+    try std.testing.expectError(error.InvalidTarget, ch.sendMessage("", "hello"));
+}

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -594,6 +594,17 @@ pub const WeComConfig = struct {
     allow_from: []const []const u8 = &.{},
 };
 
+pub const WeixinConfig = struct {
+    account_id: []const u8 = "default",
+    /// Bot token obtained from iLink QR code login flow.
+    token: []const u8 = "",
+    /// iLink API base URL (may be region-specific after login redirect).
+    base_url: []const u8 = "https://ilinkai.weixin.qq.com/",
+    /// Optional HTTP proxy URL for API requests.
+    proxy: ?[]const u8 = null,
+    allow_from: []const []const u8 = &.{},
+};
+
 pub const SignalConfig = struct {
     account_id: []const u8 = "default",
     http_url: []const u8,
@@ -933,6 +944,7 @@ pub const ChannelsConfig = struct {
     dingtalk: []const DingTalkConfig = &.{},
     wechat: []const WeChatConfig = &.{},
     wecom: []const WeComConfig = &.{},
+    weixin: []const WeixinConfig = &.{},
     signal: []const SignalConfig = &.{},
     email: []const EmailConfig = &.{},
     line: []const LineConfig = &.{},
@@ -1000,6 +1012,9 @@ pub const ChannelsConfig = struct {
     }
     pub fn wecomPrimary(self: *const ChannelsConfig) ?WeComConfig {
         return primaryAccount(WeComConfig, self.wecom);
+    }
+    pub fn weixinPrimary(self: *const ChannelsConfig) ?WeixinConfig {
+        return primaryAccount(WeixinConfig, self.weixin);
     }
     pub fn emailPrimary(self: *const ChannelsConfig) ?EmailConfig {
         return primaryAccount(EmailConfig, self.email);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2940,10 +2940,16 @@ fn runAuth(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
     const codex = yc.providers.openai_codex;
     const auth_mod = yc.auth;
 
+    if (std.mem.eql(u8, provider_name, "weixin")) {
+        runAuthWeixin(allocator, subcmd, rest);
+        return;
+    }
+
     if (!std.mem.eql(u8, provider_name, "openai-codex")) {
         std.debug.print("Unknown auth provider: {s}\n\n", .{provider_name});
         std.debug.print("Available providers:\n", .{});
         std.debug.print("  openai-codex    ChatGPT Plus/Pro subscription (OAuth)\n", .{});
+        std.debug.print("  weixin          WeChat personal account (QR code scan)\n", .{});
         std.process.exit(1);
     }
 
@@ -3031,21 +3037,165 @@ fn printAuthUsage() void {
         \\Usage: nullclaw auth <{s}> <provider> [options]
         \\
         \\Commands:
-        \\  login <provider>                    Authenticate via device code flow
+        \\  login <provider>                    Authenticate with provider
         \\  login <provider> --import-codex     Import from Codex CLI (~/.codex/auth.json)
         \\  status <provider>                   Show authentication status
         \\  logout <provider>                   Remove stored credentials
         \\
         \\Providers:
         \\  openai-codex    ChatGPT Plus/Pro subscription (OAuth)
+        \\  weixin          WeChat personal account (QR code scan)
+        \\
+        \\Weixin options:
+        \\  --base-url <url>    iLink API base URL (default: https://ilinkai.weixin.qq.com/)
+        \\  --proxy <url>       HTTP proxy URL (e.g. http://localhost:7890)
+        \\  --timeout <secs>    Login timeout in seconds (default: 300)
         \\
         \\Examples:
         \\  nullclaw auth login openai-codex
         \\  nullclaw auth login openai-codex --import-codex
+        \\  nullclaw auth login weixin
+        \\  nullclaw auth login weixin --proxy http://localhost:7890
         \\  nullclaw auth status openai-codex
+        \\  nullclaw auth status weixin
         \\  nullclaw auth logout openai-codex
         \\
     , .{AUTH_SUBCOMMANDS}), .{});
+}
+
+fn runAuthWeixin(allocator: std.mem.Allocator, subcmd: []const u8, args: []const []const u8) void {
+    const weixin_mod = yc.channels.weixin;
+    const config_mutator = yc.config_mutator;
+
+    if (std.mem.eql(u8, subcmd, "login")) {
+        var opts = weixin_mod.LoginOptions{};
+
+        var i: usize = 0;
+        while (i < args.len) : (i += 1) {
+            if (std.mem.eql(u8, args[i], "--base-url") and i + 1 < args.len) {
+                i += 1;
+                opts.base_url = args[i];
+            } else if (std.mem.eql(u8, args[i], "--proxy") and i + 1 < args.len) {
+                i += 1;
+                opts.proxy = args[i];
+            } else if (std.mem.eql(u8, args[i], "--timeout") and i + 1 < args.len) {
+                i += 1;
+                const secs = std.fmt.parseInt(u64, args[i], 10) catch {
+                    std.debug.print("Invalid timeout value: {s}\n", .{args[i]});
+                    std.process.exit(1);
+                };
+                opts.timeout_ns = secs * std.time.ns_per_s;
+            } else {
+                std.debug.print("Unknown option: {s}\n", .{args[i]});
+                printAuthUsage();
+                std.process.exit(1);
+            }
+        }
+
+        std.debug.print("Starting Weixin (WeChat personal) login...\n\n", .{});
+
+        var result = weixin_mod.performLogin(allocator, opts) catch |err| {
+            std.debug.print("Weixin login failed: {s}\n", .{@errorName(err)});
+            std.process.exit(1);
+        };
+        defer result.deinit(allocator);
+
+        std.debug.print("\nLogin successful!\n", .{});
+        std.debug.print("  Account ID: {s}\n", .{result.account_id});
+        if (result.user_id.len > 0) {
+            std.debug.print("  User ID: {s}\n", .{result.user_id});
+        }
+
+        // Persist token to config
+        const token_json = std.fmt.allocPrint(allocator, "\"{s}\"", .{result.bot_token}) catch {
+            std.debug.print("\nCould not format token for config. Add manually:\n", .{});
+            printManualWeixinConfig(result.bot_token, result.base_url);
+            return;
+        };
+        defer allocator.free(token_json);
+
+        _ = config_mutator.mutateDefaultConfig(
+            allocator,
+            .set,
+            "channels.weixin.token",
+            token_json,
+            .{ .apply = true },
+        ) catch {
+            std.debug.print("\nCould not auto-save config. Add manually:\n", .{});
+            printManualWeixinConfig(result.bot_token, result.base_url);
+            return;
+        };
+
+        // Save base_url if it differs from default
+        if (!std.mem.eql(u8, result.base_url, "https://ilinkai.weixin.qq.com/")) {
+            const base_url_json = std.fmt.allocPrint(allocator, "\"{s}\"", .{result.base_url}) catch return;
+            defer allocator.free(base_url_json);
+            _ = config_mutator.mutateDefaultConfig(
+                allocator,
+                .set,
+                "channels.weixin.base_url",
+                base_url_json,
+                .{ .apply = true },
+            ) catch {};
+        }
+
+        std.debug.print("\nConfig updated. Start the gateway with:\n", .{});
+        std.debug.print("  nullclaw gateway\n\n", .{});
+        std.debug.print("To restrict which WeChat users can send messages, add their user IDs\n", .{});
+        std.debug.print("to channels.weixin.allow_from in your config.\n", .{});
+    } else if (std.mem.eql(u8, subcmd, "status")) {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        var cfg = yc.config.Config.load(arena.allocator()) catch {
+            std.debug.print("weixin: could not load config\n", .{});
+            return;
+        };
+        defer cfg.deinit();
+
+        if (cfg.channels.weixinPrimary()) |weixin_cfg| {
+            if (weixin_cfg.token.len > 0) {
+                std.debug.print("weixin: authenticated\n", .{});
+                std.debug.print("  Token: {s}...{s}\n", .{
+                    weixin_cfg.token[0..@min(8, weixin_cfg.token.len)],
+                    if (weixin_cfg.token.len > 8) weixin_cfg.token[weixin_cfg.token.len - 4 ..] else "",
+                });
+                std.debug.print("  Base URL: {s}\n", .{weixin_cfg.base_url});
+            } else {
+                std.debug.print("weixin: not authenticated (token empty)\n", .{});
+                std.debug.print("  Run `nullclaw auth login weixin` to authenticate.\n", .{});
+            }
+        } else {
+            std.debug.print("weixin: not configured\n", .{});
+            std.debug.print("  Run `nullclaw auth login weixin` to authenticate.\n", .{});
+        }
+    } else if (std.mem.eql(u8, subcmd, "logout")) {
+        _ = config_mutator.mutateDefaultConfig(
+            allocator,
+            .unset,
+            "channels.weixin.token",
+            null,
+            .{ .apply = true },
+        ) catch |err| {
+            std.debug.print("Failed to remove weixin credentials: {s}\n", .{@errorName(err)});
+            return;
+        };
+        std.debug.print("weixin: credentials removed.\n", .{});
+    } else {
+        std.debug.print("Unknown auth command: {s}\n\n", .{subcmd});
+        printAuthUsage();
+        std.process.exit(1);
+    }
+}
+
+fn printManualWeixinConfig(token: []const u8, base_url: []const u8) void {
+    std.debug.print("\nAdd the following to the channels section of your nullclaw config:\n\n", .{});
+    std.debug.print("  \"weixin\": [{{\n", .{});
+    std.debug.print("    \"token\": \"{s}\",\n", .{token});
+    if (!std.mem.eql(u8, base_url, "https://ilinkai.weixin.qq.com/")) {
+        std.debug.print("    \"base_url\": \"{s}\",\n", .{base_url});
+    }
+    std.debug.print("    \"allow_from\": []\n", .{});
+    std.debug.print("  }}]\n", .{});
 }
 
 fn runAuthDeviceCodeLogin(

--- a/src/qr.zig
+++ b/src/qr.zig
@@ -642,10 +642,11 @@ test "encode produces valid finder patterns" {
 
 test "renderTerminal produces output" {
     const qr = try encode("hello");
-    var buf = std.ArrayListUnmanaged(u8){ .items = &.{}, .capacity = 0 };
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
     defer buf.deinit(testing.allocator);
-    const writer = buf.writer(testing.allocator);
-    try renderTerminal(&qr, writer);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(testing.allocator, &buf);
+    try renderTerminal(&qr, &buf_writer.writer);
+    buf = buf_writer.toArrayList();
     try testing.expect(buf.items.len > 0);
     // Should contain newlines
     try testing.expect(std.mem.indexOf(u8, buf.items, "\n") != null);
@@ -681,10 +682,11 @@ test "encode and render weixin-length URL" {
     const qr = try encode(url);
     try testing.expect(qr.size >= 25);
 
-    var buf = std.ArrayListUnmanaged(u8){ .items = &.{}, .capacity = 0 };
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
     defer buf.deinit(testing.allocator);
-    const writer = buf.writer(testing.allocator);
-    try renderTerminal(&qr, writer);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(testing.allocator, &buf);
+    try renderTerminal(&qr, &buf_writer.writer);
+    buf = buf_writer.toArrayList();
     try testing.expect(buf.items.len > 100);
 }
 

--- a/src/qr.zig
+++ b/src/qr.zig
@@ -1,0 +1,699 @@
+const std = @import("std");
+const testing = std.testing;
+
+/// Minimal QR Code encoder (Model 2, Version 1–6, Error correction level L).
+/// Designed for encoding short URLs into terminal-renderable QR codes.
+const MAX_VERSION = 6;
+const MAX_MODULES = 17 + MAX_VERSION * 4; // Version 6 = 41 modules
+
+pub const QrCode = struct {
+    modules: [MAX_MODULES][MAX_MODULES]bool,
+    size: u8,
+
+    pub fn get(self: *const QrCode, row: usize, col: usize) bool {
+        return self.modules[row][col];
+    }
+};
+
+const VersionInfo = struct {
+    version: u8,
+    size: u8,
+    data_codewords: u16,
+    ec_codewords: u8,
+    num_blocks: u8,
+    alignment_center: ?u8,
+};
+
+const version_table = [6]VersionInfo{
+    .{ .version = 1, .size = 21, .data_codewords = 19, .ec_codewords = 7, .num_blocks = 1, .alignment_center = null },
+    .{ .version = 2, .size = 25, .data_codewords = 34, .ec_codewords = 10, .num_blocks = 1, .alignment_center = 18 },
+    .{ .version = 3, .size = 29, .data_codewords = 55, .ec_codewords = 15, .num_blocks = 1, .alignment_center = 22 },
+    .{ .version = 4, .size = 33, .data_codewords = 80, .ec_codewords = 20, .num_blocks = 1, .alignment_center = 26 },
+    .{ .version = 5, .size = 37, .data_codewords = 108, .ec_codewords = 26, .num_blocks = 1, .alignment_center = 30 },
+    .{ .version = 6, .size = 41, .data_codewords = 136, .ec_codewords = 18, .num_blocks = 2, .alignment_center = 34 },
+};
+
+fn selectVersion(data_len: usize) !VersionInfo {
+    for (version_table) |v| {
+        const capacity = v.data_codewords - 3;
+        if (data_len <= capacity) return v;
+    }
+    return error.DataTooLong;
+}
+
+pub fn encode(data: []const u8) !QrCode {
+    const ver = try selectVersion(data.len);
+    var qr = QrCode{ .modules = std.mem.zeroes([MAX_MODULES][MAX_MODULES]bool), .size = ver.size };
+    var reserved = std.mem.zeroes([MAX_MODULES][MAX_MODULES]bool);
+
+    placeFunctionPatterns(&qr, &reserved, ver);
+    placeTimingPatterns(&qr, &reserved, ver);
+    reserveFormatArea(&reserved, ver);
+
+    const total_codewords = ver.data_codewords + @as(u16, ver.ec_codewords) * @as(u16, ver.num_blocks);
+    var codewords: [256]u8 = undefined;
+    const data_cw = buildDataCodewords(data, ver, &codewords);
+    buildEcCodewords(data_cw, ver, &codewords);
+
+    placeDataBits(&qr, &reserved, codewords[0..total_codewords], ver.size);
+
+    const best_mask = selectBestMask(&qr, &reserved, ver);
+    applyMask(&qr, &reserved, best_mask, ver.size);
+    placeFormatBits(&qr, best_mask, ver.size);
+
+    return qr;
+}
+
+fn placeFunctionPatterns(qr: *QrCode, reserved: *[MAX_MODULES][MAX_MODULES]bool, ver: VersionInfo) void {
+    placeFinderPattern(qr, reserved, 0, 0, ver.size);
+    placeFinderPattern(qr, reserved, 0, ver.size - 7, ver.size);
+    placeFinderPattern(qr, reserved, ver.size - 7, 0, ver.size);
+
+    if (ver.alignment_center) |center| {
+        placeAlignmentPattern(qr, reserved, center, center);
+    }
+}
+
+fn placeFinderPattern(qr: *QrCode, reserved: *[MAX_MODULES][MAX_MODULES]bool, row: u8, col: u8, size: u8) void {
+    const finder = [7][7]bool{
+        .{ true, true, true, true, true, true, true },
+        .{ true, false, false, false, false, false, true },
+        .{ true, false, true, true, true, false, true },
+        .{ true, false, true, true, true, false, true },
+        .{ true, false, true, true, true, false, true },
+        .{ true, false, false, false, false, false, true },
+        .{ true, true, true, true, true, true, true },
+    };
+
+    for (0..7) |r| {
+        for (0..7) |c| {
+            const rr = row + @as(u8, @intCast(r));
+            const cc = col + @as(u8, @intCast(c));
+            qr.modules[rr][cc] = finder[r][c];
+            reserved[rr][cc] = true;
+        }
+    }
+
+    // Separators
+    for (0..8) |i| {
+        const ii = @as(u8, @intCast(i));
+        // Horizontal
+        if (row == 0) {
+            if (col + 7 < size) {
+                setReserved(reserved, 7, col + ii);
+            }
+            if (col >= 1) {
+                setReserved(reserved, 7, col -| 1);
+            } else if (col == 0 and ii < 8) {
+                setReserved(reserved, 7, ii);
+            }
+        } else {
+            if (col + 7 < size) {
+                setReserved(reserved, row -| 1, col + ii);
+            }
+            if (col == 0) {
+                setReserved(reserved, row -| 1, ii);
+            }
+        }
+        // Vertical
+        if (col == 0) {
+            if (row == 0 and ii < 8) {
+                setReserved(reserved, ii, 7);
+            } else if (row > 0) {
+                setReserved(reserved, row + ii, 7);
+                if (row >= 1 and ii == 0) setReserved(reserved, row -| 1, 7);
+            }
+        }
+        if (col + 7 < size) {
+            // already handled
+        }
+    }
+
+    // Simpler approach: mark 8x8 area + separators as reserved
+    const r_start = if (row == 0) 0 else row -| 1;
+    const r_end: u8 = @min(row + 8, size);
+    const c_start = if (col == 0) 0 else col -| 1;
+    const c_end: u8 = @min(col + 8, size);
+
+    var r: u8 = r_start;
+    while (r < r_end) : (r += 1) {
+        var c: u8 = c_start;
+        while (c < c_end) : (c += 1) {
+            reserved[r][c] = true;
+        }
+    }
+}
+
+fn setReserved(reserved: *[MAX_MODULES][MAX_MODULES]bool, r: u8, c: u8) void {
+    reserved[r][c] = true;
+}
+
+fn placeAlignmentPattern(qr: *QrCode, reserved: *[MAX_MODULES][MAX_MODULES]bool, center_row: u8, center_col: u8) void {
+    const pattern = [5][5]bool{
+        .{ true, true, true, true, true },
+        .{ true, false, false, false, true },
+        .{ true, false, true, false, true },
+        .{ true, false, false, false, true },
+        .{ true, true, true, true, true },
+    };
+
+    for (0..5) |r| {
+        for (0..5) |c| {
+            const rr = center_row - 2 + @as(u8, @intCast(r));
+            const cc = center_col - 2 + @as(u8, @intCast(c));
+            qr.modules[rr][cc] = pattern[r][c];
+            reserved[rr][cc] = true;
+        }
+    }
+}
+
+fn placeTimingPatterns(qr: *QrCode, reserved: *[MAX_MODULES][MAX_MODULES]bool, ver: VersionInfo) void {
+    for (8..ver.size - 8) |i| {
+        const val = (i % 2 == 0);
+        if (!reserved[6][i]) {
+            qr.modules[6][i] = val;
+            reserved[6][i] = true;
+        }
+        if (!reserved[i][6]) {
+            qr.modules[i][6] = val;
+            reserved[i][6] = true;
+        }
+    }
+}
+
+fn reserveFormatArea(reserved: *[MAX_MODULES][MAX_MODULES]bool, ver: VersionInfo) void {
+    for (0..9) |i| {
+        reserved[8][i] = true;
+        reserved[i][8] = true;
+    }
+    for (0..8) |i| {
+        reserved[8][ver.size - 1 - @as(u8, @intCast(i))] = true;
+        reserved[ver.size - 1 - @as(u8, @intCast(i))][8] = true;
+    }
+    // Dark module
+    reserved[ver.size - 8][8] = true;
+}
+
+fn buildDataCodewords(data: []const u8, ver: VersionInfo, out: *[256]u8) []u8 {
+    var bits: BitWriter = .{};
+
+    // Byte mode indicator: 0100
+    bits.writeBits(4, 4);
+
+    // Character count (8 bits for v1-9 in byte mode)
+    bits.writeBits(@intCast(data.len), 8);
+
+    // Data
+    for (data) |byte| {
+        bits.writeBits(byte, 8);
+    }
+
+    // Terminator (up to 4 zeros)
+    const data_bits: u16 = @as(u16, ver.data_codewords) * 8;
+    const remaining = data_bits -| bits.bit_count;
+    const term_bits: u4 = @intCast(@min(remaining, 4));
+    bits.writeBits(0, term_bits);
+
+    // Pad to byte boundary
+    while (bits.bit_count % 8 != 0) {
+        bits.writeBits(0, 1);
+    }
+
+    // Pad codewords: 0xEC, 0x11 alternating
+    var pad_toggle: bool = true;
+    while (bits.bit_count < data_bits) {
+        bits.writeBits(if (pad_toggle) 0xEC else 0x11, 8);
+        pad_toggle = !pad_toggle;
+    }
+
+    const byte_count = bits.bit_count / 8;
+    @memcpy(out[0..byte_count], bits.buffer[0..byte_count]);
+    return out[0..byte_count];
+}
+
+fn buildEcCodewords(data: []const u8, ver: VersionInfo, out: *[256]u8) void {
+    if (ver.num_blocks == 1) {
+        const ec = gfPolyDivide(data, ver.ec_codewords);
+        @memcpy(out[data.len .. data.len + ver.ec_codewords], ec[0..ver.ec_codewords]);
+    } else {
+        // Version 6 has 2 blocks. Split data evenly.
+        const block_size = data.len / ver.num_blocks;
+        const extra = data.len % ver.num_blocks;
+
+        var ec_all: [2][26]u8 = undefined;
+        var block_data: [2][]const u8 = undefined;
+        var offset: usize = 0;
+
+        for (0..ver.num_blocks) |b| {
+            const sz = block_size + (if (b < extra) @as(usize, 1) else 0);
+            block_data[b] = data[offset .. offset + sz];
+            const ec = gfPolyDivide(block_data[b], ver.ec_codewords);
+            @memcpy(ec_all[b][0..ver.ec_codewords], ec[0..ver.ec_codewords]);
+            offset += sz;
+        }
+
+        // Interleave data codewords
+        var write_pos: usize = 0;
+        const max_block_sz = block_size + (if (extra > 0) @as(usize, 1) else 0);
+        for (0..max_block_sz) |i| {
+            for (0..ver.num_blocks) |b| {
+                const sz = block_size + (if (b < extra) @as(usize, 1) else 0);
+                if (i < sz) {
+                    out[write_pos] = block_data[b][i];
+                    write_pos += 1;
+                }
+            }
+        }
+
+        // Interleave EC codewords
+        for (0..ver.ec_codewords) |i| {
+            for (0..ver.num_blocks) |b| {
+                out[write_pos] = ec_all[b][i];
+                write_pos += 1;
+            }
+        }
+    }
+}
+
+fn placeDataBits(qr: *QrCode, reserved: *const [MAX_MODULES][MAX_MODULES]bool, codewords: []const u8, size: u8) void {
+    var bit_idx: usize = 0;
+    const total_bits = codewords.len * 8;
+
+    var col_: i16 = @as(i16, size) - 1;
+    while (col_ >= 1) {
+        var col = @as(u8, @intCast(col_));
+        if (col == 6) col = 5; // Skip vertical timing column
+
+        const right_col = col;
+        const left_col = col - 1;
+        if (left_col == 6) {
+            col_ -= 1; // handled: skip timing
+        }
+
+        const col_group = @divTrunc(@as(i16, size) - 1 - col_, 2);
+        var row_: i16 = if (@mod(col_group, 2) == 0) @as(i16, size) - 1 else 0;
+        const row_step: i2 = if (@mod(col_group, 2) == 0) -1 else 1;
+
+        while (row_ >= 0 and row_ < size) {
+            const row = @as(u8, @intCast(row_));
+            // Right column
+            if (!reserved[row][right_col]) {
+                if (bit_idx < total_bits) {
+                    qr.modules[row][right_col] = ((codewords[bit_idx / 8] >> @intCast(7 - (bit_idx % 8))) & 1) == 1;
+                    bit_idx += 1;
+                }
+            }
+            // Left column
+            const lc = if (right_col > 0) right_col - 1 else break;
+            if (lc != 6 and !reserved[row][lc]) {
+                if (bit_idx < total_bits) {
+                    qr.modules[row][lc] = ((codewords[bit_idx / 8] >> @intCast(7 - (bit_idx % 8))) & 1) == 1;
+                    bit_idx += 1;
+                }
+            }
+
+            row_ += row_step;
+        }
+
+        col_ -= 2;
+    }
+}
+
+fn applyMask(qr: *QrCode, reserved: *const [MAX_MODULES][MAX_MODULES]bool, mask: u3, size: u8) void {
+    for (0..size) |r| {
+        for (0..size) |c| {
+            if (reserved[r][c]) continue;
+            if (maskBit(mask, r, c)) {
+                qr.modules[r][c] = !qr.modules[r][c];
+            }
+        }
+    }
+}
+
+fn maskBit(mask: u3, row: usize, col: usize) bool {
+    return switch (mask) {
+        0 => (row + col) % 2 == 0,
+        1 => row % 2 == 0,
+        2 => col % 3 == 0,
+        3 => (row + col) % 3 == 0,
+        4 => (row / 2 + col / 3) % 2 == 0,
+        5 => (row * col) % 2 + (row * col) % 3 == 0,
+        6 => ((row * col) % 2 + (row * col) % 3) % 2 == 0,
+        7 => ((row + col) % 2 + (row * col) % 3) % 2 == 0,
+    };
+}
+
+fn selectBestMask(qr: *QrCode, reserved: *const [MAX_MODULES][MAX_MODULES]bool, ver: VersionInfo) u3 {
+    var best_mask: u3 = 0;
+    var best_penalty: u32 = std.math.maxInt(u32);
+
+    for (0..8) |m| {
+        const mask: u3 = @intCast(m);
+        var trial = qr.*;
+        applyMask(&trial, reserved, mask, ver.size);
+        placeFormatBits(&trial, mask, ver.size);
+        const penalty = evaluatePenalty(&trial, ver.size);
+        if (penalty < best_penalty) {
+            best_penalty = penalty;
+            best_mask = mask;
+        }
+    }
+
+    return best_mask;
+}
+
+fn evaluatePenalty(qr: *const QrCode, size: u8) u32 {
+    var penalty: u32 = 0;
+
+    // Rule 1: runs of same color >= 5
+    for (0..size) |r| {
+        var run: u32 = 1;
+        for (1..size) |c| {
+            if (qr.modules[r][c] == qr.modules[r][c - 1]) {
+                run += 1;
+            } else {
+                if (run >= 5) penalty += run - 2;
+                run = 1;
+            }
+        }
+        if (run >= 5) penalty += run - 2;
+    }
+    for (0..size) |c| {
+        var run: u32 = 1;
+        for (1..size) |r| {
+            if (qr.modules[r][c] == qr.modules[r - 1][c]) {
+                run += 1;
+            } else {
+                if (run >= 5) penalty += run - 2;
+                run = 1;
+            }
+        }
+        if (run >= 5) penalty += run - 2;
+    }
+
+    // Rule 2: 2x2 blocks
+    for (0..size - 1) |r| {
+        for (0..size - 1) |c| {
+            const v = qr.modules[r][c];
+            if (v == qr.modules[r][c + 1] and v == qr.modules[r + 1][c] and v == qr.modules[r + 1][c + 1]) {
+                penalty += 3;
+            }
+        }
+    }
+
+    // Rule 4: proportion of dark modules
+    var dark: u32 = 0;
+    const total: u32 = @as(u32, size) * @as(u32, size);
+    for (0..size) |r| {
+        for (0..size) |c| {
+            if (qr.modules[r][c]) dark += 1;
+        }
+    }
+    const pct = (dark * 100) / total;
+    const prev5 = (pct / 5) * 5;
+    const next5 = prev5 + 5;
+    const d1 = if (prev5 >= 50) prev5 - 50 else 50 - prev5;
+    const d2 = if (next5 >= 50) next5 - 50 else 50 - next5;
+    penalty += @min(d1, d2) * 2;
+
+    return penalty;
+}
+
+const FORMAT_BITS_TABLE = [8]u15{
+    0x77C4, // mask 0, ECC L
+    0x72F3, // mask 1
+    0x7DAA, // mask 2
+    0x789D, // mask 3
+    0x662F, // mask 4
+    0x6318, // mask 5
+    0x6C41, // mask 6
+    0x6976, // mask 7
+};
+
+fn placeFormatBits(qr: *QrCode, mask: u3, size: u8) void {
+    const fmt_bits = FORMAT_BITS_TABLE[mask];
+
+    // Around top-left finder
+    const positions_h = [15]u8{ 0, 1, 2, 3, 4, 5, 7, 8, 8, 8, 8, 8, 8, 8, 8 };
+    const positions_v = [15]u8{ 8, 8, 8, 8, 8, 8, 8, 8, 7, 5, 4, 3, 2, 1, 0 };
+
+    for (0..15) |i| {
+        const bit = ((fmt_bits >> @intCast(14 - i)) & 1) == 1;
+        if (i < 8) {
+            qr.modules[positions_v[i]][positions_h[i]] = bit;
+        } else {
+            qr.modules[positions_v[i]][positions_h[i]] = bit;
+        }
+    }
+
+    // Along bottom-left and top-right
+    for (0..7) |i| {
+        const bit = ((fmt_bits >> @intCast(14 - i)) & 1) == 1;
+        qr.modules[size - 1 - @as(u8, @intCast(i))][8] = bit;
+    }
+    for (0..8) |i| {
+        const bit = ((fmt_bits >> @intCast(7 - i)) & 1) == 1;
+        qr.modules[8][size - 8 + @as(u8, @intCast(i))] = bit;
+    }
+
+    // Dark module (always set)
+    qr.modules[size - 8][8] = true;
+}
+
+// ── GF(2^8) arithmetic for Reed-Solomon ────────────────────────────
+
+const GF_EXP = blk: {
+    var table: [512]u8 = undefined;
+    var x: u16 = 1;
+    for (0..255) |i| {
+        table[i] = @intCast(x);
+        x <<= 1;
+        if (x >= 256) x ^= 0x11D;
+    }
+    for (255..512) |i| {
+        table[i] = table[i - 255];
+    }
+    break :blk table;
+};
+
+const GF_LOG = blk: {
+    var table: [256]u8 = undefined;
+    table[0] = 0;
+    for (0..255) |i| {
+        table[GF_EXP[i]] = @intCast(i);
+    }
+    break :blk table;
+};
+
+fn gfMul(a: u8, b: u8) u8 {
+    if (a == 0 or b == 0) return 0;
+    return GF_EXP[@as(u16, GF_LOG[a]) + @as(u16, GF_LOG[b])];
+}
+
+fn gfPolyDivide(data: []const u8, ec_len: u8) [26]u8 {
+    const gen = generatorPoly(ec_len);
+    var remainder: [256]u8 = std.mem.zeroes([256]u8);
+    @memcpy(remainder[0..data.len], data);
+
+    for (0..data.len) |i| {
+        const coef = remainder[i];
+        if (coef != 0) {
+            for (0..ec_len) |j| {
+                remainder[i + 1 + j] ^= gfMul(gen[j], coef);
+            }
+        }
+    }
+
+    var result: [26]u8 = undefined;
+    @memcpy(result[0..ec_len], remainder[data.len .. data.len + ec_len]);
+    return result;
+}
+
+fn generatorPoly(degree: u8) [26]u8 {
+    var poly: [27]u8 = std.mem.zeroes([27]u8);
+    poly[0] = 1;
+    var poly_len: usize = 1;
+
+    for (0..degree) |i| {
+        // Multiply by (x - alpha^i)
+        var j: usize = poly_len;
+        while (j > 0) : (j -= 1) {
+            poly[j] = poly[j - 1] ^ gfMul(poly[j], GF_EXP[i]);
+        }
+        poly[0] = gfMul(poly[0], GF_EXP[i]);
+        poly_len += 1;
+    }
+
+    // Return coefficients excluding leading 1
+    var result: [26]u8 = undefined;
+    @memcpy(result[0..degree], poly[0..degree]);
+    return result;
+}
+
+// ── Bit Writer ─────────────────────────────────────────────────────
+
+const BitWriter = struct {
+    buffer: [256]u8 = std.mem.zeroes([256]u8),
+    bit_count: u16 = 0,
+
+    fn writeBits(self: *BitWriter, value: u32, count: u4) void {
+        var i: u4 = count;
+        while (i > 0) {
+            i -= 1;
+            const byte_idx = self.bit_count / 8;
+            const bit_pos: u3 = @intCast(7 - (self.bit_count % 8));
+            if (((value >> i) & 1) == 1) {
+                self.buffer[byte_idx] |= @as(u8, 1) << bit_pos;
+            }
+            self.bit_count += 1;
+        }
+    }
+};
+
+// ── Terminal Rendering ─────────────────────────────────────────────
+
+/// Render QR code to terminal using Unicode half-block characters.
+/// Each character cell represents two rows of modules.
+/// Uses inverted colors (dark on light) for better scanability on dark terminals.
+pub fn renderTerminal(qr: *const QrCode, writer: anytype) !void {
+    const size: usize = qr.size;
+    const quiet = 1;
+
+    // Top quiet zone
+    for (0..quiet) |_| {
+        for (0..size + quiet * 2) |_| {
+            try writer.writeAll("\u{2588}");
+        }
+        try writer.writeAll("\n");
+    }
+
+    var row: usize = 0;
+    while (row < size) {
+        // Left quiet zone
+        for (0..quiet) |_| {
+            try writer.writeAll("\u{2588}");
+        }
+
+        for (0..size) |col| {
+            const top = qr.get(row, col);
+            const bottom = if (row + 1 < size) qr.get(row + 1, col) else false;
+
+            if (top and bottom) {
+                try writer.writeAll(" ");
+            } else if (top and !bottom) {
+                try writer.writeAll("\u{2584}"); // ▄
+            } else if (!top and bottom) {
+                try writer.writeAll("\u{2580}"); // ▀
+            } else {
+                try writer.writeAll("\u{2588}"); // █
+            }
+        }
+
+        // Right quiet zone
+        for (0..quiet) |_| {
+            try writer.writeAll("\u{2588}");
+        }
+        try writer.writeAll("\n");
+
+        row += 2;
+    }
+
+    // Bottom quiet zone (if odd number of rows, we need the remainder)
+    for (0..quiet) |_| {
+        for (0..size + quiet * 2) |_| {
+            try writer.writeAll("\u{2588}");
+        }
+        try writer.writeAll("\n");
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test "encode short string selects version 1" {
+    const qr = try encode("01234");
+    try testing.expectEqual(@as(u8, 21), qr.size);
+}
+
+test "encode medium URL selects appropriate version" {
+    const qr = try encode("https://example.com/test");
+    try testing.expect(qr.size >= 21);
+    try testing.expect(qr.size <= 41);
+}
+
+test "encode returns error for data too long" {
+    const long = "A" ** 200;
+    try testing.expectError(error.DataTooLong, encode(long));
+}
+
+test "encode produces valid finder patterns" {
+    const qr = try encode("test");
+    // Top-left finder: 7x7 pattern with specific dark/light pattern
+    try testing.expect(qr.modules[0][0] == true);
+    try testing.expect(qr.modules[0][6] == true);
+    try testing.expect(qr.modules[6][0] == true);
+    try testing.expect(qr.modules[6][6] == true);
+    // Inner white ring
+    try testing.expect(qr.modules[1][1] == false);
+    try testing.expect(qr.modules[1][5] == false);
+    // Inner black square
+    try testing.expect(qr.modules[2][2] == true);
+    try testing.expect(qr.modules[4][4] == true);
+}
+
+test "renderTerminal produces output" {
+    const qr = try encode("hello");
+    var buf = std.ArrayListUnmanaged(u8){ .items = &.{}, .capacity = 0 };
+    defer buf.deinit(testing.allocator);
+    const writer = buf.writer(testing.allocator);
+    try renderTerminal(&qr, writer);
+    try testing.expect(buf.items.len > 0);
+    // Should contain newlines
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\n") != null);
+}
+
+test "GF multiply identity" {
+    try testing.expectEqual(@as(u8, 0), gfMul(0, 100));
+    try testing.expectEqual(@as(u8, 0), gfMul(100, 0));
+    try testing.expectEqual(@as(u8, 1), gfMul(1, 1));
+}
+
+test "BitWriter writes correct bits" {
+    var bw = BitWriter{};
+    bw.writeBits(0b0100, 4);
+    bw.writeBits(5, 8);
+    try testing.expectEqual(@as(u16, 12), bw.bit_count);
+    try testing.expectEqual(@as(u8, 0b0100_0000), bw.buffer[0]);
+    try testing.expectEqual(@as(u8, 0b0101_0000), bw.buffer[1]);
+}
+
+test "version selection capacity" {
+    // Version 1 byte mode: 19 - 3 = 16 bytes
+    const v1 = try selectVersion(16);
+    try testing.expectEqual(@as(u8, 1), v1.version);
+
+    // Version 2 needed for 17+ bytes
+    const v2 = try selectVersion(17);
+    try testing.expectEqual(@as(u8, 2), v2.version);
+}
+
+test "encode and render weixin-length URL" {
+    const url = "https://ilinkai.weixin.qq.com/some/path?token=abcdef1234567890";
+    const qr = try encode(url);
+    try testing.expect(qr.size >= 25);
+
+    var buf = std.ArrayListUnmanaged(u8){ .items = &.{}, .capacity = 0 };
+    defer buf.deinit(testing.allocator);
+    const writer = buf.writer(testing.allocator);
+    try renderTerminal(&qr, writer);
+    try testing.expect(buf.items.len > 100);
+}
+
+test "deterministic encoding" {
+    const qr1 = try encode("deterministic");
+    const qr2 = try encode("deterministic");
+    for (0..qr1.size) |r| {
+        for (0..qr1.size) |c| {
+            try testing.expectEqual(qr1.modules[r][c], qr2.modules[r][c]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `weixin` channel integration for iLink-based WeChat personal account access
- implement terminal QR generation/rendering and interactive login polling flow for `nullclaw auth login weixin`
- wire config/catalog/auth CLI support so `weixin` tokens can be saved, inspected, and removed

## Test plan
- [x] `zig build`
- [x] `zig build test --summary all`
- [x] `zig fmt src/qr.zig`

Made with [Cursor](https://cursor.com)