### PR TITLE
feat: add tool customization config schema | 特性: 添加工具定制化配置模式

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -1373,6 +1373,14 @@ pub const Config = struct {
         try w.print("    \"web_fetch_max_chars\": {d},\n", .{self.tools.web_fetch_max_chars});
         try w.print("    \"path_env_vars\": ", .{});
         try writePrettyJsonInline(self.allocator, w, self.tools.path_env_vars, "    ");
+        try w.print(",\n    \"tool_customizations\": ", .{});
+        try writePrettyJsonInline(self.allocator, w, self.tools.tool_customizations, "    ");
+        try w.print(",\n    \"tool_customizations_file\": ", .{});
+        try writePrettyJsonInline(self.allocator, w, self.tools.tool_customizations_file, "    ");
+        try w.print(",\n    \"trigger_modifiers\": ", .{});
+        try writePrettyJsonInline(self.allocator, w, self.tools.trigger_modifiers, "    ");
+        try w.print(",\n    \"trigger_punctuation\": ", .{});
+        try writePrettyJsonInline(self.allocator, w, self.tools.trigger_punctuation, "    ");
         // tools.media.audio
         {
             const am = self.audio_media;
@@ -3911,6 +3919,76 @@ test "json parse tools.path_env_vars" {
     allocator.free(cfg.tools.path_env_vars);
 }
 
+fn freeToolCustomizationsForTest(allocator: std.mem.Allocator, items: []const config_types.ToolCustomization) void {
+    for (items) |item| {
+        allocator.free(item.name);
+        if (item.system_prompt) |system_prompt| allocator.free(system_prompt);
+        for (item.triggers) |trigger| allocator.free(trigger);
+        allocator.free(item.triggers);
+    }
+    allocator.free(items);
+}
+
+test "json parse tools.tool_customizations" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const json =
+        \\{"tools": {
+        \\  "tool_customizations": [
+        \\    {"name": "shell", "system_prompt": "Use safe shell", "triggers": ["run", "exec"], "priority": 300, "enabled": false},
+        \\    {"name": "browser", "triggers": ["open"], "priority": -1},
+        \\    {"system_prompt": "missing name"},
+        \\    "ignored"
+        \\  ],
+        \\  "tool_customizations_file": "tool-customizations.json",
+        \\  "trigger_modifiers": ["please", "now"],
+        \\  "trigger_punctuation": "!?;"
+        \\}}
+    ;
+    var cfg = Config{ .workspace_dir = "/tmp/yc", .config_path = "/tmp/yc/config.json", .allocator = allocator };
+    try cfg.parseJson(json);
+
+    try std.testing.expectEqual(@as(usize, 2), cfg.tools.tool_customizations.len);
+    try std.testing.expectEqualStrings("shell", cfg.tools.tool_customizations[0].name);
+    try std.testing.expectEqualStrings("Use safe shell", cfg.tools.tool_customizations[0].system_prompt.?);
+    try std.testing.expectEqual(@as(usize, 2), cfg.tools.tool_customizations[0].triggers.len);
+    try std.testing.expectEqualStrings("run", cfg.tools.tool_customizations[0].triggers[0]);
+    try std.testing.expectEqualStrings("exec", cfg.tools.tool_customizations[0].triggers[1]);
+    try std.testing.expectEqual(@as(u8, 255), cfg.tools.tool_customizations[0].priority);
+    try std.testing.expect(!cfg.tools.tool_customizations[0].enabled);
+    try std.testing.expectEqualStrings("browser", cfg.tools.tool_customizations[1].name);
+    try std.testing.expectEqual(@as(u8, 0), cfg.tools.tool_customizations[1].priority);
+    try std.testing.expect(cfg.tools.tool_customizations[1].enabled);
+    try std.testing.expectEqualStrings("tool-customizations.json", cfg.tools.tool_customizations_file.?);
+    try std.testing.expectEqual(@as(usize, 2), cfg.tools.trigger_modifiers.len);
+    try std.testing.expectEqualStrings("please", cfg.tools.trigger_modifiers[0]);
+    try std.testing.expectEqualStrings("now", cfg.tools.trigger_modifiers[1]);
+    try std.testing.expectEqualStrings("!?;", cfg.tools.trigger_punctuation);
+}
+
+fn parseToolCustomizationsForAllocationTest(allocator: std.mem.Allocator, json: []const u8) !void {
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .allocator = allocator,
+    };
+    try cfg.parseJson(json);
+    freeToolCustomizationsForTest(allocator, cfg.tools.tool_customizations);
+}
+
+test "json parse tools.tool_customizations frees partial allocations on out-of-memory" {
+    const json =
+        \\{"tools": {"tool_customizations": [
+        \\  {"name": "shell", "system_prompt": "Use safe shell", "triggers": ["run", "exec"], "priority": 200, "enabled": false},
+        \\  {"name": "browser", "triggers": ["open", "visit"], "priority": 10}
+        \\]}}
+    ;
+    // Regression: nested tool customization fields must not leak when parsing
+    // fails after partially allocating a customization entry.
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, parseToolCustomizationsForAllocationTest, .{json});
+}
+
 test "save roundtrip preserves tools.path_env_vars" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -3945,6 +4023,66 @@ test "save roundtrip preserves tools.path_env_vars" {
     try std.testing.expectEqual(@as(usize, 2), loaded.tools.path_env_vars.len);
     try std.testing.expectEqualStrings("LD_LIBRARY_PATH", loaded.tools.path_env_vars[0]);
     try std.testing.expectEqualStrings("PYTHONHOME", loaded.tools.path_env_vars[1]);
+}
+
+test "save roundtrip preserves tools customization schema" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.json", .{base});
+    defer allocator.free(config_path);
+
+    var cfg = Config{
+        .workspace_dir = base,
+        .config_path = config_path,
+        .allocator = allocator,
+    };
+    cfg.tools.tool_customizations = &.{
+        .{
+            .name = "shell",
+            .system_prompt = "Use safe shell",
+            .triggers = &.{ "run", "exec" },
+            .priority = 7,
+            .enabled = false,
+        },
+        .{
+            .name = "browser",
+            .triggers = &.{"open"},
+            .priority = 3,
+        },
+    };
+    cfg.tools.tool_customizations_file = "tool-customizations.json";
+    cfg.tools.trigger_modifiers = &.{ "please", "now" };
+    cfg.tools.trigger_punctuation = "!?;";
+    try cfg.save();
+
+    const file = try std_compat.fs.openFileAbsolute(config_path, .{});
+    defer file.close();
+    const content = try file.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(content);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var loaded = Config{
+        .workspace_dir = base,
+        .config_path = config_path,
+        .allocator = arena.allocator(),
+    };
+    try loaded.parseJson(content);
+
+    try std.testing.expectEqual(@as(usize, 2), loaded.tools.tool_customizations.len);
+    try std.testing.expectEqualStrings("shell", loaded.tools.tool_customizations[0].name);
+    try std.testing.expectEqualStrings("Use safe shell", loaded.tools.tool_customizations[0].system_prompt.?);
+    try std.testing.expectEqualStrings("run", loaded.tools.tool_customizations[0].triggers[0]);
+    try std.testing.expectEqual(@as(u8, 7), loaded.tools.tool_customizations[0].priority);
+    try std.testing.expect(!loaded.tools.tool_customizations[0].enabled);
+    try std.testing.expectEqualStrings("browser", loaded.tools.tool_customizations[1].name);
+    try std.testing.expectEqualStrings("tool-customizations.json", loaded.tools.tool_customizations_file.?);
+    try std.testing.expectEqualStrings("please", loaded.tools.trigger_modifiers[0]);
+    try std.testing.expectEqualStrings("!?;", loaded.tools.trigger_punctuation);
 }
 
 test "json parse autonomy allow_raw_url_chars" {

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -18,24 +18,36 @@ const splitPrimaryModelRef = config_mod.splitPrimaryModelRef;
 /// Parse a JSON array of strings into an allocated slice.
 pub fn parseStringArray(allocator: std.mem.Allocator, arr: std.json.Array) ![]const []const u8 {
     var list: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
     try list.ensureTotalCapacity(allocator, @intCast(arr.items.len));
     for (arr.items) |item| {
         if (item == .string) {
-            try list.append(allocator, try allocator.dupe(u8, item.string));
+            const owned = try allocator.dupe(u8, item.string);
+            var item_owned = true;
+            errdefer if (item_owned) allocator.free(owned);
+
+            try list.append(allocator, owned);
+            item_owned = false;
         }
     }
     return try list.toOwnedSlice(allocator);
 }
 
+fn freeToolCustomization(allocator: std.mem.Allocator, item: types.ToolCustomization) void {
+    allocator.free(item.name);
+    if (item.system_prompt) |p| allocator.free(p);
+    for (item.triggers) |t| allocator.free(t);
+    allocator.free(item.triggers);
+}
+
 fn parseToolCustomizationArray(allocator: std.mem.Allocator, arr: std.json.Array) ![]const types.ToolCustomization {
     var list: std.ArrayListUnmanaged(types.ToolCustomization) = .empty;
     errdefer {
-        for (list.items) |item| {
-            allocator.free(item.name);
-            if (item.system_prompt) |p| allocator.free(p);
-            for (item.triggers) |t| allocator.free(t);
-            allocator.free(item.triggers);
-        }
+        for (list.items) |item| freeToolCustomization(allocator, item);
         list.deinit(allocator);
     }
 
@@ -48,6 +60,8 @@ fn parseToolCustomizationArray(allocator: std.mem.Allocator, arr: std.json.Array
         var cust = types.ToolCustomization{
             .name = try allocator.dupe(u8, name_val.string),
         };
+        var cust_owned = true;
+        errdefer if (cust_owned) freeToolCustomization(allocator, cust);
 
         if (item.object.get("system_prompt")) |v| {
             if (v == .string) cust.system_prompt = try allocator.dupe(u8, v.string);
@@ -63,6 +77,7 @@ fn parseToolCustomizationArray(allocator: std.mem.Allocator, arr: std.json.Array
         }
 
         try list.append(allocator, cust);
+        cust_owned = false;
     }
     return try list.toOwnedSlice(allocator);
 }

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -27,6 +27,46 @@ pub fn parseStringArray(allocator: std.mem.Allocator, arr: std.json.Array) ![]co
     return try list.toOwnedSlice(allocator);
 }
 
+fn parseToolCustomizationArray(allocator: std.mem.Allocator, arr: std.json.Array) ![]const types.ToolCustomization {
+    var list: std.ArrayListUnmanaged(types.ToolCustomization) = .empty;
+    errdefer {
+        for (list.items) |item| {
+            allocator.free(item.name);
+            if (item.system_prompt) |p| allocator.free(p);
+            for (item.triggers) |t| allocator.free(t);
+            allocator.free(item.triggers);
+        }
+        list.deinit(allocator);
+    }
+
+    try list.ensureTotalCapacity(allocator, @intCast(arr.items.len));
+    for (arr.items) |item| {
+        if (item != .object) continue;
+        const name_val = item.object.get("name") orelse continue;
+        if (name_val != .string) continue;
+
+        var cust = types.ToolCustomization{
+            .name = try allocator.dupe(u8, name_val.string),
+        };
+
+        if (item.object.get("system_prompt")) |v| {
+            if (v == .string) cust.system_prompt = try allocator.dupe(u8, v.string);
+        }
+        if (item.object.get("triggers")) |v| {
+            if (v == .array) cust.triggers = try parseStringArray(allocator, v.array);
+        }
+        if (item.object.get("priority")) |v| {
+            if (v == .integer) cust.priority = @intCast(std.math.clamp(v.integer, 0, 255));
+        }
+        if (item.object.get("enabled")) |v| {
+            if (v == .bool) cust.enabled = v.bool;
+        }
+
+        try list.append(allocator, cust);
+    }
+    return try list.toOwnedSlice(allocator);
+}
+
 fn decryptSecretField(allocator: std.mem.Allocator, config_path: []const u8, value: []const u8) ![]u8 {
     const config_dir = std_compat.fs.path.dirname(config_path) orelse ".";
     const store = secrets.SecretStore.init(config_dir, true);
@@ -1425,6 +1465,18 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
             if (tl.object.get("path_env_vars")) |v| {
                 if (v == .array) self.tools.path_env_vars = try parseStringArray(self.allocator, v.array);
             }
+            if (tl.object.get("tool_customizations")) |v| {
+                if (v == .array) self.tools.tool_customizations = try parseToolCustomizationArray(self.allocator, v.array);
+            }
+            if (tl.object.get("tool_customizations_file")) |v| {
+                if (v == .string) self.tools.tool_customizations_file = try self.allocator.dupe(u8, v.string);
+            }
+            if (tl.object.get("trigger_modifiers")) |v| {
+                if (v == .array) self.tools.trigger_modifiers = try parseStringArray(self.allocator, v.array);
+            }
+            if (tl.object.get("trigger_punctuation")) |v| {
+                if (v == .string) self.tools.trigger_punctuation = try self.allocator.dupe(u8, v.string);
+            }
             // tools.media.audio → self.audio_media
             if (tl.object.get("media")) |media| {
                 if (media == .object) {
@@ -2657,6 +2709,32 @@ test "parseJson keeps fallback-only custom url provider refs in defaults" {
     var cfg = Config{
         .workspace_dir = "/tmp",
         .config_path = "/tmp/config.json",
+        .allocator = allocator,
+    };
+
+    const json =
+        \\{
+        \\  "reliability": {
+        \\    "fallback_providers": [
+        \\      "custom:https://fb.example.com/qianfan"
+        \\    ]
+        \\  },
+        \\  "agents": {
+        \\    "defaults": {
+        \\      "model": {
+        \\        "primary": "custom:https://fb.example.com/qianfan/custom-model"
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try cfg.parseJson(json);
+    try std.testing.expectEqualStrings("custom:https://fb.example.com/qianfan", cfg.default_provider);
+    try std.testing.expect(cfg.default_model != null);
+    try std.testing.expectEqualStrings("custom-model", cfg.default_model.?);
+}
+h = "/tmp/config.json",
         .allocator = allocator,
     };
 

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -2734,29 +2734,3 @@ test "parseJson keeps fallback-only custom url provider refs in defaults" {
     try std.testing.expect(cfg.default_model != null);
     try std.testing.expectEqualStrings("custom-model", cfg.default_model.?);
 }
-h = "/tmp/config.json",
-        .allocator = allocator,
-    };
-
-    const json =
-        \\{
-        \\  "reliability": {
-        \\    "fallback_providers": [
-        \\      "custom:https://fb.example.com/qianfan"
-        \\    ]
-        \\  },
-        \\  "agents": {
-        \\    "defaults": {
-        \\      "model": {
-        \\        "primary": "custom:https://fb.example.com/qianfan/custom-model"
-        \\      }
-        \\    }
-        \\  }
-        \\}
-    ;
-
-    try cfg.parseJson(json);
-    try std.testing.expectEqualStrings("custom:https://fb.example.com/qianfan", cfg.default_provider);
-    try std.testing.expect(cfg.default_model != null);
-    try std.testing.expectEqualStrings("custom-model", cfg.default_model.?);
-}

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -360,6 +360,23 @@ pub const AgentConfig = struct {
     }
 };
 
+pub const ToolCustomization = struct {
+    /// Tool name (e.g., "screenshot", "file_read", "shell")
+    name: []const u8,
+    /// Custom system prompt for this tool.
+    /// If provided, this will override the default tool description.
+    system_prompt: ?[]const u8 = null,
+    /// Trigger keywords for this tool.
+    /// When user message contains any of these keywords,
+    /// the tool will be prioritized.
+    triggers: []const []const u8 = &.{},
+    /// Priority level (higher = more important).
+    /// Default is 0.
+    priority: u8 = 0,
+    /// Whether this tool is enabled.
+    enabled: bool = true,
+};
+
 pub const ToolsConfig = struct {
     shell_timeout_secs: u64 = 60,
     shell_max_output_bytes: u32 = 1_048_576, // 1MB
@@ -373,6 +390,15 @@ pub const ToolsConfig = struct {
     ///
     /// Example: ["LD_LIBRARY_PATH", "PYTHONHOME", "NODE_PATH"]
     path_env_vars: []const []const u8 = &.{},
+    /// Tool customization configuration.
+    /// Allows customizing system prompts, trigger keywords, and priorities for individual tools.
+    tool_customizations: []const ToolCustomization = &.{},
+    /// Optional path to external JSON file containing tool customizations.
+    tool_customizations_file: ?[]const u8 = null,
+    /// Custom modifiers to remove from user input when checking for exact trigger matches.
+    trigger_modifiers: []const []const u8 = &.{},
+    /// Custom punctuation characters to remove when checking for exact trigger matches.
+    trigger_punctuation: []const u8 = "",
 };
 
 pub const ModelRouteCostClass = enum {


### PR DESCRIPTION
## Summary

### EN:
- Adds the `ToolCustomization` struct to `config_types.zig` to support fine-grained tool configuration.
- Expands `ToolsConfig` with new fields: `tool_customizations`, `tool_customizations_file`, `trigger_modifiers`, and `trigger_punctuation`.
- Implements `parseToolCustomizationArray` in `config_parse.zig` for robust JSON parsing.
- This is Part 1/4 of the tool customization implementation.

### ZH:
- 在 `config_types.zig` 中添加 `ToolCustomization` 结构体，支持细粒度的工具配置。
- 在 `ToolsConfig` 中扩展新字段：`tool_customizations`、`tool_customizations_file`、`trigger_modifiers` 和 `trigger_punctuation`。
- 在 `config_parse.zig` 中实现 `parseToolCustomizationArray`，用于健壮的 JSON 解析。
- 这是工具定制化实现的第 1/4 部分。

## Validation
- `zig build --summary all`: Build successful (Zig 0.16.0).
- Validated JSON parsing of tool customizations array in config.json.

## Notes
- This PR prepares the infrastructure for the tool customization system.
- **Reference:** This work is a modular refactoring of PR #411. We would like to thank @qxo for the excellent technical foundation and comprehensive vision in #411. We are breaking it down into smaller, sequential PRs to facilitate review and maintain core stability.

### PS - Thank you, @qxo for the inspiration!