### PR TITLE
fix(memory): improve archive provenance and recall quality | 修复(memory): 提升归档来源与召回质量

### DIFF
--- a/src/agent/memory_loader.zig
+++ b/src/agent/memory_loader.zig
@@ -45,6 +45,26 @@ fn isInternalMemoryEntry(entry: MemoryEntry) bool {
     return memory_mod.isInternalMemoryEntryKeyOrContent(entry.key, entry.content);
 }
 
+fn isArchiveConversationKey(key: []const u8) bool {
+    return std.mem.startsWith(u8, key, "archive:conversation:");
+}
+
+fn isArchiveConversationEntry(entry: MemoryEntry) bool {
+    if (isArchiveConversationKey(entry.key)) return true;
+    if (extractMarkdownMemoryKey(entry.content)) |extracted| {
+        return isArchiveConversationKey(extracted);
+    }
+    return false;
+}
+
+fn isArchiveConversationCandidate(cand: memory_mod.RetrievalCandidate) bool {
+    if (isArchiveConversationKey(cand.key)) return true;
+    if (extractMarkdownMemoryKey(cand.snippet)) |extracted| {
+        return isArchiveConversationKey(extracted);
+    }
+    return false;
+}
+
 fn sanitizeMemoryText(allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
     // Strip inline image markers from recalled snippets so stale
     // [IMAGE:...] references do not accidentally trigger multimodal mode.
@@ -90,18 +110,24 @@ pub fn loadContext(
     var appended: usize = 0;
     var wrote_header = false;
 
-    for (scoped_entries) |entry| {
-        if (isInternalMemoryEntry(entry)) continue;
-        if (!wrote_header) {
-            try w.writeAll("[Memory context]\n");
-            wrote_header = true;
+    // Prefer scoped high-signal entries first. Archived conversation chunks are
+    // still allowed, but only after non-archived matches from the same scope.
+    for ([_]bool{ false, true }) |include_archived| {
+        for (scoped_entries) |entry| {
+            if (isInternalMemoryEntry(entry)) continue;
+            if (isArchiveConversationEntry(entry) != include_archived) continue;
+            if (!wrote_header) {
+                try w.writeAll("[Memory context]\n");
+                wrote_header = true;
+            }
+            // Truncate individual entry content to prevent a single large memory from blowing the budget
+            const content = util.truncateUtf8(entry.content, MAX_CONTEXT_BYTES / 2);
+            const sanitized = try sanitizeMemoryText(allocator, content);
+            defer allocator.free(sanitized);
+            try w.print("- {s}: {s}\n", .{ entry.key, sanitized });
+            appended += 1;
+            if (appended >= DEFAULT_RECALL_LIMIT or buf.items.len >= MAX_CONTEXT_BYTES) break;
         }
-        // Truncate individual entry content to prevent a single large memory from blowing the budget
-        const content = util.truncateUtf8(entry.content, MAX_CONTEXT_BYTES / 2);
-        const sanitized = try sanitizeMemoryText(allocator, content);
-        defer allocator.free(sanitized);
-        try w.print("- {s}: {s}\n", .{ entry.key, sanitized });
-        appended += 1;
         if (appended >= DEFAULT_RECALL_LIMIT or buf.items.len >= MAX_CONTEXT_BYTES) break;
     }
 
@@ -111,6 +137,7 @@ pub fn loadContext(
                 if (entry.session_id != null) continue; // keep scoped isolation (no cross-session bleed)
                 if (containsKey(scoped_entries, entry.key)) continue;
                 if (isInternalMemoryEntry(entry)) continue;
+                if (isArchiveConversationEntry(entry)) continue; // avoid low-provenance global archive bleed
 
                 if (!wrote_header) {
                     try w.writeAll("[Memory context]\n");
@@ -155,20 +182,24 @@ pub fn loadContextWithRuntime(
     var appended: usize = 0;
     var wrote_header = false;
 
-    for (scoped_candidates) |cand| {
-        if (isInternalMemoryKey(cand.key)) continue;
-        if (extractMarkdownMemoryKey(cand.snippet)) |extracted| {
-            if (isInternalMemoryKey(extracted)) continue;
+    for ([_]bool{ false, true }) |include_archived| {
+        for (scoped_candidates) |cand| {
+            if (isInternalMemoryKey(cand.key)) continue;
+            if (extractMarkdownMemoryKey(cand.snippet)) |extracted| {
+                if (isInternalMemoryKey(extracted)) continue;
+            }
+            if (isArchiveConversationCandidate(cand) != include_archived) continue;
+            if (!wrote_header) {
+                try w.writeAll("[Memory context]\n");
+                wrote_header = true;
+            }
+            const snippet = util.truncateUtf8(cand.snippet, MAX_CONTEXT_BYTES / 2);
+            const sanitized = try sanitizeMemoryText(allocator, snippet);
+            defer allocator.free(sanitized);
+            try w.print("- {s}: {s}\n", .{ cand.key, sanitized });
+            appended += 1;
+            if (appended >= DEFAULT_RECALL_LIMIT or buf.items.len >= MAX_CONTEXT_BYTES) break;
         }
-        if (!wrote_header) {
-            try w.writeAll("[Memory context]\n");
-            wrote_header = true;
-        }
-        const snippet = util.truncateUtf8(cand.snippet, MAX_CONTEXT_BYTES / 2);
-        const sanitized = try sanitizeMemoryText(allocator, snippet);
-        defer allocator.free(sanitized);
-        try w.print("- {s}: {s}\n", .{ cand.key, sanitized });
-        appended += 1;
         if (appended >= DEFAULT_RECALL_LIMIT or buf.items.len >= MAX_CONTEXT_BYTES) break;
     }
 
@@ -181,6 +212,7 @@ pub fn loadContextWithRuntime(
                 if (entry.session_id != null) continue; // keep scoped isolation (no cross-session bleed)
                 if (containsCandidateKey(scoped_candidates, entry.key)) continue;
                 if (isInternalMemoryEntry(entry)) continue;
+                if (isArchiveConversationEntry(entry)) continue; // avoid low-provenance global archive bleed
 
                 if (!wrote_header) {
                     try w.writeAll("[Memory context]\n");
@@ -473,4 +505,86 @@ test "loadContextWithRuntime with session_id includes global entries but not oth
     try std.testing.expect(std.mem.indexOf(u8, context, "sess_a_fact") != null);
     try std.testing.expect(std.mem.indexOf(u8, context, "global_fact") != null);
     try std.testing.expect(std.mem.indexOf(u8, context, "sess_b_fact") == null);
+}
+
+test "loadContext skips globally preserved archive conversation entries" {
+    const allocator = std.testing.allocator;
+
+    var sqlite_mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
+    defer sqlite_mem.deinit();
+    const mem = sqlite_mem.memory();
+
+    try mem.store("sess_a_fact", "session A favorite", .core, "sess-a");
+    try mem.store("global_fact", "global favorite", .core, null);
+    // Regression: globally scoped archive shards can leak unrelated legacy turns.
+    try mem.store(
+        "archive:conversation:autosave_user_1699999999000000000:chunk:0",
+        "Archived conversation source: archive:conversation:autosave_user_1699999999000000000\nChunk: 1/1\n\nfavorite legacy transcript",
+        .{ .custom = "archive" },
+        null,
+    );
+
+    const context = try loadContext(allocator, mem, "favorite", "sess-a");
+    defer allocator.free(context);
+
+    try std.testing.expect(std.mem.indexOf(u8, context, "sess_a_fact") != null);
+    try std.testing.expect(std.mem.indexOf(u8, context, "global_fact") != null);
+    try std.testing.expect(std.mem.indexOf(u8, context, "archive:conversation:autosave_user_1699999999000000000:chunk:0") == null);
+}
+
+test "loadContextWithRuntime skips globally preserved archive conversation entries" {
+    const allocator = std.testing.allocator;
+
+    var sqlite_mem = try memory_mod.SqliteMemory.init(allocator, ":memory:");
+    defer sqlite_mem.deinit();
+    const mem = sqlite_mem.memory();
+
+    try mem.store("sess_a_fact", "session A favorite", .core, "sess-a");
+    try mem.store("global_fact", "global favorite", .core, null);
+    // Regression: globally scoped archive shards can leak unrelated legacy turns.
+    try mem.store(
+        "archive:conversation:autosave_user_1699999999000000000:chunk:0",
+        "Archived conversation source: archive:conversation:autosave_user_1699999999000000000\nChunk: 1/1\n\nfavorite legacy transcript",
+        .{ .custom = "archive" },
+        null,
+    );
+
+    const resolved = memory_mod.ResolvedConfig{
+        .primary_backend = "test",
+        .retrieval_mode = "keyword",
+        .vector_mode = "none",
+        .embedding_provider = "none",
+        .rollout_mode = "off",
+        .vector_sync_mode = "best_effort",
+        .hygiene_enabled = false,
+        .snapshot_enabled = false,
+        .cache_enabled = false,
+        .semantic_cache_enabled = false,
+        .summarizer_enabled = false,
+        .source_count = 0,
+        .fallback_policy = "degrade",
+    };
+    var rt = memory_mod.MemoryRuntime{
+        .memory = mem,
+        .session_store = null,
+        .response_cache = null,
+        .capabilities = .{
+            .supports_keyword_rank = false,
+            .supports_session_store = false,
+            .supports_transactions = false,
+            .supports_outbox = false,
+        },
+        .resolved = resolved,
+        ._db_path = null,
+        ._cache_db_path = null,
+        ._engine = null,
+        ._allocator = allocator,
+    };
+
+    const context = try loadContextWithRuntime(allocator, &rt, "favorite", "sess-a");
+    defer allocator.free(context);
+
+    try std.testing.expect(std.mem.indexOf(u8, context, "sess_a_fact") != null);
+    try std.testing.expect(std.mem.indexOf(u8, context, "global_fact") != null);
+    try std.testing.expect(std.mem.indexOf(u8, context, "archive:conversation:autosave_user_1699999999000000000:chunk:0") == null);
 }

--- a/src/agent/memory_loader.zig
+++ b/src/agent/memory_loader.zig
@@ -12,6 +12,7 @@ const MemoryRuntime = memory_mod.MemoryRuntime;
 
 /// Default number of memory entries to recall per query.
 const DEFAULT_RECALL_LIMIT: usize = 5;
+const SCOPED_RECALL_CANDIDATE_LIMIT: usize = 64;
 const GLOBAL_RECALL_CANDIDATE_LIMIT: usize = 64;
 
 /// Maximum total bytes of memory context injected into a message.
@@ -89,18 +90,10 @@ pub fn loadContext(
     user_message: []const u8,
     session_id: ?[]const u8,
 ) ![]const u8 {
-    const scoped_entries = mem.recall(allocator, user_message, DEFAULT_RECALL_LIMIT, session_id) catch {
+    const scoped_entries = mem.recall(allocator, user_message, SCOPED_RECALL_CANDIDATE_LIMIT, session_id) catch {
         return try allocator.dupe(u8, "");
     };
     defer memory_mod.freeEntries(allocator, scoped_entries);
-
-    // When scoped recall is enabled, also include global (session_id = null) memory
-    // so long-term facts from memory_store remain visible in session chats.
-    var global_entries: ?[]MemoryEntry = null;
-    if (session_id != null and scoped_entries.len < DEFAULT_RECALL_LIMIT) {
-        global_entries = mem.recall(allocator, user_message, GLOBAL_RECALL_CANDIDATE_LIMIT, null) catch null;
-    }
-    defer if (global_entries) |entries| memory_mod.freeEntries(allocator, entries);
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer buf.deinit(allocator);
@@ -132,6 +125,11 @@ pub fn loadContext(
     }
 
     if (appended < DEFAULT_RECALL_LIMIT and buf.items.len < MAX_CONTEXT_BYTES and session_id != null) {
+        // When scoped recall is enabled, also include global (session_id = null)
+        // memory so long-term facts from memory_store remain visible in session chats.
+        const global_entries = mem.recall(allocator, user_message, GLOBAL_RECALL_CANDIDATE_LIMIT, null) catch null;
+        defer if (global_entries) |entries| memory_mod.freeEntries(allocator, entries);
+
         if (global_entries) |entries| {
             for (entries) |entry| {
                 if (entry.session_id != null) continue; // keep scoped isolation (no cross-session bleed)
@@ -170,10 +168,16 @@ pub fn loadContextWithRuntime(
     user_message: []const u8,
     session_id: ?[]const u8,
 ) ![]const u8 {
-    const scoped_candidates = rt.search(allocator, user_message, DEFAULT_RECALL_LIMIT, session_id) catch {
+    const scoped_candidates = rt.search(allocator, user_message, SCOPED_RECALL_CANDIDATE_LIMIT, session_id) catch {
         return try allocator.dupe(u8, "");
     };
     defer memory_mod.retrieval.freeCandidates(allocator, scoped_candidates);
+
+    var scoped_fallback_entries: ?[]MemoryEntry = null;
+    if (scoped_candidates.len < SCOPED_RECALL_CANDIDATE_LIMIT) {
+        scoped_fallback_entries = rt.memory.recall(allocator, user_message, SCOPED_RECALL_CANDIDATE_LIMIT, session_id) catch null;
+    }
+    defer if (scoped_fallback_entries) |entries| memory_mod.freeEntries(allocator, entries);
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer buf.deinit(allocator);
@@ -200,6 +204,25 @@ pub fn loadContextWithRuntime(
             appended += 1;
             if (appended >= DEFAULT_RECALL_LIMIT or buf.items.len >= MAX_CONTEXT_BYTES) break;
         }
+        if (appended < DEFAULT_RECALL_LIMIT and buf.items.len < MAX_CONTEXT_BYTES) {
+            if (scoped_fallback_entries) |entries| {
+                for (entries) |entry| {
+                    if (containsCandidateKey(scoped_candidates, entry.key)) continue;
+                    if (isInternalMemoryEntry(entry)) continue;
+                    if (isArchiveConversationEntry(entry) != include_archived) continue;
+                    if (!wrote_header) {
+                        try w.writeAll("[Memory context]\n");
+                        wrote_header = true;
+                    }
+                    const content = util.truncateUtf8(entry.content, MAX_CONTEXT_BYTES / 2);
+                    const sanitized = try sanitizeMemoryText(allocator, content);
+                    defer allocator.free(sanitized);
+                    try w.print("- {s}: {s}\n", .{ entry.key, sanitized });
+                    appended += 1;
+                    if (appended >= DEFAULT_RECALL_LIMIT or buf.items.len >= MAX_CONTEXT_BYTES) break;
+                }
+            }
+        }
         if (appended >= DEFAULT_RECALL_LIMIT or buf.items.len >= MAX_CONTEXT_BYTES) break;
     }
 
@@ -211,6 +234,9 @@ pub fn loadContextWithRuntime(
             for (entries) |entry| {
                 if (entry.session_id != null) continue; // keep scoped isolation (no cross-session bleed)
                 if (containsCandidateKey(scoped_candidates, entry.key)) continue;
+                if (scoped_fallback_entries) |fallback_entries| {
+                    if (containsKey(fallback_entries, entry.key)) continue;
+                }
                 if (isInternalMemoryEntry(entry)) continue;
                 if (isArchiveConversationEntry(entry)) continue; // avoid low-provenance global archive bleed
 
@@ -587,4 +613,97 @@ test "loadContextWithRuntime skips globally preserved archive conversation entri
     try std.testing.expect(std.mem.indexOf(u8, context, "sess_a_fact") != null);
     try std.testing.expect(std.mem.indexOf(u8, context, "global_fact") != null);
     try std.testing.expect(std.mem.indexOf(u8, context, "archive:conversation:autosave_user_1699999999000000000:chunk:0") == null);
+}
+
+test "loadContext prefers scoped facts when archive candidates fill recall window" {
+    const allocator = std.testing.allocator;
+
+    var mem_impl = memory_mod.InMemoryLruMemory.init(allocator, 32);
+    defer mem_impl.deinit();
+    const mem = mem_impl.memory();
+
+    try mem.store("scoped_fact", "needle scoped answer", .core, "sess-a");
+    var idx: usize = 0;
+    while (idx < DEFAULT_RECALL_LIMIT) : (idx += 1) {
+        var key_buf: [96]u8 = undefined;
+        const key = try std.fmt.bufPrint(
+            &key_buf,
+            "archive:conversation:autosave_user_1700000000000000000:chunk:{d}",
+            .{idx},
+        );
+        try mem.store(key, "needle archived transcript", .{ .custom = "archive" }, "sess-a");
+    }
+
+    // Regression: archive chunks can fill the raw recall limit and hide a lower-ranked scoped fact.
+    const context = try loadContext(allocator, mem, "needle", "sess-a");
+    defer allocator.free(context);
+
+    const fact_pos = std.mem.indexOf(u8, context, "scoped_fact") orelse return error.TestUnexpectedResult;
+    const archive_pos = std.mem.indexOf(u8, context, "archive:conversation:") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(fact_pos < archive_pos);
+}
+
+test "loadContextWithRuntime prefers scoped facts when engine candidates fill with archives" {
+    const allocator = std.testing.allocator;
+
+    var mem_impl = memory_mod.InMemoryLruMemory.init(allocator, 32);
+    defer mem_impl.deinit();
+    const mem = mem_impl.memory();
+
+    try mem.store("scoped_fact", "needle scoped answer", .core, "sess-a");
+    var idx: usize = 0;
+    while (idx < DEFAULT_RECALL_LIMIT) : (idx += 1) {
+        var key_buf: [96]u8 = undefined;
+        const key = try std.fmt.bufPrint(
+            &key_buf,
+            "archive:conversation:autosave_user_1700000000000000000:chunk:{d}",
+            .{idx},
+        );
+        try mem.store(key, "needle archived transcript", .{ .custom = "archive" }, "sess-a");
+    }
+
+    var primary = memory_mod.PrimaryAdapter.init(mem);
+    var engine = memory_mod.RetrievalEngine.init(allocator, .{ .max_results = DEFAULT_RECALL_LIMIT });
+    defer engine.deinit();
+    try engine.addSource(primary.adapter());
+
+    const resolved = memory_mod.ResolvedConfig{
+        .primary_backend = "test",
+        .retrieval_mode = "keyword",
+        .vector_mode = "none",
+        .embedding_provider = "none",
+        .rollout_mode = "off",
+        .vector_sync_mode = "best_effort",
+        .hygiene_enabled = false,
+        .snapshot_enabled = false,
+        .cache_enabled = false,
+        .semantic_cache_enabled = false,
+        .summarizer_enabled = false,
+        .source_count = 0,
+        .fallback_policy = "degrade",
+    };
+    var rt = memory_mod.MemoryRuntime{
+        .memory = mem,
+        .session_store = null,
+        .response_cache = null,
+        .capabilities = .{
+            .supports_keyword_rank = false,
+            .supports_session_store = false,
+            .supports_transactions = false,
+            .supports_outbox = false,
+        },
+        .resolved = resolved,
+        ._db_path = null,
+        ._cache_db_path = null,
+        ._engine = &engine,
+        ._allocator = allocator,
+    };
+
+    // Regression: engine top_k can fill with archive chunks and hide a lower-ranked scoped fact.
+    const context = try loadContextWithRuntime(allocator, &rt, "needle", "sess-a");
+    defer allocator.free(context);
+
+    const fact_pos = std.mem.indexOf(u8, context, "scoped_fact") orelse return error.TestUnexpectedResult;
+    const archive_pos = std.mem.indexOf(u8, context, "archive:conversation:") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(fact_pos < archive_pos);
 }

--- a/src/memory/lifecycle/hygiene.zig
+++ b/src/memory/lifecycle/hygiene.zig
@@ -49,7 +49,7 @@ pub const HygieneConfig = struct {
 /// Optional callback sink used to synchronize preserved chunks into vector storage.
 pub const PreserveSyncHook = struct {
     ptr: *anyopaque,
-    callback: *const fn (ptr: *anyopaque, allocator: std.mem.Allocator, key: []const u8, content: []const u8) void,
+    callback: *const fn (ptr: *anyopaque, allocator: std.mem.Allocator, key: []const u8, content: []const u8, session_id: ?[]const u8) void,
 };
 
 /// Run memory hygiene if the cadence window has elapsed.
@@ -237,7 +237,7 @@ fn preserveArchiveFile(
         defer allocator.free(wrapped);
         try mem.store(key, wrapped, ARCHIVE_CATEGORY, null);
         if (preserve_sync_hook) |hook| {
-            hook.callback(hook.ptr, allocator, key, wrapped);
+            hook.callback(hook.ptr, allocator, key, wrapped, null);
         }
     }
 }
@@ -247,6 +247,7 @@ fn preserveConversationEntry(
     mem: Memory,
     key_prefix: []const u8,
     content: []const u8,
+    session_id: ?[]const u8,
     preserve_sync_hook: ?PreserveSyncHook,
 ) !void {
     const chunks = try chunker.chunkMarkdown(allocator, content, ARCHIVE_CHUNK_MAX_TOKENS);
@@ -262,9 +263,9 @@ fn preserveConversationEntry(
             .{ key_prefix, idx + 1, chunks.len, chunk.content },
         );
         defer allocator.free(wrapped);
-        try mem.store(archive_key, wrapped, ARCHIVE_CATEGORY, null);
+        try mem.store(archive_key, wrapped, ARCHIVE_CATEGORY, session_id);
         if (preserve_sync_hook) |hook| {
-            hook.callback(hook.ptr, allocator, archive_key, wrapped);
+            hook.callback(hook.ptr, allocator, archive_key, wrapped, session_id);
         }
     }
 }
@@ -301,7 +302,7 @@ fn pruneConversationRowsWithPreserve(
             if (preserve_before_forget) {
                 const preserve_key_prefix = try std.fmt.allocPrint(allocator, "archive:conversation:{s}", .{entry.key});
                 defer allocator.free(preserve_key_prefix);
-                preserveConversationEntry(allocator, mem, preserve_key_prefix, entry.content, preserve_sync_hook) catch |err| {
+                preserveConversationEntry(allocator, mem, preserve_key_prefix, entry.content, entry.session_id, preserve_sync_hook) catch |err| {
                     log.warn("skipping prune for '{s}' because preservation failed: {}", .{ entry.key, err });
                     continue;
                 };
@@ -596,4 +597,38 @@ test "runIfDue preserves conversation rows before prune when enabled" {
         }
     }
     try std.testing.expect(found);
+}
+
+test "runIfDue preserves pruned conversation chunks under original session scope" {
+    if (!build_options.enable_sqlite) return;
+
+    var mem_impl = try sqlite_mod.SqliteMemory.init(std.testing.allocator, ":memory:");
+    defer mem_impl.deinit();
+    const mem = mem_impl.memory();
+
+    try mem.store("autosave_user_1700000000000000000", "scoped conversation message", .conversation, "sess-a");
+
+    const report = runIfDue(std.testing.allocator, .{
+        .hygiene_enabled = true,
+        .archive_after_days = 0,
+        .purge_after_days = 0,
+        .conversation_retention_days = 1,
+        .preserve_before_purge = true,
+        .workspace_dir = "/tmp",
+    }, mem, null);
+
+    try std.testing.expectEqual(@as(u64, 1), report.pruned_conversation_rows);
+
+    const scoped_preserved = try mem.list(std.testing.allocator, .{ .custom = "archive" }, "sess-a");
+    defer root.freeEntries(std.testing.allocator, scoped_preserved);
+    try std.testing.expect(scoped_preserved.len > 0);
+
+    for (scoped_preserved) |entry| {
+        try std.testing.expect(entry.session_id != null);
+        try std.testing.expectEqualStrings("sess-a", entry.session_id.?);
+    }
+
+    const other_scope = try mem.list(std.testing.allocator, .{ .custom = "archive" }, "sess-b");
+    defer root.freeEntries(std.testing.allocator, other_scope);
+    try std.testing.expectEqual(@as(usize, 0), other_scope.len);
 }

--- a/src/memory/root.zig
+++ b/src/memory/root.zig
@@ -877,13 +877,14 @@ fn syncPreservedChunkToVector(
     allocator: std.mem.Allocator,
     key: []const u8,
     content: []const u8,
+    session_id: ?[]const u8,
 ) void {
     const ctx: *HygienePreserveSyncCtx = @ptrCast(@alignCast(ctx_ptr));
     syncVectorUpsertWithComponents(
         allocator,
         key,
         content,
-        null,
+        session_id,
         ctx.outbox,
         ctx.embed_provider,
         ctx.vector_store,


### PR DESCRIPTION
## Summary

### EN:
   - Preserved original session scope when hygiene archives pruned conversation rows (`archive:conversation:*` is no longer forced to global scope).
   - Propagated preserved chunk `session_id` into vector-sync key encoding so retrieval partitioning stays aligned.
   - Improved memory recall quality by prioritizing scoped non-archived matches first, while still allowing scoped archived chunks as fallback.
   - Blocked globally scoped `archive:conversation:*` entries from global fallback recall to prevent cross-session contamination.
   - Added regression tests for scoped archive preservation and global-archive filtering across raw recall and runtime retrieval paths.

### ZH:
   - 在清理流程归档会话记录时保留原始 session 作用域（`archive:conversation:*` 不再被写成全局）。
   - 将归档分片的 `session_id` 传递到向量同步 key 编码，保证检索分区一致。
   - 提升记忆召回质量：优先使用当前 session 的非归档命中，同时保留当前 session 归档命中作为回退。
   - 禁止全局 `archive:conversation:*` 通过全局回退注入上下文，避免跨会话污染。
   - 增加回归测试，覆盖作用域归档保留与全局归档过滤（原始 recall 与 runtime 检索两条路径）。

## Validation
   - `zig build test --summary all`: 6660/6673 tests passed (13 skipped).

## Notes
   - This PR intentionally keeps old-memory reintroduction behavior, but tightens provenance and ranking so scoped context is favored.