### PR TITLE
feat(matrix): add pantalaimon E2EE proxy support | 特性(matrix): 添加 pantalaimon E2EE 代理支持

### DIFF
--- a/src/channel_probe.zig
+++ b/src/channel_probe.zig
@@ -171,6 +171,10 @@ fn trimTrailingSlash(value: []const u8) []const u8 {
     return out;
 }
 
+fn matrixApiBase(cfg: std.json.ObjectMap, homeserver: []const u8) []const u8 {
+    return trimTrailingSlash(optionalString(cfg, "pantalaimon_proxy_url") orelse homeserver);
+}
+
 fn timeoutString(buf: []u8, timeout_secs: u64) []const u8 {
     return std.fmt.bufPrint(buf, "{d}", .{timeout_secs}) catch "10";
 }
@@ -397,7 +401,7 @@ fn probeMatrix(
     _ = nonEmptyString(cfg, "room_id") orelse return fail(channel, account, "missing_room_id");
     const access_token = nonEmptyString(cfg, "access_token") orelse return fail(channel, account, "missing_access_token");
 
-    const base = trimTrailingSlash(homeserver);
+    const base = matrixApiBase(cfg, homeserver);
     const url = std.fmt.allocPrint(allocator, "{s}/_matrix/client/v3/account/whoami", .{base}) catch {
         return fail(channel, account, "probe_setup_failed");
     };
@@ -1171,6 +1175,26 @@ test "allocOneBotApiBase normalizes websocket schemes" {
     const wss_base = try allocOneBotApiBase(allocator, "wss://onebot.example/ws");
     defer allocator.free(wss_base);
     try std.testing.expectEqualStrings("https://onebot.example/ws", wss_base);
+}
+
+test "matrixApiBase uses pantalaimon proxy when configured" {
+    const allocator = std.testing.allocator;
+    const payload =
+        \\{
+        \\  "homeserver": "https://matrix.example/",
+        \\  "pantalaimon_proxy_url": "http://127.0.0.1:8008/"
+        \\}
+    ;
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{ .allocate = .alloc_always });
+    defer parsed.deinit();
+
+    // Regression: Matrix channel health probes must route through Pantalaimon
+    // instead of bypassing E2EE via the homeserver URL.
+    try std.testing.expectEqualStrings(
+        "http://127.0.0.1:8008",
+        matrixApiBase(parsed.value.object, "https://matrix.example/"),
+    );
 }
 
 test "oneBotResponseLooksHealthy validates retcode and status" {

--- a/src/channels/matrix.zig
+++ b/src/channels/matrix.zig
@@ -820,7 +820,7 @@ test "MatrixChannel initFromConfig falls back to homeserver when proxy is null" 
     try std.testing.expectEqualStrings("https://matrix.example", ch.effective_endpoint);
 }
 
-test "MatrixChannel buildSyncUrl uses effective_endpoint" {
+test "MatrixChannel URL builders use effective_endpoint" {
     var ch = MatrixChannel.initFromConfig(std.testing.allocator, .{
         .homeserver = "https://matrix.example/",
         .access_token = "tok",
@@ -829,8 +829,23 @@ test "MatrixChannel buildSyncUrl uses effective_endpoint" {
         .pantalaimon_proxy_url = "http://localhost:8008",
     });
     var buf: [512]u8 = undefined;
-    const url = try ch.buildSyncUrl(&buf);
-    try std.testing.expect(std.mem.startsWith(u8, url, "http://localhost:8008/_matrix/"));
+
+    // Regression: every Matrix Client-Server API URL must route through
+    // Pantalaimon when the proxy endpoint is configured.
+    const whoami_url = try ch.buildWhoAmIUrl(&buf);
+    try std.testing.expect(std.mem.startsWith(u8, whoami_url, "http://localhost:8008/_matrix/"));
+
+    const sync_url = try ch.buildSyncUrl(&buf);
+    try std.testing.expect(std.mem.startsWith(u8, sync_url, "http://localhost:8008/_matrix/"));
+
+    const send_url = try ch.buildSendUrl(&buf, "!room:example", "txn-1");
+    try std.testing.expect(std.mem.startsWith(u8, send_url, "http://localhost:8008/_matrix/"));
+
+    const typing_url = try ch.buildTypingUrl(&buf, "!room:example", "@bot:example");
+    try std.testing.expect(std.mem.startsWith(u8, typing_url, "http://localhost:8008/_matrix/"));
+
+    const join_url = try ch.buildJoinUrl(&buf, "!room:example");
+    try std.testing.expect(std.mem.startsWith(u8, join_url, "http://localhost:8008/_matrix/"));
 }
 
 test "MatrixChannel buildTypingUrl encodes room and user ids" {

--- a/src/channels/matrix.zig
+++ b/src/channels/matrix.zig
@@ -24,6 +24,9 @@ pub const MatrixChannel = struct {
     dm_policy: []const u8,
     group_policy: []const u8,
     require_mention: bool = false,
+    /// Effective API endpoint: pantalaimon proxy URL when E2EE is enabled,
+    /// otherwise equals homeserver. All Matrix API requests use this.
+    effective_endpoint: []const u8 = "",
     running: bool = false,
 
     next_batch_buf: [1024]u8 = undefined,
@@ -39,9 +42,11 @@ pub const MatrixChannel = struct {
         room_id: []const u8,
         allow_from: []const []const u8,
     ) MatrixChannel {
+        const hs = stripTrailingSlashes(homeserver);
         return .{
             .allocator = allocator,
-            .homeserver = stripTrailingSlashes(homeserver),
+            .homeserver = hs,
+            .effective_endpoint = hs,
             .access_token = access_token,
             .room_id = room_id,
             .allow_from = allow_from,
@@ -59,6 +64,9 @@ pub const MatrixChannel = struct {
         ch.dm_policy = cfg.dm_policy;
         ch.group_policy = cfg.group_policy;
         ch.require_mention = cfg.require_mention;
+        if (cfg.pantalaimon_proxy_url) |proxy| {
+            ch.effective_endpoint = stripTrailingSlashes(proxy);
+        }
         return ch;
     }
 
@@ -84,14 +92,14 @@ pub const MatrixChannel = struct {
 
     fn buildWhoAmIUrl(self: *const MatrixChannel, buf: []u8) ![]const u8 {
         var w: std.Io.Writer = .fixed(buf);
-        try w.writeAll(self.homeserver);
+        try w.writeAll(self.effective_endpoint);
         try w.writeAll("/_matrix/client/v3/account/whoami");
         return w.buffered();
     }
 
     fn buildSyncUrl(self: *const MatrixChannel, buf: []u8) ![]const u8 {
         var w: std.Io.Writer = .fixed(buf);
-        try w.writeAll(self.homeserver);
+        try w.writeAll(self.effective_endpoint);
         try w.writeAll("/_matrix/client/v3/sync?timeout=30000");
         if (self.next_batch_len > 0) {
             try w.writeAll("&since=");
@@ -102,7 +110,7 @@ pub const MatrixChannel = struct {
 
     fn buildSendUrl(self: *const MatrixChannel, buf: []u8, room_id: []const u8, txn_id: []const u8) ![]const u8 {
         var w: std.Io.Writer = .fixed(buf);
-        try w.writeAll(self.homeserver);
+        try w.writeAll(self.effective_endpoint);
         try w.writeAll("/_matrix/client/v3/rooms/");
         try appendUrlEncoded(&w, room_id);
         try w.writeAll("/send/m.room.message/");
@@ -112,7 +120,7 @@ pub const MatrixChannel = struct {
 
     fn buildTypingUrl(self: *const MatrixChannel, buf: []u8, room_id: []const u8, user_id: []const u8) ![]const u8 {
         var w: std.Io.Writer = .fixed(buf);
-        try w.writeAll(self.homeserver);
+        try w.writeAll(self.effective_endpoint);
         try w.writeAll("/_matrix/client/v3/rooms/");
         try appendUrlEncoded(&w, room_id);
         try w.writeAll("/typing/");
@@ -122,7 +130,7 @@ pub const MatrixChannel = struct {
 
     fn buildJoinUrl(self: *const MatrixChannel, buf: []u8, room_id: []const u8) ![]const u8 {
         var w: std.Io.Writer = .fixed(buf);
-        try w.writeAll(self.homeserver);
+        try w.writeAll(self.effective_endpoint);
         try w.writeAll("/_matrix/client/v3/rooms/");
         try appendUrlEncoded(&w, room_id);
         try w.writeAll("/join");
@@ -784,6 +792,45 @@ test "MatrixChannel initFromConfig maps account and policy fields" {
     try std.testing.expect(ch.require_mention);
     try std.testing.expectEqual(@as(usize, 1), ch.allow_from.len);
     try std.testing.expectEqual(@as(usize, 1), ch.group_allow_from.len);
+    try std.testing.expectEqualStrings("https://matrix.example", ch.effective_endpoint);
+}
+
+test "MatrixChannel initFromConfig routes through pantalaimon when proxy is set" {
+    const cfg = config_types.MatrixConfig{
+        .homeserver = "https://matrix.example/",
+        .access_token = "tok",
+        .room_id = "!room:example",
+        .allow_from = &.{"*"},
+        .pantalaimon_proxy_url = "http://localhost:8008/",
+    };
+    const ch = MatrixChannel.initFromConfig(std.testing.allocator, cfg);
+    try std.testing.expectEqualStrings("https://matrix.example", ch.homeserver);
+    try std.testing.expectEqualStrings("http://localhost:8008", ch.effective_endpoint);
+}
+
+test "MatrixChannel initFromConfig falls back to homeserver when proxy is null" {
+    const cfg = config_types.MatrixConfig{
+        .homeserver = "https://matrix.example/",
+        .access_token = "tok",
+        .room_id = "!room:example",
+        .allow_from = &.{"*"},
+        .pantalaimon_proxy_url = null,
+    };
+    const ch = MatrixChannel.initFromConfig(std.testing.allocator, cfg);
+    try std.testing.expectEqualStrings("https://matrix.example", ch.effective_endpoint);
+}
+
+test "MatrixChannel buildSyncUrl uses effective_endpoint" {
+    var ch = MatrixChannel.initFromConfig(std.testing.allocator, .{
+        .homeserver = "https://matrix.example/",
+        .access_token = "tok",
+        .room_id = "!room:example",
+        .allow_from = &.{"*"},
+        .pantalaimon_proxy_url = "http://localhost:8008",
+    });
+    var buf: [512]u8 = undefined;
+    const url = try ch.buildSyncUrl(&buf);
+    try std.testing.expect(std.mem.startsWith(u8, url, "http://localhost:8008/_matrix/"));
 }
 
 test "MatrixChannel buildTypingUrl encodes room and user ids" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -6160,7 +6160,7 @@ test "parse irc accounts" {
 test "parse matrix accounts" {
     const allocator = std.testing.allocator;
     const json =
-        \\{"channels": {"matrix": {"accounts": {"main": {"homeserver": "https://matrix.org", "access_token": "syt_abc", "room_id": "!room:matrix.org", "user_id": "@bot:matrix.org", "group_allow_from": ["@alice:matrix.org"], "dm_policy": "open", "group_policy": "open", "require_mention": true}}}}}
+        \\{"channels": {"matrix": {"accounts": {"main": {"homeserver": "https://matrix.org", "access_token": "syt_abc", "room_id": "!room:matrix.org", "user_id": "@bot:matrix.org", "group_allow_from": ["@alice:matrix.org"], "dm_policy": "open", "group_policy": "open", "require_mention": true, "pantalaimon_proxy_url": "http://127.0.0.1:8008"}}}}}
     ;
     var cfg = Config{ .workspace_dir = "/tmp/yc", .config_path = "/tmp/yc/config.json", .allocator = allocator };
     try cfg.parseJson(json);
@@ -6176,6 +6176,9 @@ test "parse matrix accounts" {
     try std.testing.expect(mc.require_mention);
     try std.testing.expectEqual(@as(usize, 1), mc.group_allow_from.len);
     try std.testing.expectEqualStrings("@alice:matrix.org", mc.group_allow_from[0]);
+    // Regression: Pantalaimon config must survive JSON parsing before
+    // MatrixChannel can route E2EE traffic through the proxy.
+    try std.testing.expectEqualStrings("http://127.0.0.1:8008", mc.pantalaimon_proxy_url.?);
     allocator.free(mc.account_id);
     allocator.free(mc.homeserver);
     allocator.free(mc.access_token);
@@ -6183,6 +6186,7 @@ test "parse matrix accounts" {
     allocator.free(mc.user_id.?);
     allocator.free(mc.dm_policy);
     allocator.free(mc.group_policy);
+    allocator.free(mc.pantalaimon_proxy_url.?);
     for (mc.group_allow_from) |entry| allocator.free(entry);
     allocator.free(mc.group_allow_from);
     allocator.free(cfg.channels.matrix);

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -574,6 +574,11 @@ pub const MatrixConfig = struct {
     dm_policy: []const u8 = "allowlist",
     group_policy: []const u8 = "allowlist",
     require_mention: bool = false,
+    /// Optional pantalaimon E2EE proxy URL (e.g. "http://localhost:8008").
+    /// When set, all Matrix API requests are routed through the proxy instead
+    /// of directly to the homeserver. The homeserver field is still required
+    /// for display and onboarding purposes.
+    pantalaimon_proxy_url: ?[]const u8 = null,
 };
 
 pub const MattermostConfig = struct {

--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -1636,6 +1636,10 @@ fn configureMatrixChannel(cfg: *Config, out: *std.Io.Writer, _: []u8, prefix: []
     try out.print("{s}  Matrix user ID (optional, for typing indicators): ", .{prefix});
     const user_id = prompt(out, &user_id_buf, "", "") orelse return false;
 
+    var pantalaimon_buf: [512]u8 = undefined;
+    try out.print("{s}  Pantalaimon proxy URL for E2EE (optional, e.g. http://localhost:8008): ", .{prefix});
+    const pantalaimon = prompt(out, &pantalaimon_buf, "", "") orelse return false;
+
     const accounts = try cfg.allocator.alloc(config_mod.MatrixConfig, 1);
     accounts[0] = .{
         .account_id = "default",
@@ -1643,10 +1647,12 @@ fn configureMatrixChannel(cfg: *Config, out: *std.Io.Writer, _: []u8, prefix: []
         .access_token = try cfg.allocator.dupe(u8, access_token),
         .room_id = try cfg.allocator.dupe(u8, room_id),
         .user_id = if (user_id.len > 0) try cfg.allocator.dupe(u8, user_id) else null,
+        .pantalaimon_proxy_url = if (pantalaimon.len > 0) try cfg.allocator.dupe(u8, pantalaimon) else null,
         .allow_from = &[_][]const u8{"*"},
     };
     cfg.channels.matrix = accounts;
-    try out.print("{s}  -> Matrix configured (allow_from=*)\n", .{prefix});
+    const e2ee_note: []const u8 = if (pantalaimon.len > 0) " + E2EE via pantalaimon" else "";
+    try out.print("{s}  -> Matrix configured (allow_from=*{s})\n", .{ prefix, e2ee_note });
     return true;
 }
 


### PR DESCRIPTION
## Summary

### EN:
- Adds an optional `pantalaimon_proxy_url` field to `MatrixConfig` in `config_types.zig`.
- Introduces `effective_endpoint` field in `MatrixChannel`; when a pantalaimon proxy URL is configured, all five Matrix API URL builders (`buildWhoAmIUrl`, `buildSyncUrl`, `buildSendUrl`, `buildTypingUrl`, `buildJoinUrl`) route through the proxy instead of directly to the homeserver.
- `initFromConfig` resolves `effective_endpoint` at construction time: proxy URL when set, homeserver otherwise. No runtime branching per request.
- Adds an interactive pantalaimon prompt to the Matrix onboarding wizard (`onboard.zig`), with a confirmation note in the output line when E2EE is enabled.
- 4 new tests covering proxy routing, fallback-to-homeserver, and URL generation through the proxy.

### ZH:
- 在 `config_types.zig` 的 `MatrixConfig` 中添加可选字段 `pantalaimon_proxy_url`。
- 在 `MatrixChannel` 中引入 `effective_endpoint` 字段；当配置了 pantalaimon 代理 URL 时，五个 Matrix API URL 构建函数（`buildWhoAmIUrl`、`buildSyncUrl`、`buildSendUrl`、`buildTypingUrl`、`buildJoinUrl`）均通过代理路由，而不直接访问 homeserver。
- `initFromConfig` 在构建时解析 `effective_endpoint`：如果设置了代理 URL 则使用代理，否则回退到 homeserver。每次请求时无运行时分支判断。
- 在 Matrix 引导向导（`onboard.zig`）中添加交互式 pantalaimon 提示，并在 E2EE 启用时于确认输出行中显示提示。
- 新增 4 个测试，覆盖代理路由、回退到 homeserver 及通过代理生成 URL 的场景。

## Validation
- `zig build --summary all`: Build successful (Zig 0.16.0).
- `zig build test --test-timeout 10s --summary all`: 6655/6673 tests passed (13 skipped, 5 timed out — all Redis integration tests requiring a live Redis instance, pre-existing).
- Verified `effective_endpoint` resolves to proxy URL when `pantalaimon_proxy_url` is set, and falls back to `homeserver` when null.

## Notes
- **No cryptographic code added.** Pantalaimon is a transparent local proxy that speaks the standard Matrix Client-Server API v3; the channel requires zero protocol changes beyond pointing at a different base URL.
- **Backward compatible.** `pantalaimon_proxy_url` defaults to `null`; all existing configs continue to work without modification.
- **Why not libolm bindings?** The project's two-dependency constraint and binary size target make vendoring libolm impractical at this stage. The pantalaimon approach delivers E2EE to users today with no binary size impact.

Closes #209