### PR TITLE
fix(subagent): deliver completions to original channel context | 修复(subagent): 将完成结果回传到原始频道上下文

### DIFF
--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -67,6 +67,22 @@ fn persistCliTurn(agent: *const Agent, content: []const u8, response: []const u8
     }, session_key, content, response);
 }
 
+fn printPendingSubagentNotices(
+    allocator: std.mem.Allocator,
+    writer: *std.Io.Writer,
+    manager: *subagent_mod.SubagentManager,
+    session_key: ?[]const u8,
+) !void {
+    const notices = try manager.takeCompletionNoticesForSession(allocator, session_key);
+    defer subagent_mod.SubagentManager.freeCompletionNotices(allocator, notices);
+    for (notices) |notice| {
+        try writer.print("\n{s}\n\n", .{notice.content});
+    }
+    if (notices.len > 0) {
+        try writer.flush();
+    }
+}
+
 fn cliStreamSinkCallback(ctx_ptr: *anyopaque, event: streaming.Event) void {
     if (event.stage != .chunk or event.text.len == 0) return;
     const stream_ctx: *CliStreamCtx = @ptrCast(@alignCast(ctx_ptr));
@@ -644,6 +660,8 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
     defer if (pending_line) |line| allocator.free(line);
 
     while (true) {
+        printPendingSubagentNotices(allocator, w, &subagent_manager, agent.memory_session_id) catch {};
+
         var owned_line: ?[]u8 = null;
         defer if (owned_line) |line| allocator.free(line);
 

--- a/src/agent/commands.zig
+++ b/src/agent/commands.zig
@@ -3136,6 +3136,83 @@ test "handleSubagentsCommand help documents both agent flag forms" {
     try std.testing.expect(std.mem.indexOf(u8, response, "--agent=<name>") != null);
 }
 
+test "refreshSubagentToolContext uses conversation origin route" {
+    var spawn_tool = spawn_tool_mod.SpawnTool{};
+    const tools = [_]Tool{spawn_tool.tool()};
+    var harness = struct {
+        allocator: std.mem.Allocator,
+        tools: []const Tool,
+        memory_session_id: ?[]const u8 = "agent:main:discord:direct:user-42",
+        conversation_context: ?struct {
+            channel: ?[]const u8 = null,
+            account_id: ?[]const u8 = null,
+            delivery_chat_id: ?[]const u8 = null,
+            peer_id: ?[]const u8 = null,
+        } = .{
+            .channel = "discord",
+            .account_id = "discord-main",
+            .delivery_chat_id = "dm-channel-42",
+            .peer_id = "user-42",
+        },
+    }{
+        .allocator = std.testing.allocator,
+        .tools = tools[0..],
+    };
+
+    refreshSubagentToolContext(&harness);
+
+    try std.testing.expectEqualStrings("discord", spawn_tool.default_channel.?);
+    try std.testing.expectEqualStrings("discord-main", spawn_tool.default_account_id.?);
+    try std.testing.expectEqualStrings("dm-channel-42", spawn_tool.default_chat_id.?);
+    try std.testing.expectEqualStrings("agent:main:discord:direct:user-42", spawn_tool.default_session_key.?);
+}
+
+test "handleSubagentsCommand spawn stores conversation origin route" {
+    const cfg = config_module.Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .allocator = std.testing.allocator,
+    };
+    var manager = subagent_mod.SubagentManager.init(std.testing.allocator, &cfg, null, .{});
+    manager.task_runner = testSubagentRunnerEcho;
+    defer manager.deinit();
+
+    var spawn_tool = spawn_tool_mod.SpawnTool{ .manager = &manager };
+    const tools = [_]Tool{spawn_tool.tool()};
+    var harness = struct {
+        allocator: std.mem.Allocator,
+        tools: []const Tool,
+        memory_session_id: ?[]const u8 = "agent:main:discord:direct:user-42",
+        conversation_context: ?struct {
+            channel: ?[]const u8 = null,
+            account_id: ?[]const u8 = null,
+            delivery_chat_id: ?[]const u8 = null,
+            peer_id: ?[]const u8 = null,
+        } = .{
+            .channel = "discord",
+            .account_id = "discord-main",
+            .delivery_chat_id = "dm-channel-42",
+            .peer_id = "user-42",
+        },
+    }{
+        .allocator = std.testing.allocator,
+        .tools = tools[0..],
+    };
+
+    // Regression: #849 also applies to slash-command subagent spawns, not only
+    // LLM tool-call spawns.
+    const response = try handleSubagentsCommand(&harness, "spawn check route");
+    defer std.testing.allocator.free(response);
+
+    manager.mutex.lock();
+    defer manager.mutex.unlock();
+    const state = manager.tasks.get(1) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("discord", state.origin_channel);
+    try std.testing.expectEqualStrings("discord-main", state.origin_account_id.?);
+    try std.testing.expectEqualStrings("dm-channel-42", state.origin_chat_id);
+    try std.testing.expectEqualStrings("agent:main:discord:direct:user-42", state.session_key.?);
+}
+
 fn parseTaskId(raw: []const u8) ?u64 {
     if (raw.len == 0) return null;
     return std.fmt.parseInt(u64, raw, 10) catch null;
@@ -3154,8 +3231,14 @@ fn findSubagentManager(self: anytype) ?*subagent_mod.SubagentManager {
     return spawn_tool.manager;
 }
 
-pub fn refreshSubagentToolContext(self: anytype) void {
-    const spawn_tool = findSpawnTool(self) orelse return;
+const SubagentOriginRoute = struct {
+    channel: []const u8,
+    account_id: ?[]const u8,
+    chat_id: []const u8,
+    session_key: []const u8,
+};
+
+fn resolveSubagentOriginRoute(self: anytype) SubagentOriginRoute {
     var route_channel: []const u8 = "agent";
     var route_chat_id: []const u8 = self.memory_session_id orelse "agent";
     var route_account_id: ?[]const u8 = null;
@@ -3172,10 +3255,21 @@ pub fn refreshSubagentToolContext(self: anytype) void {
         }
     }
 
-    spawn_tool.default_channel = route_channel;
-    spawn_tool.default_account_id = route_account_id;
-    spawn_tool.default_chat_id = route_chat_id;
-    spawn_tool.default_session_key = self.memory_session_id orelse route_chat_id;
+    return .{
+        .channel = route_channel,
+        .account_id = route_account_id,
+        .chat_id = route_chat_id,
+        .session_key = self.memory_session_id orelse route_chat_id,
+    };
+}
+
+pub fn refreshSubagentToolContext(self: anytype) void {
+    const spawn_tool = findSpawnTool(self) orelse return;
+    const route = resolveSubagentOriginRoute(self);
+    spawn_tool.default_channel = route.channel;
+    spawn_tool.default_account_id = route.account_id;
+    spawn_tool.default_chat_id = route.chat_id;
+    spawn_tool.default_session_key = route.session_key;
 }
 
 fn findShellTool(self: anytype) ?Tool {
@@ -4049,6 +4143,9 @@ fn freeSubagentTaskState(manager: *subagent_mod.SubagentManager, state: *subagen
     }
     if (state.result) |r| manager.allocator.free(r);
     if (state.error_msg) |e| manager.allocator.free(e);
+    manager.allocator.free(state.origin_channel);
+    manager.allocator.free(state.origin_chat_id);
+    if (state.origin_account_id) |aid| manager.allocator.free(aid);
     if (state.session_key) |sk| manager.allocator.free(sk);
     manager.allocator.free(state.label);
     manager.allocator.destroy(state);
@@ -4110,8 +4207,8 @@ fn spawnSubagentTask(self: anytype, task: []const u8, label: []const u8, agent_n
     const manager = findSubagentManager(self) orelse
         return try self.allocator.dupe(u8, "Spawn tool is not enabled.");
 
-    const origin_chat = self.memory_session_id orelse "agent";
-    const task_id = manager.spawnWithAgent(trimmed_task, label, "agent", origin_chat, null, origin_chat, agent_name) catch |err| {
+    const route = resolveSubagentOriginRoute(self);
+    const task_id = manager.spawnWithAgent(trimmed_task, label, route.channel, route.chat_id, route.account_id, route.session_key, agent_name) catch |err| {
         return switch (err) {
             error.TooManyConcurrentSubagents => try self.allocator.dupe(u8, "Too many concurrent subagents. Wait for a task to finish."),
             error.UnknownAgent => if (agent_name) |name|
@@ -4304,6 +4401,48 @@ fn handleSubagentsCommand(self: anytype, arg: []const u8) ![]const u8 {
     }
 
     return try self.allocator.dupe(u8, "Unknown /subagents action. Use /subagents help.");
+}
+
+test "handleKillCommand frees completed subagent origin route" {
+    const cfg = config_module.Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .allocator = std.testing.allocator,
+    };
+    var manager = subagent_mod.SubagentManager.init(std.testing.allocator, &cfg, null, .{});
+    defer manager.deinit();
+
+    var spawn_tool = spawn_tool_mod.SpawnTool{ .manager = &manager };
+    const tools = [_]Tool{spawn_tool.tool()};
+    var harness = struct {
+        allocator: std.mem.Allocator,
+        tools: []const Tool,
+        memory_session_id: ?[]const u8 = "session:42",
+    }{
+        .allocator = std.testing.allocator,
+        .tools = tools[0..],
+    };
+
+    const state = try std.testing.allocator.create(subagent_mod.TaskState);
+    state.* = .{
+        .status = .completed,
+        .label = try std.testing.allocator.dupe(u8, "done-task"),
+        .origin_channel = try std.testing.allocator.dupe(u8, "telegram"),
+        .origin_chat_id = try std.testing.allocator.dupe(u8, "chat-42"),
+        .origin_account_id = try std.testing.allocator.dupe(u8, "primary"),
+        .session_key = try std.testing.allocator.dupe(u8, "session:42"),
+        .result = try std.testing.allocator.dupe(u8, "done"),
+        .started_at = std_compat.time.milliTimestamp(),
+        .completed_at = std_compat.time.milliTimestamp(),
+    };
+    try manager.tasks.put(std.testing.allocator, 1, state);
+
+    // Regression: #849 made origin route fields owned by TaskState; /kill must
+    // free them when it removes completed tasks.
+    const response = try handleKillCommand(&harness, "1");
+    defer std.testing.allocator.free(response);
+    try std.testing.expectEqual(@as(usize, 0), manager.tasks.count());
+    try std.testing.expect(std.mem.indexOf(u8, response, "removed") != null);
 }
 
 fn handleSteerCommand(self: anytype, arg: []const u8) ![]const u8 {

--- a/src/agent/commands.zig
+++ b/src/agent/commands.zig
@@ -3142,8 +3142,26 @@ fn findSubagentManager(self: anytype) ?*subagent_mod.SubagentManager {
 
 pub fn refreshSubagentToolContext(self: anytype) void {
     const spawn_tool = findSpawnTool(self) orelse return;
-    spawn_tool.default_channel = "agent";
-    spawn_tool.default_chat_id = self.memory_session_id orelse "agent";
+    var route_channel: []const u8 = "agent";
+    var route_chat_id: []const u8 = self.memory_session_id orelse "agent";
+    var route_account_id: ?[]const u8 = null;
+
+    if (@hasField(@TypeOf(self.*), "conversation_context")) {
+        if (self.conversation_context) |ctx| {
+            if (ctx.channel) |channel| route_channel = channel;
+            route_account_id = ctx.account_id;
+            if (ctx.delivery_chat_id) |delivery_chat_id| {
+                route_chat_id = delivery_chat_id;
+            } else if (ctx.peer_id) |peer_id| {
+                route_chat_id = peer_id;
+            }
+        }
+    }
+
+    spawn_tool.default_channel = route_channel;
+    spawn_tool.default_account_id = route_account_id;
+    spawn_tool.default_chat_id = route_chat_id;
+    spawn_tool.default_session_key = self.memory_session_id orelse route_chat_id;
 }
 
 fn findShellTool(self: anytype) ?Tool {
@@ -4079,7 +4097,7 @@ fn spawnSubagentTask(self: anytype, task: []const u8, label: []const u8, agent_n
         return try self.allocator.dupe(u8, "Spawn tool is not enabled.");
 
     const origin_chat = self.memory_session_id orelse "agent";
-    const task_id = manager.spawnWithAgent(trimmed_task, label, "agent", origin_chat, agent_name) catch |err| {
+    const task_id = manager.spawnWithAgent(trimmed_task, label, "agent", origin_chat, null, origin_chat, agent_name) catch |err| {
         return switch (err) {
             error.TooManyConcurrentSubagents => try self.allocator.dupe(u8, "Too many concurrent subagents. Wait for a task to finish."),
             error.UnknownAgent => if (agent_name) |name|

--- a/src/subagent.zig
+++ b/src/subagent.zig
@@ -27,12 +27,21 @@ pub const TaskStatus = enum {
 pub const TaskState = struct {
     status: TaskStatus,
     label: []const u8,
+    origin_channel: []const u8,
+    origin_chat_id: []const u8,
+    origin_account_id: ?[]const u8 = null,
     session_key: ?[]const u8 = null,
     result: ?[]const u8 = null,
     error_msg: ?[]const u8 = null,
+    notified: bool = false,
     started_at: i64,
     completed_at: ?i64 = null,
     thread: ?std.Thread = null,
+};
+
+pub const CompletionNotice = struct {
+    task_id: u64,
+    content: []u8,
 };
 
 pub const SubagentConfig = struct {
@@ -78,6 +87,7 @@ const ThreadContext = struct {
     label: []const u8,
     origin_channel: []const u8,
     origin_chat_id: []const u8,
+    origin_account_id: ?[]const u8 = null,
     agent_name: ?[]const u8 = null,
     trace_id: ?[32]u8 = null,
 };
@@ -164,6 +174,9 @@ pub const SubagentManager = struct {
             }
             if (state.result) |r| self.allocator.free(r);
             if (state.error_msg) |e| self.allocator.free(e);
+            self.allocator.free(state.origin_channel);
+            self.allocator.free(state.origin_chat_id);
+            if (state.origin_account_id) |aid| self.allocator.free(aid);
             if (state.session_key) |sk| self.allocator.free(sk);
             self.allocator.free(state.label);
             self.allocator.destroy(state);
@@ -178,8 +191,10 @@ pub const SubagentManager = struct {
         label: []const u8,
         origin_channel: []const u8,
         origin_chat_id: []const u8,
+        origin_account_id: ?[]const u8,
+        origin_session_key: []const u8,
     ) !u64 {
-        return self.spawnWithAgent(task, label, origin_channel, origin_chat_id, null);
+        return self.spawnWithAgent(task, label, origin_channel, origin_chat_id, origin_account_id, origin_session_key, null);
     }
 
     /// Spawn a background subagent using an optional named agent profile.
@@ -190,6 +205,8 @@ pub const SubagentManager = struct {
         label: []const u8,
         origin_channel: []const u8,
         origin_chat_id: []const u8,
+        origin_account_id: ?[]const u8,
+        origin_session_key: []const u8,
         agent_name: ?[]const u8,
     ) !u64 {
         self.mutex.lock();
@@ -209,11 +226,20 @@ pub const SubagentManager = struct {
         errdefer self.allocator.destroy(state);
         const state_label = try self.allocator.dupe(u8, label);
         errdefer self.allocator.free(state_label);
-        const state_session = try self.allocator.dupe(u8, origin_chat_id);
+        const state_origin_channel = try self.allocator.dupe(u8, origin_channel);
+        errdefer self.allocator.free(state_origin_channel);
+        const state_origin_chat = try self.allocator.dupe(u8, origin_chat_id);
+        errdefer self.allocator.free(state_origin_chat);
+        const state_origin_account = if (origin_account_id) |account_id| try self.allocator.dupe(u8, account_id) else null;
+        errdefer if (state_origin_account) |account_id| self.allocator.free(account_id);
+        const state_session = try self.allocator.dupe(u8, origin_session_key);
         errdefer self.allocator.free(state_session);
         state.* = .{
             .status = .running,
             .label = state_label,
+            .origin_channel = state_origin_channel,
+            .origin_chat_id = state_origin_chat,
+            .origin_account_id = state_origin_account,
             .session_key = state_session,
             .started_at = std_compat.time.milliTimestamp(),
         };
@@ -229,6 +255,8 @@ pub const SubagentManager = struct {
         errdefer self.allocator.free(origin_channel_copy);
         const origin_chat_copy = try self.allocator.dupe(u8, origin_chat_id);
         errdefer self.allocator.free(origin_chat_copy);
+        const origin_account_copy = if (origin_account_id) |account_id| try self.allocator.dupe(u8, account_id) else null;
+        errdefer if (origin_account_copy) |account_id| self.allocator.free(account_id);
         const agent_name_copy = if (agent_name) |name| try self.allocator.dupe(u8, name) else null;
         errdefer if (agent_name_copy) |name| self.allocator.free(name);
 
@@ -244,6 +272,7 @@ pub const SubagentManager = struct {
             .label = label_copy,
             .origin_channel = origin_channel_copy,
             .origin_chat_id = origin_chat_copy,
+            .origin_account_id = origin_account_copy,
             .agent_name = agent_name_copy,
             .trace_id = trace_id,
         };
@@ -293,6 +322,15 @@ pub const SubagentManager = struct {
         return count;
     }
 
+    fn formatTaskCompletionContent(allocator: Allocator, label: []const u8, result: ?[]const u8, err_msg: ?[]const u8) ![]u8 {
+        return if (result) |r|
+            try std.fmt.allocPrint(allocator, "[Subagent '{s}' completed]\n{s}", .{ label, r })
+        else if (err_msg) |e|
+            try std.fmt.allocPrint(allocator, "[Subagent '{s}' failed]\n{s}", .{ label, e })
+        else
+            try std.fmt.allocPrint(allocator, "[Subagent '{s}' finished]", .{label});
+    }
+
     /// Mark a task as completed or failed. Thread-safe.
     fn completeTask(self: *SubagentManager, task_id: u64, result: ?[]const u8, err_msg: ?[]const u8) void {
         // Dupe result/error into manager's allocator (source may be arena-backed)
@@ -300,6 +338,9 @@ pub const SubagentManager = struct {
         const owned_err = if (err_msg) |e| self.allocator.dupe(u8, e) catch null else null;
 
         var label: []const u8 = "subagent";
+        var origin_channel: []const u8 = "system";
+        var origin_chat_id: []const u8 = "subagent";
+        var origin_account_id: ?[]const u8 = null;
         {
             self.mutex.lock();
             defer self.mutex.unlock();
@@ -307,38 +348,85 @@ pub const SubagentManager = struct {
                 state.status = if (owned_err != null) .failed else .completed;
                 state.result = owned_result;
                 state.error_msg = owned_err;
+                state.notified = false;
                 state.completed_at = std_compat.time.milliTimestamp();
                 label = state.label;
+                origin_channel = state.origin_channel;
+                origin_chat_id = state.origin_chat_id;
+                origin_account_id = state.origin_account_id;
             }
         }
 
+        const content = formatTaskCompletionContent(self.allocator, label, owned_result, owned_err) catch return;
+        defer self.allocator.free(content);
+
         // Route result via bus (outside lock)
         if (self.bus) |b| {
-            const content = if (owned_result) |r|
-                std.fmt.allocPrint(self.allocator, "[Subagent '{s}' completed]\n{s}", .{ label, r }) catch return
-            else if (owned_err) |e|
-                std.fmt.allocPrint(self.allocator, "[Subagent '{s}' failed]\n{s}", .{ label, e }) catch return
+            var out = if (origin_account_id) |account_id|
+                bus_mod.makeOutboundWithAccount(
+                    self.allocator,
+                    origin_channel,
+                    account_id,
+                    origin_chat_id,
+                    content,
+                ) catch return
             else
-                std.fmt.allocPrint(self.allocator, "[Subagent '{s}' finished]", .{label}) catch return;
+                bus_mod.makeOutbound(
+                    self.allocator,
+                    origin_channel,
+                    origin_chat_id,
+                    content,
+                ) catch return;
 
-            const msg = bus_mod.makeInbound(
-                self.allocator,
-                "system",
-                "subagent",
-                "agent",
-                content,
-                "system:subagent",
-            ) catch {
-                self.allocator.free(content);
-                return;
-            };
-            self.allocator.free(content);
-
-            b.publishInbound(msg) catch |err| {
-                msg.deinit(self.allocator);
-                log.err("subagent: failed to publish result to bus: {}", .{err});
+            b.publishOutbound(out) catch |err| {
+                out.deinit(self.allocator);
+                log.err("subagent: failed to publish result to outbound bus: {}", .{err});
             };
         }
+    }
+
+    pub fn takeCompletionNoticesForSession(
+        self: *SubagentManager,
+        allocator: Allocator,
+        session_key: ?[]const u8,
+    ) ![]CompletionNotice {
+        var notices: std.ArrayListUnmanaged(CompletionNotice) = .empty;
+        errdefer {
+            for (notices.items) |notice| allocator.free(notice.content);
+            notices.deinit(allocator);
+        }
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        var it = self.tasks.iterator();
+        while (it.next()) |entry| {
+            const task_id = entry.key_ptr.*;
+            const state = entry.value_ptr.*;
+            if (state.status == .running or state.notified) continue;
+
+            if (session_key) |expected_session| {
+                const state_session = state.session_key orelse continue;
+                if (!std.mem.eql(u8, state_session, expected_session)) continue;
+            }
+
+            const content = formatTaskCompletionContent(allocator, state.label, state.result, state.error_msg) catch continue;
+            notices.append(allocator, .{
+                .task_id = task_id,
+                .content = content,
+            }) catch {
+                allocator.free(content);
+                continue;
+            };
+            state.notified = true;
+        }
+
+        return notices.toOwnedSlice(allocator);
+    }
+
+    pub fn freeCompletionNotices(allocator: Allocator, notices: []CompletionNotice) void {
+        for (notices) |notice| allocator.free(notice.content);
+        allocator.free(notices);
     }
 };
 
@@ -365,6 +453,7 @@ fn subagentThreadFn(ctx: *ThreadContext) void {
         ctx.manager.allocator.free(ctx.label);
         ctx.manager.allocator.free(ctx.origin_channel);
         ctx.manager.allocator.free(ctx.origin_chat_id);
+        if (ctx.origin_account_id) |account_id| ctx.manager.allocator.free(account_id);
         if (ctx.agent_name) |agent_name| ctx.manager.allocator.free(agent_name);
         ctx.manager.allocator.destroy(ctx);
     }
@@ -548,10 +637,13 @@ test "TaskState initial defaults" {
     const state = TaskState{
         .status = .running,
         .label = "test",
+        .origin_channel = "agent",
+        .origin_chat_id = "session:1",
         .started_at = 0,
     };
     try std.testing.expect(state.result == null);
     try std.testing.expect(state.error_msg == null);
+    try std.testing.expect(!state.notified);
     try std.testing.expect(state.completed_at == null);
     try std.testing.expect(state.thread == null);
 }
@@ -603,6 +695,8 @@ test "SubagentManager completeTask updates state" {
     state.* = .{
         .status = .running,
         .label = try std.testing.allocator.dupe(u8, "test-task"),
+        .origin_channel = try std.testing.allocator.dupe(u8, "agent"),
+        .origin_chat_id = try std.testing.allocator.dupe(u8, "session:1"),
         .started_at = std_compat.time.milliTimestamp(),
     };
     try mgr.tasks.put(std.testing.allocator, 1, state);
@@ -626,6 +720,8 @@ test "SubagentManager completeTask with error" {
     state.* = .{
         .status = .running,
         .label = try std.testing.allocator.dupe(u8, "fail-task"),
+        .origin_channel = try std.testing.allocator.dupe(u8, "agent"),
+        .origin_chat_id = try std.testing.allocator.dupe(u8, "session:1"),
         .started_at = std_compat.time.milliTimestamp(),
     };
     try mgr.tasks.put(std.testing.allocator, 1, state);
@@ -636,7 +732,7 @@ test "SubagentManager completeTask with error" {
     try std.testing.expect(mgr.getTaskResult(1) == null);
 }
 
-test "SubagentManager completeTask routes via bus" {
+test "SubagentManager completeTask routes outbound via bus to origin channel" {
     const cfg = config_mod.Config{
         .workspace_dir = "/tmp/yc",
         .config_path = "/tmp/yc/config.json",
@@ -652,20 +748,55 @@ test "SubagentManager completeTask routes via bus" {
     state.* = .{
         .status = .running,
         .label = try std.testing.allocator.dupe(u8, "bus-task"),
+        .origin_channel = try std.testing.allocator.dupe(u8, "telegram"),
+        .origin_chat_id = try std.testing.allocator.dupe(u8, "chat-42"),
+        .origin_account_id = try std.testing.allocator.dupe(u8, "primary"),
         .started_at = std_compat.time.milliTimestamp(),
     };
     try mgr.tasks.put(std.testing.allocator, 1, state);
 
     mgr.completeTask(1, "result text", null);
 
-    // Check bus received the message — verify depth increased
-    try std.testing.expect(bus.inboundDepth() > 0);
+    try std.testing.expectEqual(@as(usize, 1), bus.outboundDepth());
+    var msg = bus.consumeOutbound() orelse return error.TestUnexpectedResult;
+    defer msg.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("telegram", msg.channel);
+    try std.testing.expectEqualStrings("chat-42", msg.chat_id);
+    try std.testing.expect(msg.account_id != null);
+    try std.testing.expectEqualStrings("primary", msg.account_id.?);
+    try std.testing.expect(std.mem.indexOf(u8, msg.content, "bus-task") != null);
+}
 
-    // Drain the bus to avoid memory leak
-    bus.close();
-    if (bus.consumeInbound()) |msg| {
-        msg.deinit(std.testing.allocator);
-    }
+test "SubagentManager takeCompletionNoticesForSession returns once per task" {
+    const cfg = config_mod.Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .allocator = std.testing.allocator,
+    };
+    var mgr = SubagentManager.init(std.testing.allocator, &cfg, null, .{});
+    defer mgr.deinit();
+
+    const state = try std.testing.allocator.create(TaskState);
+    state.* = .{
+        .status = .running,
+        .label = try std.testing.allocator.dupe(u8, "notice-task"),
+        .origin_channel = try std.testing.allocator.dupe(u8, "cli"),
+        .origin_chat_id = try std.testing.allocator.dupe(u8, "session:42"),
+        .session_key = try std.testing.allocator.dupe(u8, "session:42"),
+        .started_at = std_compat.time.milliTimestamp(),
+    };
+    try mgr.tasks.put(std.testing.allocator, 1, state);
+    mgr.completeTask(1, "done", null);
+
+    const notices1 = try mgr.takeCompletionNoticesForSession(std.testing.allocator, "session:42");
+    defer SubagentManager.freeCompletionNotices(std.testing.allocator, notices1);
+    try std.testing.expectEqual(@as(usize, 1), notices1.len);
+    try std.testing.expectEqual(@as(u64, 1), notices1[0].task_id);
+    try std.testing.expect(std.mem.indexOf(u8, notices1[0].content, "notice-task") != null);
+
+    const notices2 = try mgr.takeCompletionNoticesForSession(std.testing.allocator, "session:42");
+    defer SubagentManager.freeCompletionNotices(std.testing.allocator, notices2);
+    try std.testing.expectEqual(@as(usize, 0), notices2.len);
 }
 
 test "SubagentManager spawn stores session key" {
@@ -677,7 +808,7 @@ test "SubagentManager spawn stores session key" {
     var mgr = SubagentManager.init(std.testing.allocator, &cfg, null, .{});
     defer mgr.deinit();
 
-    const task_id = try mgr.spawn("quick task", "session-check", "agent", "session:42");
+    const task_id = try mgr.spawn("quick task", "session-check", "agent", "session:42", null, "session:42");
     mgr.mutex.lock();
     defer mgr.mutex.unlock();
     const state = mgr.tasks.get(task_id) orelse return error.TestUnexpectedResult;
@@ -696,7 +827,7 @@ test "SubagentManager spawnWithAgent rejects unknown agent" {
 
     try std.testing.expectError(
         error.UnknownAgent,
-        mgr.spawnWithAgent("quick task", "session-check", "agent", "session:42", "missing-agent"),
+        mgr.spawnWithAgent("quick task", "session-check", "agent", "session:42", null, "session:42", "missing-agent"),
     );
 }
 
@@ -715,7 +846,7 @@ test "SubagentManager spawnWithAgent accepts configured agent" {
     var mgr = SubagentManager.init(std.testing.allocator, &cfg, null, .{});
     defer mgr.deinit();
 
-    const task_id = try mgr.spawnWithAgent("quick task", "session-check", "agent", "session:42", "researcher");
+    const task_id = try mgr.spawnWithAgent("quick task", "session-check", "agent", "session:42", null, "session:42", "researcher");
     try std.testing.expect(task_id > 0);
 }
 
@@ -746,7 +877,7 @@ test "SubagentManager uses named agent workspace_path for task runner" {
     mgr.task_runner = testTaskRunnerWorkspace;
     defer mgr.deinit();
 
-    const task_id = try mgr.spawnWithAgent("quick task", "workspace-check", "agent", "session:42", "researcher");
+    const task_id = try mgr.spawnWithAgent("quick task", "workspace-check", "agent", "session:42", null, "session:42", "researcher");
     const status = try waitTaskTerminalStatus(&mgr, task_id);
     try std.testing.expectEqual(TaskStatus.completed, status);
     try std.testing.expectEqualStrings(expected_workspace, mgr.getTaskResult(task_id).?);
@@ -781,7 +912,7 @@ test "SubagentManager preserves named agent system_prompt when workspace_path is
     mgr.task_runner = testTaskRunnerWorkspaceAndPrompt;
     defer mgr.deinit();
 
-    const task_id = try mgr.spawnWithAgent("quick task", "workspace-prompt-check", "agent", "session:42", "researcher");
+    const task_id = try mgr.spawnWithAgent("quick task", "workspace-prompt-check", "agent", "session:42", null, "session:42", "researcher");
     const status = try waitTaskTerminalStatus(&mgr, task_id);
     try std.testing.expectEqual(TaskStatus.completed, status);
 
@@ -800,7 +931,7 @@ test "SubagentManager uses task runner callback result" {
     mgr.task_runner = testTaskRunnerOk;
     defer mgr.deinit();
 
-    const task_id = try mgr.spawn("quick task", "runner-ok", "agent", "session:42");
+    const task_id = try mgr.spawn("quick task", "runner-ok", "agent", "session:42", null, "session:42");
     const status = try waitTaskTerminalStatus(&mgr, task_id);
     try std.testing.expectEqual(TaskStatus.completed, status);
     try std.testing.expectEqualStrings("runner-ok", mgr.getTaskResult(task_id).?);
@@ -819,7 +950,7 @@ test "SubagentManager propagates http timeout to task runner" {
     mgr.task_runner = testTaskRunnerHttpTimeout;
     defer mgr.deinit();
 
-    const task_id = try mgr.spawn("quick task", "runner-timeout", "agent", "session:42");
+    const task_id = try mgr.spawn("quick task", "runner-timeout", "agent", "session:42", null, "session:42");
     const status = try waitTaskTerminalStatus(&mgr, task_id);
     try std.testing.expectEqual(TaskStatus.completed, status);
     try std.testing.expectEqualStrings("17", mgr.getTaskResult(task_id).?);
@@ -835,7 +966,7 @@ test "SubagentManager stores runner callback error" {
     mgr.task_runner = testTaskRunnerFail;
     defer mgr.deinit();
 
-    const task_id = try mgr.spawn("quick task", "runner-fail", "agent", "session:42");
+    const task_id = try mgr.spawn("quick task", "runner-fail", "agent", "session:42", null, "session:42");
     const status = try waitTaskTerminalStatus(&mgr, task_id);
     try std.testing.expectEqual(TaskStatus.failed, status);
 
@@ -862,7 +993,7 @@ test "SubagentManager spawn rollback removes task on out-of-memory" {
 
     try std.testing.expectError(
         error.OutOfMemory,
-        mgr.spawn("oom-task", "oom-label", "agent", "session:oom"),
+        mgr.spawn("oom-task", "oom-label", "agent", "session:oom", null, "session:oom"),
     );
     try std.testing.expectEqual(@as(usize, 0), mgr.tasks.count());
     try std.testing.expectEqual(@as(u32, 0), mgr.getRunningCount());

--- a/src/subagent.zig
+++ b/src/subagent.zig
@@ -2,7 +2,7 @@
 //!
 //! Spawns subagents in separate OS threads with restricted tool sets
 //! (no message, spawn, delegate — to prevent infinite loops).
-//! Task results are routed via the event bus as system InboundMessages.
+//! Task results are routed back to the originating channel/session.
 
 const std = @import("std");
 const std_compat = @import("compat");
@@ -85,9 +85,6 @@ const ThreadContext = struct {
     task_id: u64,
     task: []const u8,
     label: []const u8,
-    origin_channel: []const u8,
-    origin_chat_id: []const u8,
-    origin_account_id: ?[]const u8 = null,
     agent_name: ?[]const u8 = null,
     trace_id: ?[32]u8 = null,
 };
@@ -251,12 +248,6 @@ pub const SubagentManager = struct {
         errdefer self.allocator.free(task_copy);
         const label_copy = try self.allocator.dupe(u8, label);
         errdefer self.allocator.free(label_copy);
-        const origin_channel_copy = try self.allocator.dupe(u8, origin_channel);
-        errdefer self.allocator.free(origin_channel_copy);
-        const origin_chat_copy = try self.allocator.dupe(u8, origin_chat_id);
-        errdefer self.allocator.free(origin_chat_copy);
-        const origin_account_copy = if (origin_account_id) |account_id| try self.allocator.dupe(u8, account_id) else null;
-        errdefer if (origin_account_copy) |account_id| self.allocator.free(account_id);
         const agent_name_copy = if (agent_name) |name| try self.allocator.dupe(u8, name) else null;
         errdefer if (agent_name_copy) |name| self.allocator.free(name);
 
@@ -270,9 +261,6 @@ pub const SubagentManager = struct {
             .task_id = task_id,
             .task = task_copy,
             .label = label_copy,
-            .origin_channel = origin_channel_copy,
-            .origin_chat_id = origin_chat_copy,
-            .origin_account_id = origin_account_copy,
             .agent_name = agent_name_copy,
             .trace_id = trace_id,
         };
@@ -451,9 +439,6 @@ fn subagentThreadFn(ctx: *ThreadContext) void {
     defer {
         ctx.manager.allocator.free(ctx.task);
         ctx.manager.allocator.free(ctx.label);
-        ctx.manager.allocator.free(ctx.origin_channel);
-        ctx.manager.allocator.free(ctx.origin_chat_id);
-        if (ctx.origin_account_id) |account_id| ctx.manager.allocator.free(account_id);
         if (ctx.agent_name) |agent_name| ctx.manager.allocator.free(agent_name);
         ctx.manager.allocator.destroy(ctx);
     }

--- a/src/tools/spawn.zig
+++ b/src/tools/spawn.zig
@@ -65,7 +65,7 @@ pub const SpawnTool = struct {
 
         const msg = std.fmt.allocPrint(
             allocator,
-            "Subagent '{s}' spawned with task_id={d}. Results will be delivered as system messages.",
+            "Subagent '{s}' spawned with task_id={d}. Results will be delivered as follow-up messages.",
             .{ label, task_id },
         ) catch return ToolResult.ok("Subagent spawned");
 

--- a/src/tools/spawn.zig
+++ b/src/tools/spawn.zig
@@ -6,14 +6,16 @@ const JsonObjectMap = root.JsonObjectMap;
 const SubagentManager = @import("../subagent.zig").SubagentManager;
 
 /// Spawn tool — launches a background subagent to work on a task asynchronously.
-/// Returns a task ID immediately. Results are delivered as system messages.
+/// Returns a task ID immediately. Results are delivered as follow-up messages.
 pub const SpawnTool = struct {
     manager: ?*SubagentManager = null,
     default_channel: ?[]const u8 = null,
+    default_account_id: ?[]const u8 = null,
     default_chat_id: ?[]const u8 = null,
+    default_session_key: ?[]const u8 = null,
 
     pub const tool_name = "spawn";
-    pub const tool_description = "Spawn a background subagent to work on a task asynchronously. Returns a task ID immediately. Results are delivered as system messages when complete.";
+    pub const tool_description = "Spawn a background subagent to work on a task asynchronously. Returns a task ID immediately. Results are delivered as follow-up messages when complete.";
     pub const tool_params =
         \\{"type":"object","properties":{"task":{"type":"string","minLength":1,"description":"The task/prompt for the subagent"},"label":{"type":"string","description":"Optional human-readable label for tracking"},"agent":{"type":"string","description":"Optional named agent profile from agents.list for provider/model override"}},"required":["task"]}
     ;
@@ -49,9 +51,11 @@ pub const SpawnTool = struct {
             return ToolResult.fail("Spawn tool not connected to SubagentManager");
 
         const channel = self.default_channel orelse "system";
+        const account_id = self.default_account_id;
         const chat_id = self.default_chat_id orelse "agent";
+        const session_key = self.default_session_key orelse chat_id;
 
-        const task_id = manager.spawnWithAgent(trimmed_task, label, channel, chat_id, agent_name) catch |err| {
+        const task_id = manager.spawnWithAgent(trimmed_task, label, channel, chat_id, account_id, session_key, agent_name) catch |err| {
             return switch (err) {
                 error.TooManyConcurrentSubagents => ToolResult.fail("Too many concurrent subagents. Wait for some to complete."),
                 error.UnknownAgent => ToolResult.fail("Unknown named agent profile"),


### PR DESCRIPTION
Fixes #849

## Summary

### EN:
- Updated subagent task state to persist origin routing metadata (`channel`, `chat_id`, `account_id`) and notify exactly once per completion.
- Changed completion publishing to send results back to the original conversation context instead of the synthetic `system:subagent` inbound path.
- Added CLI fallback notices for no-bus scenarios and wired spawn context defaults from live conversation context.
- Added regression tests in `src/subagent.zig` covering origin routing and one-time completion notification behavior.

### ZH:
- 更新了 subagent 任务状态，持久化来源路由信息（`channel`、`chat_id`、`account_id`），并确保每次完成只通知一次。
- 调整完成结果发布逻辑：回传到原始会话上下文，而不是固定走 `system:subagent` 的入站路径。
- 为无 bus 场景补充了 CLI 提示回退机制，并将 spawn 的默认上下文与当前会话上下文联动。
- 在 `src/subagent.zig` 增加回归测试，覆盖来源路由与一次性通知语义。

## Validation
- `zig build test --summary all`

## Notes
- The patch is scoped to subagent result delivery and spawn/CLI integration points required for preserving origin fidelity.