### PR TITLE
feat(agent,gateway): add --workspace flag to override workspace directory

### DIFF
--- a/docs/en/commands.md
+++ b/docs/en/commands.md
@@ -43,6 +43,7 @@ This page groups the NullClaw CLI by task so you can find the right command quic
 | `nullclaw onboard --api-key ... --provider ... --model ... --memory ...` | Set provider, model, and memory backend in one command |
 | `nullclaw onboard --channels-only` | Reconfigure channels and allowlists only |
 | `nullclaw agent -m "..."` | Run a single prompt |
+| `nullclaw agent --workspace /path/to/workspace -m "..."` | Run the agent against a specific workspace for this process |
 | `nullclaw agent` | Start interactive chat mode |
 
 ### Interactive model routing
@@ -64,6 +65,7 @@ This page groups the NullClaw CLI by task so you can find the right command quic
 | `nullclaw gateway` | Start the long-running runtime using configured host and port |
 | `nullclaw gateway --port 8080` | Override the gateway port from the CLI |
 | `nullclaw gateway --host 0.0.0.0 --port 8080` | Override host and port from the CLI |
+| `nullclaw gateway --workspace /path/to/workspace` | Override the workspace directory for this gateway process |
 | `nullclaw service install` | Install the background service |
 | `nullclaw service start` | Start the background service |
 | `nullclaw service stop` | Stop the background service |
@@ -83,6 +85,7 @@ Notes:
 
 - `auth` currently supports only `openai-codex`.
 - `gateway --host/--port` overrides only the bind settings; the rest of gateway security still comes from config.
+- `agent --workspace` and `gateway --workspace` override the resolved workspace for the current process, equivalent to setting `NULLCLAW_WORKSPACE`.
 
 ## Channels, scheduling, and extensions
 

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -29,6 +29,7 @@
 | `nullclaw onboard --api-key ... --provider ... --model ... --memory ...` | 一次性指定 provider、model、memory backend |
 | `nullclaw onboard --channels-only` | 只重配 channel / allowlist |
 | `nullclaw agent -m "..."` | 单条消息模式 |
+| `nullclaw agent --workspace /path/to/workspace -m "..."` | 本次进程使用指定 workspace 运行 agent |
 | `nullclaw agent` | 交互会话模式 |
 
 ### 交互式模型路由
@@ -50,6 +51,7 @@
 | `nullclaw gateway` | 启动长期运行 runtime，默认读取配置中的 host/port |
 | `nullclaw gateway --port 8080` | 用 CLI 覆盖网关端口 |
 | `nullclaw gateway --host 0.0.0.0 --port 8080` | 用 CLI 覆盖监听地址与端口 |
+| `nullclaw gateway --workspace /path/to/workspace` | 本次 gateway 进程使用指定 workspace |
 | `nullclaw service install` | 安装后台服务 |
 | `nullclaw service start` | 启动后台服务 |
 | `nullclaw service stop` | 停止后台服务 |
@@ -69,6 +71,7 @@
 
 - `auth` 目前只支持 `openai-codex`。
 - `gateway` 只是覆盖 host/port，其他安全策略仍以配置文件为准。
+- `agent --workspace` 和 `gateway --workspace` 只覆盖当前进程解析到的 workspace，效果等同于设置 `NULLCLAW_WORKSPACE`。
 
 ## 渠道、任务与扩展
 

--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -165,6 +165,7 @@ const ParsedAgentArgs = struct {
     model_override: ?[]const u8 = null,
     temperature_override: ?f64 = null,
     agent_name: ?[]const u8 = null,
+    workspace_override: ?[]const u8 = null,
     verbose: bool = false,
 };
 
@@ -204,6 +205,10 @@ fn parseAgentArgs(args: []const []const u8) AgentArgParseResult {
             if (i + 1 >= args.len) return .{ .missing_value = arg };
             i += 1;
             parsed.agent_name = args[i];
+        } else if (std.mem.eql(u8, arg, "--workspace")) {
+            if (i + 1 >= args.len) return .{ .missing_value = arg };
+            i += 1;
+            parsed.workspace_override = args[i];
         } else if (std.mem.eql(u8, arg, "--verbose") or std.mem.eql(u8, arg, "-v")) {
             parsed.verbose = true;
         }
@@ -334,6 +339,9 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
             selected_workspace_dir = try cfg.resolveAgentWorkspacePath(allocator, workspace_path);
             cfg.workspace_dir = selected_workspace_dir.?;
         }
+    }
+    if (parsed_args.workspace_override) |workspace| {
+        cfg.workspace_dir = workspace;
     }
 
     var agent_memory_session_id: ?[]u8 = null;
@@ -1045,6 +1053,24 @@ test "parseAgentArgs returns missing value for --agent" {
     const args = [_][]const u8{"--agent"};
     switch (parseAgentArgs(&args)) {
         .missing_value => |value| try std.testing.expectEqualStrings("--agent", value),
+        else => unreachable,
+    }
+}
+
+test "parseAgentArgs parses --workspace" {
+    const args = [_][]const u8{ "--workspace", "/custom/ws", "-m", "hi" };
+    const parsed = switch (parseAgentArgs(&args)) {
+        .ok => |value| value,
+        else => unreachable,
+    };
+    try std.testing.expectEqualStrings("/custom/ws", parsed.workspace_override.?);
+    try std.testing.expectEqualStrings("hi", parsed.message_arg.?);
+}
+
+test "parseAgentArgs returns missing value for --workspace" {
+    const args = [_][]const u8{"--workspace"};
+    switch (parseAgentArgs(&args)) {
+        .missing_value => |value| try std.testing.expectEqualStrings("--workspace", value),
         else => unreachable,
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -87,8 +87,8 @@ const TOP_LEVEL_USAGE = std.fmt.comptimePrint(
     \\
     \\OPTIONS:
     \\  onboard [--interactive] [--api-key KEY] [--provider PROV] [--model MODEL] [--memory MEM]
-    \\  agent [-m MESSAGE] [-s SESSION] [--provider PROVIDER] [--model MODEL] [--temperature TEMP]
-    \\  gateway [--port PORT] [--host HOST]
+    \\  agent [-m MESSAGE] [-s SESSION] [--provider PROVIDER] [--model MODEL] [--temperature TEMP] [--workspace PATH]
+    \\  gateway [--port PORT] [--host HOST] [--workspace PATH]
     \\  status [--json]
     \\  version | --version | -V
     \\  service <{s}>
@@ -314,7 +314,8 @@ fn gatewayHelpRequested(args: []const []const u8) bool {
         }
         if (std.mem.eql(u8, arg, "--port") or
             std.mem.eql(u8, arg, "-p") or
-            std.mem.eql(u8, arg, "--host"))
+            std.mem.eql(u8, arg, "--host") or
+            std.mem.eql(u8, arg, "--workspace"))
         {
             if (i + 1 < args.len) i += 1;
         }
@@ -334,6 +335,9 @@ fn applyGatewayDaemonOverrides(cfg: *yc.config.Config, sub_args: []const []const
         } else if (std.mem.eql(u8, sub_args[i], "--host") and i + 1 < sub_args.len) {
             i += 1;
             host = sub_args[i];
+        } else if (std.mem.eql(u8, sub_args[i], "--workspace") and i + 1 < sub_args.len) {
+            i += 1;
+            cfg.workspace_dir = sub_args[i];
         }
     }
 
@@ -352,6 +356,7 @@ fn printGatewayUsage() void {
         \\OPTIONS:
         \\  --port PORT, -p PORT   Override gateway listen port
         \\  --host HOST            Override gateway listen host
+        \\  --workspace PATH       Override workspace directory
         \\  --verbose, -v          Enable verbose logging
         \\  --help, -h             Show this help
         \\
@@ -379,6 +384,7 @@ fn printAgentUsage() void {
         \\  --provider PROVIDER           Override default provider
         \\  --model MODEL                 Override default model
         \\  --temperature TEMP            Override sampling temperature
+        \\  --workspace PATH              Override workspace directory
         \\  --verbose, -v                 Enable verbose logging
         \\  --help, -h                    Show this help
         \\
@@ -5303,6 +5309,24 @@ test "applyGatewayDaemonOverrides rejects invalid port" {
     };
     const args = [_][]const u8{ "--port", "bad" };
     try std.testing.expectError(error.InvalidPort, applyGatewayDaemonOverrides(&cfg, &args));
+}
+
+test "applyGatewayDaemonOverrides applies workspace override" {
+    var cfg = yc.config.Config{
+        .workspace_dir = "/tmp/nullclaw-test",
+        .config_path = "/tmp/nullclaw-test/config.json",
+        .default_model = "openrouter/auto",
+        .allocator = std.testing.allocator,
+    };
+    const args = [_][]const u8{ "--workspace", "/custom/workspace" };
+    try applyGatewayDaemonOverrides(&cfg, &args);
+    try std.testing.expectEqualStrings("/custom/workspace", cfg.workspace_dir);
+}
+
+test "gatewayHelpRequested skips workspace value" {
+    // --help here is the value of --workspace, not a real flag — should not trigger help
+    const args = [_][]const u8{ "--workspace", "--help" };
+    try std.testing.expect(!gatewayHelpRequested(&args));
 }
 
 test "hasConfiguredStartableChannels ignores cli and webhook-only defaults" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -292,7 +292,9 @@ fn agentHelpRequested(args: []const []const u8) bool {
             std.mem.eql(u8, arg, "--session") or
             std.mem.eql(u8, arg, "--provider") or
             std.mem.eql(u8, arg, "--model") or
-            std.mem.eql(u8, arg, "--temperature"))
+            std.mem.eql(u8, arg, "--temperature") or
+            std.mem.eql(u8, arg, "--agent") or
+            std.mem.eql(u8, arg, "--workspace"))
         {
             if (i + 1 < args.len) i += 1;
         }
@@ -5171,6 +5173,16 @@ test "agentHelpRequested ignores message value that matches help flag" {
 
 test "agentHelpRequested ignores session value that matches short help flag" {
     const args = [_][]const u8{ "--session", "-h" };
+    try std.testing.expect(!agentHelpRequested(&args));
+}
+
+test "agentHelpRequested ignores workspace value that matches help flag" {
+    const args = [_][]const u8{ "--workspace", "--help" };
+    try std.testing.expect(!agentHelpRequested(&args));
+}
+
+test "agentHelpRequested ignores agent value that matches help flag" {
+    const args = [_][]const u8{ "--agent", "--help" };
     try std.testing.expect(!agentHelpRequested(&args));
 }
 


### PR DESCRIPTION
## Summary

- Adds `--workspace PATH` to `nullclaw gateway` and `nullclaw agent` (single-message and interactive REPL modes)
- The flag overrides `workspace_dir` at startup, equivalent to setting `NULLCLAW_WORKSPACE=PATH` — useful for running multiple gateway instances pointing at different workspaces without separate config files
- For `agent`, the CLI flag takes priority over the profile-level `workspace_path` setting
- Mirrors `--workspace` support already present in the WASI build (`main_wasi.zig`) — this brings the native binary to parity
- No new config fields needed; wires directly into the existing `workspace_dir` field on `Config`

Closes #833

---

## 摘要

- 为 `nullclaw gateway` 和 `nullclaw agent` 新增 `--workspace PATH` 选项
- 该选项在启动时覆盖 `workspace_dir`，等效于设置 `NULLCLAW_WORKSPACE=PATH` 环境变量，便于在不同配置文件的情况下运行多个 gateway 实例
- 在 `agent` 命令中，CLI 参数优先于 profile 级别的 `workspace_path` 配置
- 与 WASI 构建（`main_wasi.zig`）中已有的 `--workspace` 支持保持一致，使原生二进制文件达到同等功能
- 无需新增配置字段，直接绑定到 `Config` 上现有的 `workspace_dir` 字段

关闭 #833

---

## Test plan

- [x] `applyGatewayDaemonOverrides applies workspace override` — asserts `cfg.workspace_dir` is updated
- [x] `gatewayHelpRequested skips workspace value` — asserts `--help` as workspace value does not trigger help
- [x] `parseAgentArgs parses --workspace` — verifies flag parsed into `workspace_override`
- [x] `parseAgentArgs returns missing value for --workspace` — verifies error on missing argument
- [x] Full suite: 6594 pass, 13 skip, 5 timeout (Redis integration — pre-existing, no server in CI)