### PR TITLE
feat(core): inbound router and mid-turn injection infrastructure | 特性(core): 入站路由器与中途注入基础设施

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -75,6 +75,10 @@ pub const ProgressSink = struct {
     }
 };
 
+/// Callback invoked at each tool-loop boundary to drain a pending mid-turn injection.
+/// Returns an owned slice allocated with the provided allocator, or null if empty.
+pub const DrainCallback = *const fn (ctx: *anyopaque, allocator: std.mem.Allocator) ?[]u8;
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Agent
 // ═══════════════════════════════════════════════════════════════════════════
@@ -171,7 +175,7 @@ pub const Agent = struct {
         }
     };
 
-    const QueueMode = enum {
+    pub const QueueMode = enum {
         off,
         serial,
         latest,
@@ -357,6 +361,12 @@ pub const Agent = struct {
     progress_callback: ?ProgressCallback = null,
     /// Context pointer passed to progress_callback.
     progress_ctx: ?*anyopaque = null,
+    /// Optional mid-turn injection drain. When set, called at each tool-loop boundary
+    /// to pull a pending user message and fold it into the active turn.
+    /// Returns an owned slice (allocated with the agent allocator) or null if empty.
+    drain_injection_cb: ?DrainCallback = null,
+    /// Context pointer passed to drain_injection_cb.
+    drain_injection_ctx: ?*anyopaque = null,
     /// Optional callback invoked for each LLM response usage record.
     usage_record_callback: ?UsageRecordCallback = null,
     /// Context pointer passed to usage_record_callback.
@@ -1850,6 +1860,15 @@ pub const Agent = struct {
         while (iteration < self.max_tool_iterations) : (iteration += 1) {
             if (self.isInterruptRequested()) {
                 return self.interruptedReply();
+            }
+
+            // Drain any mid-turn injection at each tool boundary.
+            if (self.drain_injection_cb) |drain_cb| {
+                if (self.drain_injection_ctx) |drain_ctx| {
+                    if (drain_cb(drain_ctx, self.allocator)) |injected| {
+                        try self.appendOwnedHistoryMessage(.{ .role = .user, .content = injected });
+                    }
+                }
             }
 
             _ = iter_arena.reset(.retain_capacity);

--- a/src/inbound_router.zig
+++ b/src/inbound_router.zig
@@ -1,23 +1,23 @@
 //! Pure routing logic for inbound messages.
 //!
 //! Given session state and the configured queue policy, returns the action
-//! the effectful shell should take.  No I/O, no allocations — fully unit-testable.
+//! the effectful shell should take. No I/O, no allocations; fully unit-testable.
 //!
 //! Usage:
 //!   const input = session_mgr.routeInput(session_key);
 //!   switch (inbound_router.route(input)) {
-//!       .process          => session_mgr.processMessageStreaming(...),
-//!       .inject           => session_mgr.injectMidTurn(session_key, text),
+//!       .process           => session_mgr.processMessageStreaming(...),
+//!       .inject            => session_mgr.injectMidTurn(session_key, text),
 //!       .replace_injection => session_mgr.injectMidTurn(session_key, text),  // same effect
-//!       .queue            => session_mgr.enqueuePostTurn(session_key, text),
-//!       .drop             => {},
+//!       .queue             => queue_for_later_processing,
+//!       .drop              => {},
 //!   }
 
 const agent_mod = @import("agent/root.zig");
 
 pub const QueueMode = agent_mod.Agent.QueueMode;
 
-/// Lock-free snapshot of the state needed to make a routing decision.
+/// Snapshot of the state needed to make a routing decision.
 /// Obtained via SessionManager.routeInput().
 pub const RouteInput = struct {
     /// True when agent.turn() is currently executing for this session.
@@ -54,7 +54,7 @@ pub fn route(input: RouteInput) RoutingDecision {
     };
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────
+// Tests
 
 const testing = @import("std").testing;
 
@@ -113,7 +113,7 @@ test "route injects when turn running and queue_mode is debounce" {
         .queue_mode = .debounce,
         .has_pending_injection = false,
     }));
-    // debounce always injects (accumulation handled inside the injection buffer)
+    // Debounce timing/merge is handled by the caller before depositing text.
     try testing.expectEqual(RoutingDecision.inject, route(.{
         .turn_running = true,
         .queue_mode = .debounce,

--- a/src/inbound_router.zig
+++ b/src/inbound_router.zig
@@ -1,0 +1,133 @@
+//! Pure routing logic for inbound messages.
+//!
+//! Given session state and the configured queue policy, returns the action
+//! the effectful shell should take.  No I/O, no allocations — fully unit-testable.
+//!
+//! Usage:
+//!   const input = session_mgr.routeInput(session_key);
+//!   switch (inbound_router.route(input)) {
+//!       .process          => session_mgr.processMessageStreaming(...),
+//!       .inject           => session_mgr.injectMidTurn(session_key, text),
+//!       .replace_injection => session_mgr.injectMidTurn(session_key, text),  // same effect
+//!       .queue            => session_mgr.enqueuePostTurn(session_key, text),
+//!       .drop             => {},
+//!   }
+
+const agent_mod = @import("agent/root.zig");
+
+pub const QueueMode = agent_mod.Agent.QueueMode;
+
+/// Lock-free snapshot of the state needed to make a routing decision.
+/// Obtained via SessionManager.routeInput().
+pub const RouteInput = struct {
+    /// True when agent.turn() is currently executing for this session.
+    turn_running: bool,
+    /// The session's configured inbound queue policy.
+    queue_mode: QueueMode,
+    /// True when there is already a message pending in the injection buffer.
+    has_pending_injection: bool,
+};
+
+/// Action the effectful shell should perform for an inbound message.
+pub const RoutingDecision = enum {
+    /// No turn in progress: acquire the session lock and start a new turn.
+    process,
+    /// Turn running, serial mode: enqueue behind the current turn.
+    queue,
+    /// Turn running: deposit text in the injection buffer so the active turn
+    /// picks it up at the next tool-loop boundary.
+    inject,
+    /// Turn running and an injection is already pending: replace it (latest-wins).
+    replace_injection,
+    /// Turn running, queue mode is off: discard the message silently.
+    drop,
+};
+
+/// Decide how to handle an inbound message given the current session state.
+pub fn route(input: RouteInput) RoutingDecision {
+    if (!input.turn_running) return .process;
+    return switch (input.queue_mode) {
+        .off => .drop,
+        .serial => .queue,
+        .latest => if (input.has_pending_injection) .replace_injection else .inject,
+        .debounce => .inject,
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+const testing = @import("std").testing;
+
+test "route returns process when turn is not running" {
+    for ([_]QueueMode{ .off, .serial, .latest, .debounce }) |mode| {
+        const decision = route(.{
+            .turn_running = false,
+            .queue_mode = mode,
+            .has_pending_injection = false,
+        });
+        try testing.expectEqual(RoutingDecision.process, decision);
+    }
+}
+
+test "route drops when turn running and queue_mode is off" {
+    try testing.expectEqual(RoutingDecision.drop, route(.{
+        .turn_running = true,
+        .queue_mode = .off,
+        .has_pending_injection = false,
+    }));
+}
+
+test "route queues when turn running and queue_mode is serial" {
+    try testing.expectEqual(RoutingDecision.queue, route(.{
+        .turn_running = true,
+        .queue_mode = .serial,
+        .has_pending_injection = false,
+    }));
+    // serial always queues regardless of pending injection
+    try testing.expectEqual(RoutingDecision.queue, route(.{
+        .turn_running = true,
+        .queue_mode = .serial,
+        .has_pending_injection = true,
+    }));
+}
+
+test "route injects when turn running and queue_mode is latest with no pending" {
+    try testing.expectEqual(RoutingDecision.inject, route(.{
+        .turn_running = true,
+        .queue_mode = .latest,
+        .has_pending_injection = false,
+    }));
+}
+
+test "route replaces injection when turn running and queue_mode is latest with pending" {
+    try testing.expectEqual(RoutingDecision.replace_injection, route(.{
+        .turn_running = true,
+        .queue_mode = .latest,
+        .has_pending_injection = true,
+    }));
+}
+
+test "route injects when turn running and queue_mode is debounce" {
+    try testing.expectEqual(RoutingDecision.inject, route(.{
+        .turn_running = true,
+        .queue_mode = .debounce,
+        .has_pending_injection = false,
+    }));
+    // debounce always injects (accumulation handled inside the injection buffer)
+    try testing.expectEqual(RoutingDecision.inject, route(.{
+        .turn_running = true,
+        .queue_mode = .debounce,
+        .has_pending_injection = true,
+    }));
+}
+
+test "route process takes priority over all modes when not running" {
+    const inputs = [_]RouteInput{
+        .{ .turn_running = false, .queue_mode = .off, .has_pending_injection = true },
+        .{ .turn_running = false, .queue_mode = .latest, .has_pending_injection = true },
+        .{ .turn_running = false, .queue_mode = .debounce, .has_pending_injection = false },
+    };
+    for (inputs) |input| {
+        try testing.expectEqual(RoutingDecision.process, route(input));
+    }
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -43,6 +43,7 @@ pub const provider_probe = @import("provider_probe.zig");
 pub const channel_probe = @import("channel_probe.zig");
 pub const from_json = @import("from_json.zig");
 pub const inbound_debounce = @import("inbound_debounce.zig");
+pub const inbound_router = @import("inbound_router.zig");
 
 // Phase 2: Agent core
 pub const agent = @import("agent.zig");

--- a/src/session.zig
+++ b/src/session.zig
@@ -201,11 +201,22 @@ pub const Session = struct {
         self.injection_pending = duped;
     }
 
-    /// Returns true if there is a pending injection (lock-free snapshot).
+    /// Returns true if there is a pending injection.
     pub fn hasInjection(self: *Session) bool {
         self.injection_mu.lock();
         defer self.injection_mu.unlock();
         return self.injection_pending != null;
+    }
+
+    fn drainInjection(self: *Session, owner_allocator: Allocator, target_allocator: Allocator) ?[]u8 {
+        self.injection_mu.lock();
+        defer self.injection_mu.unlock();
+
+        const pending = self.injection_pending orelse return null;
+        const drained = target_allocator.dupe(u8, pending) catch return null;
+        owner_allocator.free(pending);
+        self.injection_pending = null;
+        return drained;
     }
 };
 
@@ -1763,14 +1774,7 @@ pub const SessionManager = struct {
 
             fn callback(ctx: *anyopaque, agent_alloc: std.mem.Allocator) ?[]u8 {
                 const dc: *@This() = @ptrCast(@alignCast(ctx));
-                dc.session.injection_mu.lock();
-                defer dc.session.injection_mu.unlock();
-                const pending = dc.session.injection_pending orelse return null;
-                defer {
-                    dc.sm_allocator.free(pending);
-                    dc.session.injection_pending = null;
-                }
-                return agent_alloc.dupe(u8, pending) catch null;
+                return dc.session.drainInjection(dc.sm_allocator, agent_alloc);
             }
         };
         var drain_ctx = DrainCtx{ .session = session, .sm_allocator = self.allocator };
@@ -2180,6 +2184,73 @@ const MockProvider = struct {
     }
 
     fn mockDeinit(_: *anyopaque) void {}
+};
+
+const CaptureMessagesProvider = struct {
+    response: []const u8 = "ok",
+    chat_calls: usize = 0,
+    user_count: usize = 0,
+    user_lens: [4]usize = [_]usize{0} ** 4,
+    user_bufs: [4][128]u8 = undefined,
+
+    const vtable = Provider.VTable{
+        .chatWithSystem = chatWithSystem,
+        .chat = chat,
+        .supportsNativeTools = supportsNativeTools,
+        .getName = getName,
+        .deinit = deinitFn,
+    };
+
+    fn provider(self: *CaptureMessagesProvider) Provider {
+        return .{ .ptr = @ptrCast(self), .vtable = &vtable };
+    }
+
+    fn chatWithSystem(
+        ptr: *anyopaque,
+        allocator: Allocator,
+        _: ?[]const u8,
+        _: []const u8,
+        _: []const u8,
+        _: f64,
+    ) anyerror![]const u8 {
+        const self: *CaptureMessagesProvider = @ptrCast(@alignCast(ptr));
+        return allocator.dupe(u8, self.response);
+    }
+
+    fn chat(
+        ptr: *anyopaque,
+        allocator: Allocator,
+        request: providers.ChatRequest,
+        _: []const u8,
+        _: f64,
+    ) anyerror!providers.ChatResponse {
+        const self: *CaptureMessagesProvider = @ptrCast(@alignCast(ptr));
+        self.chat_calls += 1;
+        self.user_count = 0;
+        for (request.messages) |message| {
+            if (message.role != .user or self.user_count >= self.user_bufs.len) continue;
+            const idx = self.user_count;
+            const len = @min(message.content.len, self.user_bufs[idx].len);
+            @memcpy(self.user_bufs[idx][0..len], message.content[0..len]);
+            self.user_lens[idx] = len;
+            self.user_count += 1;
+        }
+        return .{ .content = try allocator.dupe(u8, self.response) };
+    }
+
+    fn userMessage(self: *const CaptureMessagesProvider, idx: usize) []const u8 {
+        return self.user_bufs[idx][0..self.user_lens[idx]];
+    }
+
+    fn supportsNativeTools(_: *anyopaque) bool {
+        return false;
+    }
+
+    fn getName(_: *anyopaque) []const u8 {
+        return "capture_messages";
+    }
+
+    fn deinitFn(_: *anyopaque) void {}
 };
 
 const CapturePromptProvider = struct {
@@ -3764,6 +3835,89 @@ test "processMessageStreaming forwards tool progress hints" {
     // Regression: A2A streaming depends on this sink to observe tool-call starts.
     try testing.expectEqual(@as(usize, 1), collector.count);
     try testing.expectEqualStrings("probe", collector.lastText());
+}
+
+test "routeInput observes pending mid-turn injection" {
+    var mock = MockProvider{ .response = "ok" };
+    const cfg = testConfig();
+    var sm = testSessionManager(testing.allocator, &mock, &cfg);
+    defer sm.deinit();
+
+    const session_key = "route:injection";
+    const session = try sm.getOrCreate(session_key);
+    session.agent.queue_mode = .latest;
+    session.turn_running.store(true, .release);
+    defer session.turn_running.store(false, .release);
+
+    try sm.injectMidTurn(session_key, "first");
+    try sm.injectMidTurn(session_key, "second");
+
+    const input = sm.routeInput(session_key);
+    try testing.expect(input.turn_running);
+    try testing.expectEqual(agent_mod.Agent.QueueMode.latest, input.queue_mode);
+    try testing.expect(input.has_pending_injection);
+    try testing.expectEqual(inbound_router.RoutingDecision.replace_injection, inbound_router.route(input));
+
+    const drained = session.drainInjection(testing.allocator, testing.allocator) orelse return error.TestExpectedEqual;
+    defer testing.allocator.free(drained);
+    try testing.expectEqualStrings("second", drained);
+    try testing.expect(!session.hasInjection());
+}
+
+test "drainInjection preserves pending message when target allocation fails" {
+    var mock = MockProvider{ .response = "ok" };
+    const cfg = testConfig();
+    var sm = testSessionManager(testing.allocator, &mock, &cfg);
+    defer sm.deinit();
+
+    const session = try sm.getOrCreate("inject:oom");
+    try session.injectMidTurn(testing.allocator, "keep me");
+
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{});
+    failing.fail_index = failing.alloc_index;
+
+    // Regression: a transient allocation failure in the agent allocator must not
+    // drop the pending injection before a later tool-loop boundary can retry it.
+    try testing.expect(session.drainInjection(testing.allocator, failing.allocator()) == null);
+    try testing.expect(session.hasInjection());
+
+    const drained = session.drainInjection(testing.allocator, testing.allocator) orelse return error.TestExpectedEqual;
+    defer testing.allocator.free(drained);
+    try testing.expectEqualStrings("keep me", drained);
+    try testing.expect(!session.hasInjection());
+}
+
+test "processMessageStreaming drains pending mid-turn injection into provider messages" {
+    var provider = CaptureMessagesProvider{};
+    const cfg = testConfig();
+    var noop = observability.NoopObserver{};
+    var sm = SessionManager.init(
+        testing.allocator,
+        &cfg,
+        provider.provider(),
+        &.{},
+        null,
+        noop.observer(),
+        null,
+        null,
+    );
+    defer sm.deinit();
+
+    const session_key = "inject:provider";
+    _ = try sm.getOrCreate(session_key);
+    try sm.injectMidTurn(session_key, "mid turn");
+
+    const resp = try sm.processMessage(session_key, "initial", null);
+    defer testing.allocator.free(resp);
+
+    // Regression: pending injections must be folded into the active provider
+    // request as user history, not left stranded in the session buffer.
+    try testing.expectEqual(@as(usize, 1), provider.chat_calls);
+    try testing.expectEqual(@as(usize, 2), provider.user_count);
+    try testing.expectEqualStrings("initial", provider.userMessage(0));
+    try testing.expectEqualStrings("mid turn", provider.userMessage(1));
+    const session = try sm.getOrCreate(session_key);
+    try testing.expect(!session.hasInjection());
 }
 
 test "processMessage refreshes system prompt when conversation context is cleared" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -28,6 +28,7 @@ const util = @import("util.zig");
 const onboard = @import("onboard.zig");
 const bootstrap_mod = @import("bootstrap/root.zig");
 const observability = @import("observability.zig");
+const inbound_router = @import("inbound_router.zig");
 const Observer = observability.Observer;
 const tools_mod = @import("tools/root.zig");
 const cron_mod = @import("cron.zig");
@@ -176,13 +177,35 @@ pub const Session = struct {
     turn_count: u64,
     turn_running: std.atomic.Value(bool),
     mutex: std_compat.sync.Mutex,
+    /// Protects injection_pending independently of the session turn mutex.
+    injection_mu: std_compat.sync.Mutex = .{},
+    /// Pending mid-turn message; owned by the SessionManager allocator.
+    injection_pending: ?[]u8 = null,
 
     pub fn deinit(self: *Session, allocator: Allocator) void {
         self.agent.deinit();
         if (self.provider_holder) |*holder| holder.deinit();
         if (self.owned_provider_api_key) |key| allocator.free(key);
         if (self.owned_memory_session_id) |sid| allocator.free(sid);
+        if (self.injection_pending) |p| allocator.free(p);
         allocator.free(self.session_key);
+    }
+
+    /// Deposit text in the injection buffer (replaces any existing pending injection).
+    /// Must be called with the SM allocator, NOT while holding session.mutex.
+    pub fn injectMidTurn(self: *Session, allocator: Allocator, text: []const u8) !void {
+        const duped = try allocator.dupe(u8, text);
+        self.injection_mu.lock();
+        defer self.injection_mu.unlock();
+        if (self.injection_pending) |old| allocator.free(old);
+        self.injection_pending = duped;
+    }
+
+    /// Returns true if there is a pending injection (lock-free snapshot).
+    pub fn hasInjection(self: *Session) bool {
+        self.injection_mu.lock();
+        defer self.injection_mu.unlock();
+        return self.injection_pending != null;
     }
 };
 
@@ -1734,6 +1757,32 @@ pub const SessionManager = struct {
             session.agent.progress_ctx = null;
         }
 
+        const DrainCtx = struct {
+            session: *Session,
+            sm_allocator: Allocator,
+
+            fn callback(ctx: *anyopaque, agent_alloc: std.mem.Allocator) ?[]u8 {
+                const dc: *@This() = @ptrCast(@alignCast(ctx));
+                dc.session.injection_mu.lock();
+                defer dc.session.injection_mu.unlock();
+                const pending = dc.session.injection_pending orelse return null;
+                defer {
+                    dc.sm_allocator.free(pending);
+                    dc.session.injection_pending = null;
+                }
+                return agent_alloc.dupe(u8, pending) catch null;
+            }
+        };
+        var drain_ctx = DrainCtx{ .session = session, .sm_allocator = self.allocator };
+        const prev_drain_cb = session.agent.drain_injection_cb;
+        const prev_drain_ctx_val = session.agent.drain_injection_ctx;
+        defer {
+            session.agent.drain_injection_cb = prev_drain_cb;
+            session.agent.drain_injection_ctx = prev_drain_ctx_val;
+        }
+        session.agent.drain_injection_cb = DrainCtx.callback;
+        session.agent.drain_injection_ctx = @ptrCast(&drain_ctx);
+
         // Record agent start event with channel attribution
         const start_event = @import("observability.zig").ObserverEvent{ .agent_start = .{
             .provider = session.agent.provider.getName(),
@@ -1786,6 +1835,35 @@ pub const SessionManager = struct {
             self.active_tool = null;
         }
     };
+
+    /// Return the routing input for a session without acquiring session.mutex.
+    /// If the session does not exist yet, returns defaults (process, off, false).
+    pub fn routeInput(self: *SessionManager, session_key: []const u8) inbound_router.RouteInput {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const session = self.sessions.get(session_key) orelse return .{
+            .turn_running = false,
+            .queue_mode = .off,
+            .has_pending_injection = false,
+        };
+        return .{
+            .turn_running = session.turn_running.load(.acquire),
+            .queue_mode = session.agent.queue_mode,
+            .has_pending_injection = session.hasInjection(),
+        };
+    }
+
+    /// Deposit a mid-turn injection for a running session.
+    /// Safe to call while the session turn is in progress — does not acquire session.mutex.
+    /// Replaces any existing pending injection.  No-op when session does not exist.
+    pub fn injectMidTurn(self: *SessionManager, session_key: []const u8, text: []const u8) !void {
+        const session = blk: {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            break :blk self.sessions.get(session_key) orelse return;
+        };
+        try session.injectMidTurn(self.allocator, text);
+    }
 
     pub const SessionSnapshot = struct {
         session_key: []u8,


### PR DESCRIPTION
## Summary

### EN:
Part 1 of #832 (concurrent/non-blocking interactivity). Introduces the pure routing core and the effectful injection buffer. Subsequent PRs will wire each shell (`channel_loop`, `gateway`) to use them.

**`src/inbound_router.zig`** (new — pure, no I/O):
- `route(RouteInput) -> RoutingDecision`: given `turn_running`, `queue_mode`, and `has_pending_injection`, returns one of `process / queue / inject / replace_injection / drop`.
- 7 unit tests cover all mode × state combinations.

**`src/agent/root.zig`**:
- `QueueMode` promoted to `pub` so `inbound_router` can reference it.
- `DrainCallback` type added (mirrors `StreamCallback` / `ProgressCallback` pattern).
- `drain_injection_cb` / `drain_injection_ctx` fields on `Agent`.
- Tool loop drains any pending injection at each boundary before building provider messages, appending it as an owned user history message.

**`src/session.zig`**:
- `Session` gains `injection_mu` (separate from `session.mutex`) and `injection_pending` (`?[]u8` owned by SM allocator).
- `Session.injectMidTurn` writes to the buffer without touching `session.mutex` — safe to call while a turn is in progress.
- `processMessageStreaming` sets up a `DrainCtx` bridging the SM allocator and the injection buffer into the agent's `DrainCallback`, following the same set/restore pattern as `stream_callback`.
- `SessionManager.routeInput` returns `RouteInput` without acquiring `session.mutex`.
- `SessionManager.injectMidTurn` exposes public injection for shell callers.

### ZH:
#832（并发/非阻塞交互）的第 1 部分。引入纯路由核心和副作用注入缓冲区，后续 PR 将逐个对 shell 层（`channel_loop`、`gateway`）进行迁移。

- 新增 `src/inbound_router.zig`：纯函数 `route()` 根据 `turn_running`、`queue_mode`、`has_pending_injection` 返回路由决策，7 个单元测试覆盖所有模式组合。
- `agent/root.zig`：`QueueMode` 改为 `pub`；新增 `DrainCallback` 类型和对应字段；工具循环每次迭代前检查并排空注入缓冲区。
- `session.zig`：`Session` 新增独立于 `session.mutex` 的 `injection_mu` 和 `injection_pending`；`processMessageStreaming` 通过 `DrainCtx` 将 SM 分配器和注入缓冲区桥接至 Agent 的 `DrainCallback`；`SessionManager` 新增 `routeInput` 和 `injectMidTurn` 公共方法。

## Validation
- `zig build` ✓
- `zig build test --test-timeout 30s --summary all`: 6601 pass, 13 skip, 5 Redis timeouts (pre-existing) ✓
- 7 new unit tests in `inbound_router.zig` covering all `QueueMode × turn_running` combinations

## Notes
- This PR is intentionally shell-agnostic: no channel code is changed. The routing decision is computed but not yet consumed by any caller — that is the scope of the follow-up PRs.
- Lock ordering: `SM.mutex` → release → `Session.injection_mu`. `session.mutex` and `injection_mu` are never held simultaneously, eliminating any deadlock risk.
