### PR TITLE
fix(onboard): clear actionable message when KeyWriteFailed during config save

### DIFF
--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -2423,7 +2423,21 @@ pub fn runWizard(allocator: std.mem.Allocator) !void {
     try scaffoldWorkspaceForConfig(allocator, &cfg, &ProjectContext{});
 
     // Save config
-    try cfg.save();
+    cfg.save() catch |err| {
+        if (err == error.KeyWriteFailed) {
+            try out.print(
+                "\n  Error: could not write encryption key to {s}.\n" ++
+                    "  This usually means the config directory is not writable by the current user.\n" ++
+                    "  In Docker: run `docker compose run --rm --user root agent chown -R 65534:65534 /nullclaw-data`\n" ++
+                    "  then retry onboard. Alternatively, set `\"secrets\": {{\"encrypt\": false}}` in config.json\n" ++
+                    "  to disable at-rest encryption (not recommended for production).\n",
+                .{std_compat.fs.path.dirname(cfg.config_path) orelse cfg.config_path},
+            );
+            try out.flush();
+            return;
+        }
+        return err;
+    };
 
     // Print summary
     try out.writeAll("  ── Configuration complete ──\n\n");

--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -68,6 +68,7 @@ const WORKSPACE_HEARTBEAT_TEMPLATE = @embedFile("workspace_templates/HEARTBEAT.m
 const WORKSPACE_BOOTSTRAP_TEMPLATE = @embedFile("workspace_templates/BOOTSTRAP.md");
 const MODELS_REFRESH_TIMEOUT_SECS = "10";
 const MODELS_REFRESH_MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+const KEY_WRITE_FAILED_DOCKER_FIX = "docker compose run --rm --user root --entrypoint chown agent -R 65534:65534 /nullclaw-data";
 // ── Project context ──────────────────────────────────────────────
 
 pub const ProjectContext = struct {
@@ -957,7 +958,7 @@ pub fn runQuickSetup(allocator: std.mem.Allocator, api_key: ?[]const u8, provide
     try scaffoldWorkspaceForConfig(allocator, &cfg, &ProjectContext{});
 
     // Save config so subsequent commands can find it
-    try cfg.save();
+    try saveConfigWithOnboardErrorMessage(&cfg, stdout);
 
     // Print summary
     try stdout.print("  [OK] Workspace:  {s}\n", .{cfg.workspace_dir});
@@ -988,6 +989,29 @@ fn ensureSecretsEncryptionEnabled(cfg: *const Config) Config.ValidationError!voi
     }
 }
 
+fn printKeyWriteFailedSaveError(out: *std.Io.Writer, config_path: []const u8) !void {
+    const config_dir = std_compat.fs.path.dirname(config_path) orelse config_path;
+    try out.print(
+        "\n  Error: could not write encryption key in {s}.\n" ++
+            "  This usually means the config directory is not writable by the current user.\n" ++
+            "  In Docker Compose, repair the volume ownership with:\n" ++
+            "    {s}\n" ++
+            "  Then retry onboard.\n",
+        .{ config_dir, KEY_WRITE_FAILED_DOCKER_FIX },
+    );
+}
+
+fn saveConfigWithOnboardErrorMessage(cfg: *const Config, out: *std.Io.Writer) !void {
+    cfg.save() catch |err| switch (err) {
+        error.KeyWriteFailed => {
+            try printKeyWriteFailedSaveError(out, cfg.config_path);
+            try out.flush();
+            return err;
+        },
+        else => return err,
+    };
+}
+
 /// Reconfigure channels and allowlists only (preserves existing config).
 pub fn runChannelsOnly(allocator: std.mem.Allocator) !void {
     var stdout_buf: [4096]u8 = undefined;
@@ -1007,7 +1031,7 @@ pub fn runChannelsOnly(allocator: std.mem.Allocator) !void {
     try stdout.writeAll("Channel setup wizard:\n");
     const changed = try configureChannelsInteractive(allocator, &cfg, stdout, &input_buf, "");
     if (changed) {
-        try cfg.save();
+        try saveConfigWithOnboardErrorMessage(&cfg, stdout);
         try stdout.writeAll("Channel configuration saved.\n\n");
     } else {
         try stdout.writeAll("No channel changes applied.\n\n");
@@ -2423,21 +2447,7 @@ pub fn runWizard(allocator: std.mem.Allocator) !void {
     try scaffoldWorkspaceForConfig(allocator, &cfg, &ProjectContext{});
 
     // Save config
-    cfg.save() catch |err| {
-        if (err == error.KeyWriteFailed) {
-            try out.print(
-                "\n  Error: could not write encryption key to {s}.\n" ++
-                    "  This usually means the config directory is not writable by the current user.\n" ++
-                    "  In Docker: run `docker compose run --rm --user root agent chown -R 65534:65534 /nullclaw-data`\n" ++
-                    "  then retry onboard. Alternatively, set `\"secrets\": {{\"encrypt\": false}}` in config.json\n" ++
-                    "  to disable at-rest encryption (not recommended for production).\n",
-                .{std_compat.fs.path.dirname(cfg.config_path) orelse cfg.config_path},
-            );
-            try out.flush();
-            return;
-        }
-        return err;
-    };
+    try saveConfigWithOnboardErrorMessage(&cfg, out);
 
     // Print summary
     try out.writeAll("  ── Configuration complete ──\n\n");
@@ -3999,6 +4009,21 @@ test "bootstrap lifecycle stays equivalent across markdown hybrid and sqlite bac
 }
 
 // ── Additional onboard tests ────────────────────────────────────
+
+test "onboard key write failure message gives safe docker ownership fix" {
+    // Regression: #763 — KeyWriteFailed during onboard must print the failing
+    // config directory and an executable Docker Compose ownership fix.
+    var buf: [1024]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+
+    try printKeyWriteFailedSaveError(&writer, "/nullclaw-data/config.json");
+    const message = writer.buffered();
+
+    try std.testing.expect(std.mem.indexOf(u8, message, "could not write encryption key in /nullclaw-data") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "--entrypoint chown agent -R 65534:65534 /nullclaw-data") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "Then retry onboard.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "encrypt\": false") == null);
+}
 
 test "canonicalProviderName passthrough for known providers" {
     try std.testing.expectEqualStrings("anthropic", canonicalProviderName("anthropic"));


### PR DESCRIPTION
## Summary

Fixes the silent `error: KeyWriteFailed` crash at step 8 of interactive onboard (#763).

**Root cause:** when `cfg.save()` tries to write the encryption key file (`nullclaw.key`) to the config directory, it fails if that directory isn't writable by the current user. In Docker, this happens when the `nullclaw-data` named volume was created by an older image version before `chown -R 65534:65534 /nullclaw-data` was added to the Dockerfile — the volume retains root ownership on subsequent `docker compose pull` + recreate.

**Before:** the process exits with the bare message `error: KeyWriteFailed` — no indication of what failed or how to fix it.

**After:** the interactive onboard catches the error, prints the config directory that is unwritable, explains the cause, and shows the exact Docker command to repair permissions:

```
  Error: could not write encryption key to /nullclaw-data.
  This usually means the config directory is not writable by the current user.
  In Docker: run `docker compose run --rm --user root agent chown -R 65534:65534 /nullclaw-data`
  then retry onboard. Alternatively, set `"secrets": {"encrypt": false}` in config.json
  to disable at-rest encryption (not recommended for production).
```

No behaviour change when `save()` succeeds.

Fixes #763

---

## 摘要

修复了交互式 onboard 第 8 步静默崩溃为 `error: KeyWriteFailed` 的问题（#763）。

**根因：** `cfg.save()` 在向配置目录写入加密密钥文件（`nullclaw.key`）时，若当前用户对该目录没有写权限则失败。在 Docker 中，当 `nullclaw-data` 卷由旧版镜像创建（彼时 Dockerfile 中尚未添加 `chown -R 65534:65534 /nullclaw-data`），执行 `docker compose pull` 后卷的所有权仍为 root，导致写入失败。

**修复前：** 进程直接以 `error: KeyWriteFailed` 退出，没有任何提示。

**修复后：** 交互式 onboard 捕获该错误，打印无法写入的配置目录路径、解释原因，并给出修复 Docker 权限的精确命令。

关闭 #763

---

## Test plan

- [x] Build passes cleanly
- [x] Full suite: 6592 pass, 13 skip, 5 timeout (Redis integration — pre-existing, no server in CI)
- Manual verification path: `KeyWriteFailed` is only reachable when the filesystem rejects the key write; the new branch catches it before it propagates and prints the guidance message instead of crashing