### PR TITLE
fix(daemon,session): enable inbound concurrency and turn preemption | 修复(daemon,session): 启用入站并发与轮次抢占

### DIFF
--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -1130,6 +1130,25 @@ const DebouncedInboundPollResult = enum {
     closed,
 };
 
+const INBOUND_DISPATCH_QUEUE_CAPACITY: usize = 256;
+const INBOUND_DISPATCH_WORKER_COUNT: usize = if (builtin.is_test) 2 else 4;
+const EVICT_IDLE_DISPATCH_INTERVAL: u32 = 100;
+
+const InboundDispatchQueue = bus_mod.BoundedQueue(bus_mod.InboundMessage, INBOUND_DISPATCH_QUEUE_CAPACITY);
+
+const InboundWorkerCtx = struct {
+    allocator: std.mem.Allocator,
+    queue: *InboundDispatchQueue,
+    event_bus: *bus_mod.Bus,
+    registry: *const dispatch.ChannelRegistry,
+    runtime: *channel_loop.ChannelRuntime,
+    evict_counter: *Atomic(u32),
+};
+
+fn shouldRunInboundIdleEviction(dispatch_count: u32) bool {
+    return dispatch_count != 0 and (dispatch_count % EVICT_IDLE_DISPATCH_INTERVAL) == 0;
+}
+
 fn pollDebouncedInbound(
     _: std.mem.Allocator,
     event_bus: *bus_mod.Bus,
@@ -1158,17 +1177,230 @@ fn pollDebouncedInbound(
     return if (ready_messages.items.len > 0) .ready else .closed;
 }
 
+fn processInboundMessage(
+    allocator: std.mem.Allocator,
+    event_bus: *bus_mod.Bus,
+    registry: *const dispatch.ChannelRegistry,
+    runtime: *channel_loop.ChannelRuntime,
+    evict_counter: *Atomic(u32),
+    msg: *const bus_mod.InboundMessage,
+) void {
+    var parsed_meta = parseInboundMetadata(allocator, msg.metadata_json);
+    defer parsed_meta.deinit();
+
+    const outbound_account_id = parsed_meta.fields.account_id;
+    const routed_session_key = resolveInboundMainSessionKeyWithMetadata(
+        allocator,
+        runtime.config,
+        msg,
+        parsed_meta.fields,
+    ) orelse resolveInboundRouteSessionKeyWithMetadata(
+        allocator,
+        runtime.config,
+        msg,
+        parsed_meta.fields,
+    );
+    defer if (routed_session_key) |key| allocator.free(key);
+    const session_key = routed_session_key orelse msg.session_key;
+
+    const typing_recipient = sendInboundProcessingIndicator(
+        allocator,
+        registry,
+        msg.channel,
+        outbound_account_id,
+        msg.chat_id,
+        parsed_meta.fields,
+    );
+    defer clearInboundProcessingIndicator(
+        allocator,
+        registry,
+        msg.channel,
+        outbound_account_id,
+        typing_recipient,
+    );
+
+    const outbound_channel = resolveOutboundChannel(registry, msg.channel, outbound_account_id);
+    if (outbound_channel) |channel| {
+        markInboundMessageRead(channel, buildInboundMessageRef(msg, parsed_meta.fields));
+    }
+    const use_tracked_draft_outbound = if (outbound_channel) |channel|
+        !channel.supportsStreamingOutbound() and dispatch.supportsDraftStreaming(channel)
+    else
+        false;
+    const use_streaming_outbound = if (outbound_channel) |channel|
+        channel.supportsStreamingOutbound() or dispatch.supportsDraftStreaming(channel)
+    else
+        false;
+    const outbound_draft_id: u64 = if (use_tracked_draft_outbound) nextOutboundDraftId() else 0;
+    var streaming_ctx = StreamingOutboundCtx{
+        .allocator = allocator,
+        .event_bus = event_bus,
+        .channel = msg.channel,
+        .account_id = outbound_account_id,
+        .chat_id = msg.chat_id,
+        .draft_id = outbound_draft_id,
+    };
+    var stream_sink: ?streaming.Sink = null;
+    var outbound_tag_filter: streaming.TagFilter = undefined;
+    if (use_streaming_outbound) {
+        const raw_sink = streaming.Sink{
+            .callback = publishStreamingChunk,
+            .ctx = @ptrCast(&streaming_ctx),
+        };
+        stream_sink = makeStreamingSinkForChannel(use_streaming_outbound, raw_sink, &outbound_tag_filter);
+    }
+
+    if (std.mem.eql(u8, msg.channel, "max")) {
+        channels_mod.max.setInteractiveOwnerContext(msg.sender_id);
+        defer channels_mod.max.setInteractiveOwnerContext(null);
+    }
+
+    const conversation_context = buildInboundConversationContext(msg, parsed_meta.fields);
+
+    const reply = runtime.session_mgr.processMessageStreaming(
+        session_key,
+        msg.content,
+        conversation_context,
+        stream_sink,
+    ) catch |err| {
+        log.warn("inbound dispatch process failed: {}", .{err});
+
+        // Send user-visible error reply back to the originating channel
+        const err_msg: []const u8 = switch (err) {
+            error.CurlFailed, error.CurlReadError, error.CurlWaitError, error.CurlWriteError, error.CurlDnsError, error.CurlConnectError, error.CurlTimeout, error.CurlTlsError => "Network error contacting provider. Check base_url, DNS, proxy, and TLS certificates, then try again.",
+            error.ProviderDoesNotSupportVision => "The current provider does not support image input.",
+            error.NoResponseContent => "Model returned an empty response. Please try again.",
+            error.OutOfMemory => "Out of memory.",
+            else => "An error occurred. Try again.",
+        };
+        var err_out = if (outbound_account_id) |aid|
+            bus_mod.makeOutboundWithAccount(allocator, msg.channel, aid, msg.chat_id, err_msg) catch return
+        else
+            bus_mod.makeOutbound(allocator, msg.channel, msg.chat_id, err_msg) catch return;
+        err_out.draft_id = outbound_draft_id;
+        event_bus.publishOutbound(err_out) catch {
+            err_out.deinit(allocator);
+        };
+        return;
+    };
+    defer allocator.free(reply);
+
+    if ((parsed_meta.fields.replace_message orelse false) and parsed_meta.fields.message_id != null) {
+        if (outbound_channel) |channel| {
+            var payload = makeAssistantReplyPayload(allocator, reply) catch |err| {
+                log.warn("failed to build edit payload: {}", .{err});
+                const out = makeAssistantReplyOutbound(
+                    allocator,
+                    msg.channel,
+                    outbound_account_id,
+                    msg.chat_id,
+                    reply,
+                    outbound_draft_id,
+                ) catch return;
+                event_bus.publishOutbound(out) catch |publish_err| {
+                    out.deinit(allocator);
+                    log.err("inbound dispatch publishOutbound failed: {}", .{publish_err});
+                };
+                return;
+            };
+            defer payload.deinit(allocator);
+
+            if (channel.editMessage(.{
+                .target = msg.chat_id,
+                .message_id = parsed_meta.fields.message_id.?,
+                .payload = payload.payload(),
+            })) |_| {
+                return;
+            } else |err| {
+                log.warn("editMessage failed; falling back to normal outbound: {}", .{err});
+            }
+        }
+    }
+
+    const out = makeAssistantReplyOutbound(
+        allocator,
+        msg.channel,
+        outbound_account_id,
+        msg.chat_id,
+        reply,
+        outbound_draft_id,
+    ) catch |err| {
+        log.err("inbound dispatch makeOutbound failed: {}", .{err});
+        return;
+    };
+
+    event_bus.publishOutbound(out) catch |err| {
+        out.deinit(allocator);
+        if (err != error.Closed) {
+            log.err("inbound dispatch publishOutbound failed: {}", .{err});
+        }
+        return;
+    };
+
+    health.markComponentOk("inbound_dispatcher");
+    const dispatch_count = evict_counter.fetchAdd(1, .monotonic) + 1;
+    if (shouldRunInboundIdleEviction(dispatch_count)) {
+        _ = runtime.session_mgr.evictIdle(runtime.config.agent.session_idle_timeout_secs);
+    }
+}
+
+fn inboundWorkerThread(ctx: *InboundWorkerCtx) void {
+    while (ctx.queue.consume()) |msg| {
+        var inbound_msg = msg;
+        defer inbound_msg.deinit(ctx.allocator);
+        processInboundMessage(
+            ctx.allocator,
+            ctx.event_bus,
+            ctx.registry,
+            ctx.runtime,
+            ctx.evict_counter,
+            &inbound_msg,
+        );
+    }
+}
+
 fn inboundDispatcherThread(
     allocator: std.mem.Allocator,
     event_bus: *bus_mod.Bus,
     registry: *const dispatch.ChannelRegistry,
     runtime: *channel_loop.ChannelRuntime,
-    state: *DaemonState,
+    _: *DaemonState,
 ) void {
-    var evict_counter: u32 = 0;
+    var evict_counter = Atomic(u32).init(0);
     var debouncer = inbound_debounce.InboundDebouncer.init(allocator, runtime.config.messages.inbound.debounce_ms);
     defer debouncer.deinit();
     var ready_messages: std.ArrayListUnmanaged(bus_mod.InboundMessage) = .empty;
+
+    var worker_queue = InboundDispatchQueue.init();
+    var worker_ctxs: [INBOUND_DISPATCH_WORKER_COUNT]InboundWorkerCtx = undefined;
+    var worker_threads: [INBOUND_DISPATCH_WORKER_COUNT]?std.Thread = .{null} ** INBOUND_DISPATCH_WORKER_COUNT;
+    var worker_count: usize = 0;
+    while (worker_count < INBOUND_DISPATCH_WORKER_COUNT) : (worker_count += 1) {
+        worker_ctxs[worker_count] = .{
+            .allocator = allocator,
+            .queue = &worker_queue,
+            .event_bus = event_bus,
+            .registry = registry,
+            .runtime = runtime,
+            .evict_counter = &evict_counter,
+        };
+        worker_threads[worker_count] = std.Thread.spawn(
+            .{ .stack_size = thread_stacks.SESSION_TURN_STACK_SIZE },
+            inboundWorkerThread,
+            .{&worker_ctxs[worker_count]},
+        ) catch |err| {
+            log.warn("inbound worker spawn failed: {}", .{err});
+            break;
+        };
+    }
+    defer {
+        worker_queue.close();
+        var i: usize = 0;
+        while (i < worker_count) : (i += 1) {
+            if (worker_threads[i]) |thread| thread.join();
+        }
+    }
+
     defer {
         for (ready_messages.items) |msg| msg.deinit(allocator);
         ready_messages.deinit(allocator);
@@ -1191,167 +1423,15 @@ fn inboundDispatcherThread(
 
         while (ready_messages.items.len > 0) {
             var msg = ready_messages.orderedRemove(0);
-            defer msg.deinit(allocator);
-
-            var parsed_meta = parseInboundMetadata(allocator, msg.metadata_json);
-            defer parsed_meta.deinit();
-
-            const outbound_account_id = parsed_meta.fields.account_id;
-            const routed_session_key = resolveInboundMainSessionKeyWithMetadata(
-                allocator,
-                runtime.config,
-                &msg,
-                parsed_meta.fields,
-            ) orelse resolveInboundRouteSessionKeyWithMetadata(
-                allocator,
-                runtime.config,
-                &msg,
-                parsed_meta.fields,
-            );
-            defer if (routed_session_key) |key| allocator.free(key);
-            const session_key = routed_session_key orelse msg.session_key;
-
-            const typing_recipient = sendInboundProcessingIndicator(
-                allocator,
-                registry,
-                msg.channel,
-                outbound_account_id,
-                msg.chat_id,
-                parsed_meta.fields,
-            );
-            defer clearInboundProcessingIndicator(
-                allocator,
-                registry,
-                msg.channel,
-                outbound_account_id,
-                typing_recipient,
-            );
-
-            const outbound_channel = resolveOutboundChannel(registry, msg.channel, outbound_account_id);
-            if (outbound_channel) |channel| {
-                markInboundMessageRead(channel, buildInboundMessageRef(&msg, parsed_meta.fields));
-            }
-            const use_tracked_draft_outbound = if (outbound_channel) |channel|
-                !channel.supportsStreamingOutbound() and dispatch.supportsDraftStreaming(channel)
-            else
-                false;
-            const use_streaming_outbound = if (outbound_channel) |channel|
-                channel.supportsStreamingOutbound() or dispatch.supportsDraftStreaming(channel)
-            else
-                false;
-            const outbound_draft_id: u64 = if (use_tracked_draft_outbound) nextOutboundDraftId() else 0;
-            var streaming_ctx = StreamingOutboundCtx{
-                .allocator = allocator,
-                .event_bus = event_bus,
-                .channel = msg.channel,
-                .account_id = outbound_account_id,
-                .chat_id = msg.chat_id,
-                .draft_id = outbound_draft_id,
-            };
-            var stream_sink: ?streaming.Sink = null;
-            var outbound_tag_filter: streaming.TagFilter = undefined;
-            if (use_streaming_outbound) {
-                const raw_sink = streaming.Sink{
-                    .callback = publishStreamingChunk,
-                    .ctx = @ptrCast(&streaming_ctx),
+            if (worker_count > 0) {
+                worker_queue.publish(msg) catch |err| {
+                    msg.deinit(allocator);
+                    if (err == error.Closed) break;
+                    continue;
                 };
-                stream_sink = makeStreamingSinkForChannel(use_streaming_outbound, raw_sink, &outbound_tag_filter);
-            }
-
-            if (std.mem.eql(u8, msg.channel, "max")) {
-                channels_mod.max.setInteractiveOwnerContext(msg.sender_id);
-                defer channels_mod.max.setInteractiveOwnerContext(null);
-            }
-
-            const conversation_context = buildInboundConversationContext(&msg, parsed_meta.fields);
-
-            const reply = runtime.session_mgr.processMessageStreaming(
-                session_key,
-                msg.content,
-                conversation_context,
-                stream_sink,
-            ) catch |err| {
-                log.warn("inbound dispatch process failed: {}", .{err});
-
-                // Send user-visible error reply back to the originating channel
-                const err_msg: []const u8 = switch (err) {
-                    error.CurlFailed, error.CurlReadError, error.CurlWaitError, error.CurlWriteError, error.CurlDnsError, error.CurlConnectError, error.CurlTimeout, error.CurlTlsError => "Network error contacting provider. Check base_url, DNS, proxy, and TLS certificates, then try again.",
-                    error.ProviderDoesNotSupportVision => "The current provider does not support image input.",
-                    error.NoResponseContent => "Model returned an empty response. Please try again.",
-                    error.OutOfMemory => "Out of memory.",
-                    else => "An error occurred. Try again.",
-                };
-                var err_out = if (outbound_account_id) |aid|
-                    bus_mod.makeOutboundWithAccount(allocator, msg.channel, aid, msg.chat_id, err_msg) catch continue
-                else
-                    bus_mod.makeOutbound(allocator, msg.channel, msg.chat_id, err_msg) catch continue;
-                err_out.draft_id = outbound_draft_id;
-                event_bus.publishOutbound(err_out) catch {
-                    err_out.deinit(allocator);
-                };
-                continue;
-            };
-            defer allocator.free(reply);
-
-            if ((parsed_meta.fields.replace_message orelse false) and parsed_meta.fields.message_id != null) {
-                if (outbound_channel) |channel| {
-                    var payload = makeAssistantReplyPayload(allocator, reply) catch |err| {
-                        log.warn("failed to build edit payload: {}", .{err});
-                        const out = makeAssistantReplyOutbound(
-                            allocator,
-                            msg.channel,
-                            outbound_account_id,
-                            msg.chat_id,
-                            reply,
-                            outbound_draft_id,
-                        ) catch continue;
-                        event_bus.publishOutbound(out) catch |publish_err| {
-                            out.deinit(allocator);
-                            log.err("inbound dispatch publishOutbound failed: {}", .{publish_err});
-                        };
-                        continue;
-                    };
-                    defer payload.deinit(allocator);
-
-                    if (channel.editMessage(.{
-                        .target = msg.chat_id,
-                        .message_id = parsed_meta.fields.message_id.?,
-                        .payload = payload.payload(),
-                    })) |_| {
-                        continue;
-                    } else |err| {
-                        log.warn("editMessage failed; falling back to normal outbound: {}", .{err});
-                    }
-                }
-            }
-
-            const out = makeAssistantReplyOutbound(
-                allocator,
-                msg.channel,
-                outbound_account_id,
-                msg.chat_id,
-                reply,
-                outbound_draft_id,
-            ) catch |err| {
-                log.err("inbound dispatch makeOutbound failed: {}", .{err});
-                continue;
-            };
-
-            event_bus.publishOutbound(out) catch |err| {
-                out.deinit(allocator);
-                if (err == error.Closed) break;
-                log.err("inbound dispatch publishOutbound failed: {}", .{err});
-                continue;
-            };
-
-            state.markRunning("inbound_dispatcher");
-            health.markComponentOk("inbound_dispatcher");
-
-            // Periodic session eviction for bus-based channels
-            evict_counter += 1;
-            if (evict_counter >= 100) {
-                evict_counter = 0;
-                _ = runtime.session_mgr.evictIdle(runtime.config.agent.session_idle_timeout_secs);
+            } else {
+                processInboundMessage(allocator, event_bus, registry, runtime, &evict_counter, &msg);
+                msg.deinit(allocator);
             }
         }
     }
@@ -1359,7 +1439,14 @@ fn inboundDispatcherThread(
     debouncer.flushAll(&ready_messages) catch {};
     while (ready_messages.items.len > 0) {
         var msg = ready_messages.orderedRemove(0);
-        msg.deinit(allocator);
+        if (worker_count > 0) {
+            worker_queue.publish(msg) catch {
+                msg.deinit(allocator);
+            };
+        } else {
+            processInboundMessage(allocator, event_bus, registry, runtime, &evict_counter, &msg);
+            msg.deinit(allocator);
+        }
     }
 }
 
@@ -1778,6 +1865,14 @@ test "pollDebouncedInbound merge out-of-memory does not double free" {
         pollDebouncedInbound(allocator, &event_bus, &debouncer, &ready_messages),
     );
     try std.testing.expectEqual(@as(usize, 0), ready_messages.items.len);
+}
+
+test "shouldRunInboundIdleEviction only triggers at configured interval" {
+    try std.testing.expect(!shouldRunInboundIdleEviction(0));
+    try std.testing.expect(!shouldRunInboundIdleEviction(EVICT_IDLE_DISPATCH_INTERVAL - 1));
+    try std.testing.expect(shouldRunInboundIdleEviction(EVICT_IDLE_DISPATCH_INTERVAL));
+    try std.testing.expect(shouldRunInboundIdleEviction(EVICT_IDLE_DISPATCH_INTERVAL * 2));
+    try std.testing.expect(!shouldRunInboundIdleEviction(EVICT_IDLE_DISPATCH_INTERVAL + 1));
 }
 
 test "hasSupervisedChannels false for defaults" {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -1152,6 +1152,46 @@ fn shouldRunInboundIdleEviction(dispatch_count: u32) bool {
     return dispatch_count != 0 and (dispatch_count % EVICT_IDLE_DISPATCH_INTERVAL) == 0;
 }
 
+fn inboundDispatchShardIndex(
+    allocator: std.mem.Allocator,
+    config: *const Config,
+    msg: *const bus_mod.InboundMessage,
+    worker_count: usize,
+) usize {
+    if (worker_count == 0) return 0;
+
+    var parsed_meta = parseInboundMetadata(allocator, msg.metadata_json);
+    defer parsed_meta.deinit();
+
+    const routed_session_key = resolveInboundMainSessionKeyWithMetadata(
+        allocator,
+        config,
+        msg,
+        parsed_meta.fields,
+    ) orelse resolveInboundRouteSessionKeyWithMetadata(
+        allocator,
+        config,
+        msg,
+        parsed_meta.fields,
+    );
+    defer if (routed_session_key) |key| allocator.free(key);
+
+    const session_key = routed_session_key orelse msg.session_key;
+    const shard_count: u64 = @intCast(worker_count);
+    return @intCast(std.hash.Wyhash.hash(0, session_key) % shard_count);
+}
+
+fn publishInboundToWorkerQueue(
+    allocator: std.mem.Allocator,
+    config: *const Config,
+    worker_queues: []InboundDispatchQueue,
+    msg: bus_mod.InboundMessage,
+) error{Closed}!void {
+    std.debug.assert(worker_queues.len > 0);
+    const shard_index = inboundDispatchShardIndex(allocator, config, &msg, worker_queues.len);
+    try worker_queues[shard_index].publish(msg);
+}
+
 fn pollDebouncedInbound(
     _: std.mem.Allocator,
     event_bus: *bus_mod.Bus,
@@ -1378,14 +1418,15 @@ fn inboundDispatcherThread(
     defer debouncer.deinit();
     var ready_messages: std.ArrayListUnmanaged(bus_mod.InboundMessage) = .empty;
 
-    var worker_queue = InboundDispatchQueue.init();
+    var worker_queues: [INBOUND_DISPATCH_WORKER_COUNT]InboundDispatchQueue = undefined;
     var worker_ctxs: [INBOUND_DISPATCH_WORKER_COUNT]InboundWorkerCtx = undefined;
     var worker_threads: [INBOUND_DISPATCH_WORKER_COUNT]?std.Thread = .{null} ** INBOUND_DISPATCH_WORKER_COUNT;
     var worker_count: usize = 0;
     while (worker_count < INBOUND_DISPATCH_WORKER_COUNT) : (worker_count += 1) {
+        worker_queues[worker_count] = InboundDispatchQueue.init();
         worker_ctxs[worker_count] = .{
             .allocator = allocator,
-            .queue = &worker_queue,
+            .queue = &worker_queues[worker_count],
             .event_bus = event_bus,
             .registry = registry,
             .runtime = runtime,
@@ -1401,7 +1442,9 @@ fn inboundDispatcherThread(
         };
     }
     defer {
-        worker_queue.close();
+        for (worker_queues[0..worker_count]) |*queue| {
+            queue.close();
+        }
         var i: usize = 0;
         while (i < worker_count) : (i += 1) {
             if (worker_threads[i]) |thread| thread.join();
@@ -1431,7 +1474,7 @@ fn inboundDispatcherThread(
         while (ready_messages.items.len > 0) {
             var msg = ready_messages.orderedRemove(0);
             if (worker_count > 0) {
-                worker_queue.publish(msg) catch |err| {
+                publishInboundToWorkerQueue(allocator, runtime.config, worker_queues[0..worker_count], msg) catch |err| {
                     msg.deinit(allocator);
                     if (err == error.Closed) break;
                     continue;
@@ -1447,7 +1490,7 @@ fn inboundDispatcherThread(
     while (ready_messages.items.len > 0) {
         var msg = ready_messages.orderedRemove(0);
         if (worker_count > 0) {
-            worker_queue.publish(msg) catch {
+            publishInboundToWorkerQueue(allocator, runtime.config, worker_queues[0..worker_count], msg) catch {
                 msg.deinit(allocator);
             };
         } else {
@@ -1880,6 +1923,55 @@ test "shouldRunInboundIdleEviction only triggers at configured interval" {
     try std.testing.expect(shouldRunInboundIdleEviction(EVICT_IDLE_DISPATCH_INTERVAL));
     try std.testing.expect(shouldRunInboundIdleEviction(EVICT_IDLE_DISPATCH_INTERVAL * 2));
     try std.testing.expect(!shouldRunInboundIdleEviction(EVICT_IDLE_DISPATCH_INTERVAL + 1));
+}
+
+test "inboundDispatchShardIndex keeps routed session on same worker" {
+    const allocator = std.testing.allocator;
+    const bindings = [_]agent_routing.AgentBinding{
+        .{
+            .agent_id = "tg-ops",
+            .match = .{
+                .channel = "telegram",
+                .account_id = "backup",
+                .peer = .{ .kind = .group, .id = "-100123:thread:77" },
+            },
+        },
+    };
+    const config = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .allocator = allocator,
+        .agent_bindings = &bindings,
+        .channels = .{
+            .telegram = &[_]@import("config_types.zig").TelegramConfig{
+                .{ .account_id = "backup", .bot_token = "token" },
+            },
+        },
+    };
+    const first = bus_mod.InboundMessage{
+        .channel = "telegram",
+        .sender_id = "system:cron",
+        .chat_id = "chat-42",
+        .content = "first",
+        .session_key = "raw:first",
+        .metadata_json = "{\"account_id\":\"backup\",\"peer_kind\":\"group\",\"peer_id\":\"-100123\",\"thread_id\":\"77\"}",
+    };
+    const second = bus_mod.InboundMessage{
+        .channel = "telegram",
+        .sender_id = "system:cron",
+        .chat_id = "chat-42",
+        .content = "second",
+        .session_key = "raw:second",
+        .metadata_json = "{\"account_id\":\"backup\",\"peer_kind\":\"group\",\"peer_id\":\"-100123\",\"thread_id\":\"77\"}",
+    };
+
+    const worker_count = INBOUND_DISPATCH_WORKER_COUNT;
+    const shard_count: u64 = @intCast(worker_count);
+    const expected_shard: usize = @intCast(std.hash.Wyhash.hash(0, "agent:tg-ops:main") % shard_count);
+
+    // Regression (#855): same resolved session must stay on one FIFO worker queue.
+    try std.testing.expectEqual(expected_shard, inboundDispatchShardIndex(allocator, &config, &first, worker_count));
+    try std.testing.expectEqual(expected_shard, inboundDispatchShardIndex(allocator, &config, &second, worker_count));
 }
 
 test "hasSupervisedChannels false for defaults" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -1599,6 +1599,14 @@ pub const SessionManager = struct {
         return self.processMessageStreaming(session_key, content, conversation_context, null);
     }
 
+    fn lockSessionForTurn(session: *Session) void {
+        if (session.mutex.tryLock()) return;
+        if (session.turn_running.load(.acquire)) {
+            session.agent.requestInterrupt();
+        }
+        session.mutex.lock();
+    }
+
     /// Handle a slash command against the live session without invoking the LLM turn loop.
     /// Used for transport-driven local UIs such as Telegram callback menus.
     pub fn handleLocalSlashCommand(
@@ -1609,7 +1617,7 @@ pub const SessionManager = struct {
     ) !?[]const u8 {
         const session = try self.getOrCreate(session_key);
 
-        session.mutex.lock();
+        lockSessionForTurn(session);
         defer session.mutex.unlock();
         session.turn_running.store(true, .release);
         defer {
@@ -1689,7 +1697,7 @@ pub const SessionManager = struct {
 
         const session = try self.getOrCreate(session_key);
 
-        session.mutex.lock();
+        lockSessionForTurn(session);
         defer session.mutex.unlock();
         session.turn_running.store(true, .release);
         defer {
@@ -3563,6 +3571,50 @@ test "requestTurnInterrupt returns active tool snapshot when available" {
     try testing.expect(res.requested);
     try testing.expect(res.active_tool != null);
     try testing.expectEqualStrings("shell", res.active_tool.?);
+}
+
+test "lockSessionForTurn requests interrupt when turn is already running" {
+    var mock = MockProvider{ .response = "ok" };
+    const cfg = testConfig();
+    var sm = testSessionManager(testing.allocator, &mock, &cfg);
+    defer sm.deinit();
+
+    const session = try sm.getOrCreate("interrupt:contention");
+    session.turn_running.store(true, .release);
+    defer session.turn_running.store(false, .release);
+    session.agent.clearInterruptRequest();
+
+    session.mutex.lock();
+    var session_unlocked = false;
+    defer if (!session_unlocked) session.mutex.unlock();
+
+    const Worker = struct {
+        const Ctx = struct {
+            session: *Session,
+        };
+
+        fn run(ctx: Ctx) void {
+            SessionManager.lockSessionForTurn(ctx.session);
+            ctx.session.mutex.unlock();
+        }
+    };
+
+    const ctx = Worker.Ctx{ .session = session };
+    var thread = try std.Thread.spawn(.{}, Worker.run, .{ctx});
+    var thread_joined = false;
+    defer if (!thread_joined) thread.join();
+
+    var attempts: usize = 0;
+    while (attempts < 100 and !session.agent.interrupt_requested.load(.acquire)) : (attempts += 1) {
+        std_compat.thread.sleep(2 * std.time.ns_per_ms);
+    }
+    // Regression (#832): a follow-up turn waiting on the same session lock must signal interruption.
+    try testing.expect(session.agent.interrupt_requested.load(.acquire));
+
+    session.mutex.unlock();
+    session_unlocked = true;
+    thread.join();
+    thread_joined = true;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/session.zig
+++ b/src/session.zig
@@ -1652,10 +1652,6 @@ pub const SessionManager = struct {
     }
 
     fn lockSessionForTurn(session: *Session) void {
-        if (session.mutex.tryLock()) return;
-        if (session.turn_running.load(.acquire)) {
-            session.agent.requestInterrupt();
-        }
         session.mutex.lock();
     }
 
@@ -3960,7 +3956,7 @@ test "requestTurnInterrupt returns active tool snapshot when available" {
     try testing.expectEqualStrings("shell", res.active_tool.?);
 }
 
-test "lockSessionForTurn requests interrupt when turn is already running" {
+test "lockSessionForTurn waits without interrupting active serial turn" {
     var mock = MockProvider{ .response = "ok" };
     const cfg = testConfig();
     var sm = testSessionManager(testing.allocator, &mock, &cfg);
@@ -3978,25 +3974,34 @@ test "lockSessionForTurn requests interrupt when turn is already running" {
     const Worker = struct {
         const Ctx = struct {
             session: *Session,
+            started: *std.atomic.Value(bool),
         };
 
         fn run(ctx: Ctx) void {
+            ctx.started.store(true, .release);
             SessionManager.lockSessionForTurn(ctx.session);
             ctx.session.mutex.unlock();
         }
     };
 
-    const ctx = Worker.Ctx{ .session = session };
+    var worker_started = std.atomic.Value(bool).init(false);
+    const ctx = Worker.Ctx{ .session = session, .started = &worker_started };
     var thread = try std.Thread.spawn(.{}, Worker.run, .{ctx});
     var thread_joined = false;
     defer if (!thread_joined) thread.join();
 
     var attempts: usize = 0;
-    while (attempts < 100 and !session.agent.interrupt_requested.load(.acquire)) : (attempts += 1) {
+    while (attempts < 100 and !worker_started.load(.acquire)) : (attempts += 1) {
         std_compat.thread.sleep(2 * std.time.ns_per_ms);
     }
-    // Regression (#832): a follow-up turn waiting on the same session lock must signal interruption.
-    try testing.expect(session.agent.interrupt_requested.load(.acquire));
+    try testing.expect(worker_started.load(.acquire));
+
+    attempts = 0;
+    while (attempts < 20) : (attempts += 1) {
+        std_compat.thread.sleep(2 * std.time.ns_per_ms);
+    }
+    // Regression (#832): serial queued turns must wait behind active turns without hard-stopping them.
+    try testing.expect(!session.agent.interrupt_requested.load(.acquire));
 
     session.mutex.unlock();
     session_unlocked = true;


### PR DESCRIPTION
Fixes #832

## Summary

### EN:
- Added session-level preemption behavior: when a new message arrives for a busy session, the session manager requests interrupt on the running turn before waiting for lock handoff.
- Refactored daemon inbound handling from single-thread serial processing into bounded-queue + worker-pool dispatch, so ingress is no longer blocked by one long-running turn.
- Extracted message processing path into `processInboundMessage(...)` and retained periodic idle-eviction checks with atomic accounting.
- Added regression tests in `src/session.zig` and `src/daemon.zig` for preemption-on-contention and idle-eviction trigger behavior.

### ZH:
- 增加会话级抢占：当繁忙会话收到新消息时，session manager 会先请求中断正在执行的轮次，再等待锁交接。
- 将 daemon 入站处理从单线程串行改为“有界队列 + worker 池”分发，避免单个长轮次阻塞整体消息入口。
- 抽取 `processInboundMessage(...)` 作为统一处理路径，并保留基于原子计数的周期性空闲淘汰检查。
- 在 `src/session.zig` 与 `src/daemon.zig` 增加回归测试，覆盖“竞争触发抢占”和“空闲淘汰触发条件”。

## Validation
- `zig build test --summary all`

## Notes
- The scope is intentionally limited to contention/preemption and inbound dispatch concurrency; no security policy defaults were changed.