### PR TITLE
feat(skills): support nested skill discovery in category subdirectories | 特性(skills): 支持在分类子目录中发现技能

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,7 +860,7 @@ Implement a vtable interface, submit a PR:
 - New `Tunnel` -> `src/tunnel.zig`
 - New `Sandbox` backend -> `src/security/`
 - New `Peripheral` -> `src/peripherals.zig`
-- New `Skill` -> `~/.nullclaw/workspace/skills/<name>/`
+- New `Skill` -> `~/.nullclaw/workspace/skills/<name>/` or `~/.nullclaw/workspace/skills/<category>/<name>/`
 
 ## Chinese Docs (中文文档)
 

--- a/src/skillforge.zig
+++ b/src/skillforge.zig
@@ -391,7 +391,7 @@ pub fn evaluateCandidate(candidate: SkillCandidate, min_score: f64) EvalResult {
 // ── Integration ─────────────────────────────────────────────────
 
 /// Integrate a skill: clone repo to skills_dir/NAME/,
-/// verify structure (expects skill.json, root.zig, or build.zig).
+/// verify structure (agent skill manifests, root.zig, or build.zig).
 pub fn integrate(allocator: std.mem.Allocator, candidate: SkillCandidate, skills_dir: []const u8) !IntegrationResult {
     const safe_name = try sanitizePathComponent(candidate.result_name);
 
@@ -452,19 +452,14 @@ pub fn integrate(allocator: std.mem.Allocator, candidate: SkillCandidate, skills
         },
     }
 
-    // Verify the cloned repo has expected structure
-    const has_skill_json = hasFile(target_path, "skill.json");
-    const has_build_zig = hasFile(target_path, "build.zig");
-    const has_root_zig = hasFile(target_path, "root.zig");
-
-    if (!has_skill_json and !has_build_zig and !has_root_zig) {
+    if (!hasSupportedSkillStructure(target_path)) {
         // Remove the cloned directory since it lacks expected structure
         std_compat.fs.deleteTreeAbsolute(target_path) catch {};
         return IntegrationResult{
             .skill_name = safe_name,
             .install_path = skills_dir,
             .success = false,
-            .error_message = "Cloned repo lacks skill.json, build.zig, or root.zig",
+            .error_message = "Cloned repo lacks SKILL.md, SKILL.toml, skill.json, build.zig, or root.zig",
         };
     }
 
@@ -481,6 +476,14 @@ fn hasFile(dir_path: []const u8, filename: []const u8) bool {
     const full = std.fmt.bufPrint(&buf, "{s}/{s}", .{ dir_path, filename }) catch return false;
     std_compat.fs.accessAbsolute(full, .{}) catch return false;
     return true;
+}
+
+fn hasSupportedSkillStructure(dir_path: []const u8) bool {
+    return hasFile(dir_path, "SKILL.md") or
+        hasFile(dir_path, "SKILL.toml") or
+        hasFile(dir_path, "skill.json") or
+        hasFile(dir_path, "build.zig") or
+        hasFile(dir_path, "root.zig");
 }
 
 pub const IntegrationResult = struct {
@@ -835,6 +838,42 @@ test "default config values" {
     try std.testing.expect(cfg.auto_integrate);
     try std.testing.expectEqual(@as(u64, 24), cfg.scan_interval_hours);
     try std.testing.expect(@abs(cfg.min_score - 0.7) < 0.001);
+}
+
+test "hasSupportedSkillStructure accepts agent skill manifests" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("md");
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("toml");
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("empty");
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("md/SKILL.md", .{});
+        defer f.close();
+        try f.writeAll("# Skill");
+    }
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("toml/SKILL.toml", .{});
+        defer f.close();
+        try f.writeAll(
+            \\[skill]
+            \\name = "toml"
+        );
+    }
+
+    const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+    const md_path = try std_compat.fs.path.join(allocator, &.{ base, "md" });
+    defer allocator.free(md_path);
+    const toml_path = try std_compat.fs.path.join(allocator, &.{ base, "toml" });
+    defer allocator.free(toml_path);
+    const empty_path = try std_compat.fs.path.join(allocator, &.{ base, "empty" });
+    defer allocator.free(empty_path);
+
+    try std.testing.expect(hasSupportedSkillStructure(md_path));
+    try std.testing.expect(hasSupportedSkillStructure(toml_path));
+    try std.testing.expect(!hasSupportedSkillStructure(empty_path));
 }
 
 test "forge disabled returns empty report" {

--- a/src/skills.zig
+++ b/src/skills.zig
@@ -11,7 +11,9 @@ const skillforge = @import("skillforge.zig");
 
 // Skills — user-defined capabilities loaded from disk.
 //
-// Each skill lives in ~/.nullclaw/workspace/skills/<name>/ with:
+// Skills live under ~/.nullclaw/workspace/skills/, either directly as
+// skills/<name>/ or one level below a category directory as skills/<category>/<name>/.
+// Each skill directory uses:
 //   - SKILL.toml  — preferred manifest format (zeroclaw-compatible)
 //   - skill.json  — legacy manifest format (optional)
 //   - SKILL.md    — instruction text
@@ -709,7 +711,8 @@ fn checkBinaryExists(allocator: std.mem.Allocator, bin_name: []const u8) bool {
 
 // ── Listing ─────────────────────────────────────────────────────
 
-/// Scan workspace_dir/skills/ for subdirectories, loading each as a Skill.
+/// Scan workspace_dir/skills/ for direct skill directories and one level of
+/// category subdirectories, loading each discovered entry as a Skill.
 /// Returns owned slice; caller must free with freeSkills().
 pub fn listSkills(allocator: std.mem.Allocator, workspace_dir: []const u8, observer: ?observability.Observer) ![]Skill {
     const skills_dir_path = try std.fmt.allocPrint(allocator, "{s}/skills", .{workspace_dir});
@@ -738,9 +741,14 @@ pub fn listSkills(allocator: std.mem.Allocator, workspace_dir: []const u8, obser
 
         if (loadSkill(allocator, sub_path, observer)) |skill| {
             try skills_list.append(allocator, skill);
-        } else |_| {
-            // No valid manifest — treat as a category directory and scan one level deeper.
-            try scanCategoryDir(allocator, sub_path, observer, &skills_list);
+        } else |err| {
+            switch (err) {
+                // A directory with no manifest is a category candidate. A directory
+                // with a malformed manifest is a broken skill and must not expose
+                // arbitrary nested support directories as skills.
+                error.ManifestNotFound => try scanCategoryDir(allocator, sub_path, observer, &skills_list),
+                else => continue,
+            }
         }
     }
 
@@ -1722,6 +1730,62 @@ fn deriveSkillNameFromSourcePath(allocator: std.mem.Allocator, source_path: []co
     return try allocator.dupe(u8, base_name);
 }
 
+fn installSkillsFromRepositoryCategory(
+    allocator: std.mem.Allocator,
+    category_path: []const u8,
+    category_name: []const u8,
+    workspace_dir: []const u8,
+    detail_out: ?*?[]u8,
+) !usize {
+    var category_dir = if (std_compat.fs.path.isAbsolute(category_path))
+        std_compat.fs.openDirAbsolute(category_path, .{ .iterate = true }) catch
+            return error.ManifestNotFound
+    else
+        fs_compat.openDirPath(category_path, .{ .iterate = true }) catch
+            return error.ManifestNotFound;
+    defer category_dir.close();
+
+    var installed_count: usize = 0;
+    var failed_count: usize = 0;
+    var last_failed_error: ?anyerror = null;
+    var it = category_dir.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind != .directory) continue;
+
+        const nested_skill_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ category_path, entry.name });
+        defer allocator.free(nested_skill_path);
+        installSkillFromPath(allocator, nested_skill_path, workspace_dir) catch |err| switch (err) {
+            error.ManifestNotFound => continue,
+            error.SkillAlreadyExists => {
+                failed_count += 1;
+                last_failed_error = err;
+                std.log.warn("failed to install skill '{s}/{s}' from repository collection: {s}", .{ category_name, entry.name, @errorName(err) });
+                const msg = std.fmt.allocPrint(allocator, "failed to install skill from repository collection entry '{s}/{s}': {s}", .{ category_name, entry.name, @errorName(err) }) catch null;
+                if (msg) |m| {
+                    defer allocator.free(m);
+                    setInstallErrorDetail(allocator, detail_out, m);
+                }
+                continue;
+            },
+            else => {
+                const msg = std.fmt.allocPrint(allocator, "failed to install skill from repository collection entry '{s}/{s}': {s}", .{ category_name, entry.name, @errorName(err) }) catch null;
+                if (msg) |m| {
+                    defer allocator.free(m);
+                    setInstallErrorDetail(allocator, detail_out, m);
+                }
+                return err;
+            },
+        };
+        installed_count += 1;
+    }
+
+    if (installed_count == 0) {
+        if (last_failed_error) |err| return err;
+        if (failed_count == 0) return error.ManifestNotFound;
+    }
+    return installed_count;
+}
+
 fn installSkillsFromRepositoryCollection(
     allocator: std.mem.Allocator,
     repo_root: []const u8,
@@ -1749,7 +1813,19 @@ fn installSkillsFromRepositoryCollection(
         const skill_source_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ collection_path, entry.name });
         defer allocator.free(skill_source_path);
         installSkillFromPath(allocator, skill_source_path, workspace_dir) catch |err| switch (err) {
-            error.ManifestNotFound => continue,
+            error.ManifestNotFound => {
+                const nested_installed = installSkillsFromRepositoryCategory(allocator, skill_source_path, entry.name, workspace_dir, detail_out) catch |nested_err| switch (nested_err) {
+                    error.ManifestNotFound => continue,
+                    error.SkillAlreadyExists => {
+                        failed_count += 1;
+                        last_failed_error = nested_err;
+                        continue;
+                    },
+                    else => return nested_err,
+                };
+                installed_count += nested_installed;
+                continue;
+            },
             error.SkillAlreadyExists => {
                 failed_count += 1;
                 last_failed_error = err;
@@ -2113,23 +2189,32 @@ fn copyFilePath(src: []const u8, dst: []const u8) !void {
 
 // ── Removal ─────────────────────────────────────────────────────
 
-/// Remove a skill by deleting its directory from workspace_dir/skills/<name>/.
+/// Remove a skill by name from either a direct or one-level category directory.
 pub fn removeSkill(allocator: std.mem.Allocator, name: []const u8, workspace_dir: []const u8) !void {
-    // Sanitize name
-    for (name) |c| {
-        if (c == '/' or c == '\\' or c == 0) return error.UnsafeName;
-    }
-    if (name.len == 0 or std.mem.eql(u8, name, "..")) return error.UnsafeName;
+    try validateSkillName(name);
 
     const skill_path = try std.fmt.allocPrint(allocator, "{s}/skills/{s}", .{ workspace_dir, name });
     defer allocator.free(skill_path);
 
-    // Verify the skill directory actually exists before deleting
-    std_compat.fs.accessAbsolute(skill_path, .{}) catch return error.SkillNotFound;
+    if (pathExists(skill_path)) {
+        std_compat.fs.deleteTreeAbsolute(skill_path) catch |err| {
+            return err;
+        };
+        return;
+    }
 
-    std_compat.fs.deleteTreeAbsolute(skill_path) catch |err| {
-        return err;
-    };
+    const skills = try listSkills(allocator, workspace_dir, null);
+    defer freeSkills(allocator, skills);
+
+    for (skills) |skill| {
+        if (!std.mem.eql(u8, skill.name, name)) continue;
+        std_compat.fs.deleteTreeAbsolute(skill.path) catch |err| {
+            return err;
+        };
+        return;
+    }
+
+    return error.SkillNotFound;
 }
 
 // ── Community Skills Sync ────────────────────────────────────────
@@ -2850,20 +2935,24 @@ test "listSkills discovers skills nested inside a category directory" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    // skills/coding/git-helpers/ — nested skill
+    // skills/coding/git-helpers/ — nested markdown-only skill
     try @import("compat").fs.Dir.wrap(tmp.dir).makePath("skills/coding/git-helpers");
     {
-        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/coding/git-helpers/skill.json", .{});
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/coding/git-helpers/SKILL.md", .{});
         defer f.close();
-        try f.writeAll("{\"name\": \"git-helpers\", \"version\": \"1.0.0\", \"description\": \"Git utilities\", \"author\": \"dev\"}");
+        try f.writeAll("# Git Helpers\nGit utilities.");
     }
 
-    // skills/coding/docker-ops/ — another nested skill in the same category
+    // skills/coding/docker-ops/ — nested TOML skill in the same category
     try @import("compat").fs.Dir.wrap(tmp.dir).makePath("skills/coding/docker-ops");
     {
-        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/coding/docker-ops/skill.json", .{});
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/coding/docker-ops/SKILL.toml", .{});
         defer f.close();
-        try f.writeAll("{\"name\": \"docker-ops\", \"version\": \"1.0.0\", \"description\": \"Docker tools\", \"author\": \"dev\"}");
+        try f.writeAll(
+            \\[skill]
+            \\name = "docker-ops"
+            \\description = "Docker tools"
+        );
     }
 
     // skills/flat-skill/ — flat skill still works alongside categories
@@ -2918,6 +3007,34 @@ test "listSkills skips category directory itself when it has no manifest" {
     // Only the nested skill is loaded — not the category dir itself
     try std.testing.expectEqual(@as(usize, 1), skills.len);
     try std.testing.expectEqualStrings("web-search", skills[0].name);
+}
+
+test "listSkills does not scan invalid skill manifests as categories" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("skills/broken/nested");
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/broken/skill.json", .{});
+        defer f.close();
+        try f.writeAll("{");
+    }
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/broken/nested/skill.json", .{});
+        defer f.close();
+        try f.writeAll("{\"name\": \"nested\"}");
+    }
+
+    const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+
+    const skills = try listSkills(allocator, base, null);
+    defer freeSkills(allocator, skills);
+
+    // Regression: a malformed top-level skill must stay skipped instead of
+    // turning its support subdirectories into discovered skills.
+    try std.testing.expectEqual(@as(usize, 0), skills.len);
 }
 
 test "listSkills discovers markdown-only skill directories" {
@@ -3969,6 +4086,68 @@ test "installSkillFromGit installs all skills from repository skills directory" 
     try std.testing.expect(pathExists(installed_skill_md));
 }
 
+test "installSkillFromGit installs nested repository skills directory entries" {
+    const allocator = std.testing.allocator;
+    if (!checkBinaryExists(allocator, "git")) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("workspace");
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("repo/skills/coding/git-helpers");
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("repo/skills/coding/docker-ops");
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("repo/skills/flat-skill");
+
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("repo/skills/coding/git-helpers/SKILL.md", .{});
+        defer f.close();
+        try f.writeAll("# Git Helpers\nGit utilities.");
+    }
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("repo/skills/coding/docker-ops/SKILL.toml", .{});
+        defer f.close();
+        try f.writeAll(
+            \\[skill]
+            \\name = "docker-ops"
+            \\description = "Docker tools"
+        );
+    }
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("repo/skills/flat-skill/SKILL.md", .{});
+        defer f.close();
+        try f.writeAll("# Flat Skill\nTop-level skill.");
+    }
+
+    const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+    const workspace = try std_compat.fs.path.join(allocator, &.{ base, "workspace" });
+    defer allocator.free(workspace);
+    const repo = try std_compat.fs.path.join(allocator, &.{ base, "repo" });
+    defer allocator.free(repo);
+
+    try runCommand(allocator, &.{ "git", "-C", repo, "init" });
+    try runCommand(allocator, &.{ "git", "-C", repo, "add", "skills" });
+    try runCommand(allocator, &.{ "git", "-C", repo, "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-m", "init" });
+
+    try installSkillFromGit(allocator, repo, workspace, null);
+
+    const skills = try listSkills(allocator, workspace, null);
+    defer freeSkills(allocator, skills);
+    try std.testing.expectEqual(@as(usize, 3), skills.len);
+
+    var found_git = false;
+    var found_docker = false;
+    var found_flat = false;
+    for (skills) |s| {
+        if (std.mem.eql(u8, s.name, "git-helpers")) found_git = true;
+        if (std.mem.eql(u8, s.name, "docker-ops")) found_docker = true;
+        if (std.mem.eql(u8, s.name, "flat-skill")) found_flat = true;
+    }
+    try std.testing.expect(found_git);
+    try std.testing.expect(found_docker);
+    try std.testing.expect(found_flat);
+}
+
 test "installSkillFromGit installs SKILL.toml entry from repository skills directory" {
     const allocator = std.testing.allocator;
     if (!checkBinaryExists(allocator, "git")) return error.SkipZigTest;
@@ -4219,6 +4398,28 @@ test "removeSkill nonexistent returns SkillNotFound" {
     defer allocator.free(workspace);
 
     try std.testing.expectError(error.SkillNotFound, removeSkill(allocator, "nonexistent", workspace));
+}
+
+test "removeSkill removes nested skill by discovered name" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("skills/coding/web-search");
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/coding/web-search/SKILL.md", .{});
+        defer f.close();
+        try f.writeAll("# Web Search\nSearch the web.");
+    }
+
+    const workspace = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(workspace);
+
+    try removeSkill(allocator, "web-search", workspace);
+
+    const skills = try listSkills(allocator, workspace, null);
+    defer freeSkills(allocator, skills);
+    try std.testing.expectEqual(@as(usize, 0), skills.len);
 }
 
 test "removeSkill rejects unsafe names" {

--- a/src/skills.zig
+++ b/src/skills.zig
@@ -739,12 +739,37 @@ pub fn listSkills(allocator: std.mem.Allocator, workspace_dir: []const u8, obser
         if (loadSkill(allocator, sub_path, observer)) |skill| {
             try skills_list.append(allocator, skill);
         } else |_| {
-            // Skip directories without valid skill.json
-            continue;
+            // No valid manifest — treat as a category directory and scan one level deeper.
+            try scanCategoryDir(allocator, sub_path, observer, &skills_list);
         }
     }
 
     return try skills_list.toOwnedSlice(allocator);
+}
+
+/// Scans one level inside a category directory for skill subdirectories.
+/// Directories without a valid manifest are silently skipped.
+fn scanCategoryDir(
+    allocator: std.mem.Allocator,
+    category_path: []const u8,
+    observer: ?observability.Observer,
+    skills_list: *std.ArrayList(Skill),
+) !void {
+    const cat_dir = fs_compat.openDirPath(category_path, .{ .iterate = true }) catch return;
+    var cat_dir_mut = cat_dir;
+    defer cat_dir_mut.close();
+
+    var cat_it = cat_dir_mut.iterate();
+    while (try cat_it.next()) |entry| {
+        if (entry.kind != .directory) continue;
+
+        const nested_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ category_path, entry.name });
+        defer allocator.free(nested_path);
+
+        if (loadSkill(allocator, nested_path, observer)) |skill| {
+            try skills_list.append(allocator, skill);
+        } else |_| {}
+    }
 }
 
 /// Load skills from two sources: built-in and workspace.
@@ -2818,6 +2843,81 @@ test "listSkills discovers skills in subdirectories" {
     }
     try std.testing.expect(found_alpha);
     try std.testing.expect(found_beta);
+}
+
+test "listSkills discovers skills nested inside a category directory" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // skills/coding/git-helpers/ — nested skill
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("skills/coding/git-helpers");
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/coding/git-helpers/skill.json", .{});
+        defer f.close();
+        try f.writeAll("{\"name\": \"git-helpers\", \"version\": \"1.0.0\", \"description\": \"Git utilities\", \"author\": \"dev\"}");
+    }
+
+    // skills/coding/docker-ops/ — another nested skill in the same category
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("skills/coding/docker-ops");
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/coding/docker-ops/skill.json", .{});
+        defer f.close();
+        try f.writeAll("{\"name\": \"docker-ops\", \"version\": \"1.0.0\", \"description\": \"Docker tools\", \"author\": \"dev\"}");
+    }
+
+    // skills/flat-skill/ — flat skill still works alongside categories
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("skills/flat-skill");
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/flat-skill/skill.json", .{});
+        defer f.close();
+        try f.writeAll("{\"name\": \"flat-skill\", \"version\": \"1.0.0\", \"description\": \"Top-level skill\", \"author\": \"dev\"}");
+    }
+
+    const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+
+    const skills = try listSkills(allocator, base, null);
+    defer freeSkills(allocator, skills);
+
+    try std.testing.expectEqual(@as(usize, 3), skills.len);
+
+    var found_git = false;
+    var found_docker = false;
+    var found_flat = false;
+    for (skills) |s| {
+        if (std.mem.eql(u8, s.name, "git-helpers")) found_git = true;
+        if (std.mem.eql(u8, s.name, "docker-ops")) found_docker = true;
+        if (std.mem.eql(u8, s.name, "flat-skill")) found_flat = true;
+    }
+    try std.testing.expect(found_git);
+    try std.testing.expect(found_docker);
+    try std.testing.expect(found_flat);
+}
+
+test "listSkills skips category directory itself when it has no manifest" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // skills/tools/ — category dir with no manifest of its own
+    // skills/tools/web-search/ — valid nested skill
+    try @import("compat").fs.Dir.wrap(tmp.dir).makePath("skills/tools/web-search");
+    {
+        const f = try @import("compat").fs.Dir.wrap(tmp.dir).createFile("skills/tools/web-search/skill.json", .{});
+        defer f.close();
+        try f.writeAll("{\"name\": \"web-search\", \"version\": \"1.0.0\", \"description\": \"Search the web\", \"author\": \"dev\"}");
+    }
+
+    const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+
+    const skills = try listSkills(allocator, base, null);
+    defer freeSkills(allocator, skills);
+
+    // Only the nested skill is loaded — not the category dir itself
+    try std.testing.expectEqual(@as(usize, 1), skills.len);
+    try std.testing.expectEqualStrings("web-search", skills[0].name);
 }
 
 test "listSkills discovers markdown-only skill directories" {


### PR DESCRIPTION
## Summary

### EN:
- `listSkills()` previously performed a flat scan of `skills/` — any directory without a valid manifest was silently skipped, making it impossible to organize skills into category subdirectories.
- Adds one-level-deep scanning: when a directory under `skills/` has no valid manifest (`SKILL.toml` / `skill.json` / `SKILL.md`), it is now treated as a category and its immediate subdirectories are scanned for skills.
- The skill name is still derived from the manifest `name` field or the leaf directory name — no new naming convention required.
- Flat skills (`skills/my-skill/`) continue to work exactly as before — fully backward compatible.
- Logic extracted into a private `scanCategoryDir()` helper in `src/skills.zig`.
- 2 new tests covering nested discovery and the category-skip behavior.

### ZH:
- `listSkills()` 之前对 `skills/` 目录执行扁平扫描——任何没有有效清单的目录都会被静默跳过，使得无法将技能组织到分类子目录中。
- 新增一层深度扫描：当 `skills/` 下的目录没有有效清单（`SKILL.toml` / `skill.json` / `SKILL.md`）时，现在将其视为分类目录，并扫描其直接子目录以发现技能。
- 技能名称仍从清单的 `name` 字段或叶子目录名称派生——不需要新的命名约定。
- 扁平技能（`skills/my-skill/`）继续完全按原样工作——完全向后兼容。
- 逻辑提取到 `src/skills.zig` 中的私有 `scanCategoryDir()` 辅助函数。
- 新增 2 个测试，覆盖嵌套发现和分类目录跳过行为。

## Example

```
skills/
├── coding/               ← category (no manifest) — scanned one level deeper
│   ├── git-helpers/
│   │   └── skill.json    ← discovered as "git-helpers"
│   └── docker-ops/
│       └── SKILL.toml    ← discovered as "docker-ops"
├── research/             ← category (no manifest)
│   └── web-search/
│       └── SKILL.md      ← discovered as "web-search"
└── my-flat-skill/        ← flat skill — works unchanged
    └── SKILL.md
```

## Validation
- `zig build`: Build successful (Zig 0.16.0).
- `zig build test --test-timeout 10s --summary all`: 6654/6672 tests passed (13 skipped, 5 timed out — all pre-existing Redis integration tests requiring a live Redis instance).

## Notes
- Scanning is intentionally limited to one extra level. Deeper nesting (e.g. `skills/a/b/c/skill/`) is not supported — this keeps the behavior predictable and avoids accidental discovery of support files or example directories that may live inside a skill's own subdirectories.

Closes #825