### PR TITLE
feat(capabilities): add colored table format for channels with TTY detection

### DIFF
--- a/src/capabilities.zig
+++ b/src/capabilities.zig
@@ -8,6 +8,13 @@ const tools_mod = @import("tools/root.zig");
 const Config = config_mod.Config;
 const Tool = tools_mod.Tool;
 
+const Color = struct {
+    const reset = "\x1b[0m";
+    const green = "\x1b[32m";
+    const yellow = "\x1b[33m";
+    const red = "\x1b[31m";
+};
+
 const core_tool_names = [_][]const u8{
     "shell",
     "file_read",
@@ -200,6 +207,52 @@ fn appendJsonStringArray(w: anytype, names: []const []const u8) !void {
     try w.writeAll("]");
 }
 
+fn channelStatusColor(status: []const u8) []const u8 {
+    if (std.mem.eql(u8, status, "enabled") or
+        std.mem.eql(u8, status, "enabled in build") or
+        std.mem.startsWith(u8, status, "configured"))
+    {
+        return Color.green;
+    }
+    if (std.mem.eql(u8, status, "not configured")) return Color.yellow;
+    if (std.mem.indexOf(u8, status, "disabled") != null) return Color.red;
+    return "";
+}
+
+fn buildChannelStatusTable(allocator: std.mem.Allocator, cfg_opt: ?*const Config, colorize: bool) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var out_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &out);
+    const w = &out_writer.writer;
+
+    var sorted = channel_catalog.known_channels;
+    std.mem.sort(channel_catalog.ChannelMeta, &sorted, {}, struct {
+        fn lessThan(_: void, a: channel_catalog.ChannelMeta, b: channel_catalog.ChannelMeta) bool {
+            return std.mem.lessThan(u8, a.key, b.key);
+        }
+    }.lessThan);
+
+    try w.writeAll("    key          status\n");
+    try w.writeAll("    -----------  --------------------------\n");
+    for (sorted) |meta| {
+        var status_buf: [64]u8 = undefined;
+        const status = if (cfg_opt) |cfg|
+            channel_catalog.statusText(cfg, meta, &status_buf)
+        else if (channel_catalog.isBuildEnabled(meta.id))
+            "enabled in build"
+        else
+            "disabled in build";
+        const color = if (colorize) channelStatusColor(status) else "";
+        if (color.len != 0) try w.writeAll(color);
+        try w.print("    {s:<11}  {s}", .{ meta.key, status });
+        if (color.len != 0) try w.writeAll(Color.reset);
+        try w.writeByte('\n');
+    }
+
+    out = out_writer.toArrayList();
+    return try out.toOwnedSlice(allocator);
+}
+
 pub fn buildManifestJson(
     allocator: std.mem.Allocator,
     cfg_opt: ?*const Config,
@@ -295,12 +348,17 @@ pub fn buildSummaryText(
     cfg_opt: ?*const Config,
     runtime_tools: ?[]const Tool,
 ) ![]u8 {
-    const channels_enabled = try collectChannelNames(allocator, cfg_opt, .build_enabled);
-    defer allocator.free(channels_enabled);
-    const channels_disabled = try collectChannelNames(allocator, cfg_opt, .build_disabled);
-    defer allocator.free(channels_disabled);
-    const channels_configured = try collectChannelNames(allocator, cfg_opt, .configured);
-    defer allocator.free(channels_configured);
+    return buildSummaryTextWithColor(allocator, cfg_opt, runtime_tools, false);
+}
+
+pub fn buildSummaryTextWithColor(
+    allocator: std.mem.Allocator,
+    cfg_opt: ?*const Config,
+    runtime_tools: ?[]const Tool,
+    colorize: bool,
+) ![]u8 {
+    const channels_status_s = try buildChannelStatusTable(allocator, cfg_opt, colorize);
+    defer allocator.free(channels_status_s);
 
     const engines_enabled = try collectMemoryEngineNames(allocator, .build_enabled);
     defer allocator.free(engines_enabled);
@@ -312,12 +370,6 @@ pub fn buildSummaryText(
     const optional_disabled = try collectOptionalTools(allocator, cfg_opt, .disabled);
     defer allocator.free(optional_disabled);
 
-    const channels_enabled_s = try joinNames(allocator, channels_enabled);
-    defer allocator.free(channels_enabled_s);
-    const channels_disabled_s = try joinNames(allocator, channels_disabled);
-    defer allocator.free(channels_disabled_s);
-    const channels_configured_s = try joinNames(allocator, channels_configured);
-    defer allocator.free(channels_configured_s);
     const engines_enabled_s = try joinNames(allocator, engines_enabled);
     defer allocator.free(engines_enabled_s);
     const engines_disabled_s = try joinNames(allocator, engines_disabled);
@@ -334,23 +386,19 @@ pub fn buildSummaryText(
         allocator,
         "Capabilities\n" ++
             "\nAvailable in this runtime:\n" ++
-            "  channels (build): {s}\n" ++
-            "  channels (configured): {s}\n" ++
+            "  channels:\n{s}" ++
             "  memory engines (build): {s}\n" ++
             "  active memory backend: {s}\n" ++
             "  {s}: {s}\n" ++
             "\nNot available in this runtime:\n" ++
-            "  channels (disabled in build): {s}\n" ++
             "  memory engines (disabled in build): {s}\n" ++
             "  optional tools (disabled by config): {s}\n",
         .{
-            channels_enabled_s,
-            channels_configured_s,
+            channels_status_s,
             engines_enabled_s,
             active_backend,
             tools_label,
             runtime_tools_s,
-            channels_disabled_s,
             engines_disabled_s,
             optional_disabled_s,
         },
@@ -452,5 +500,19 @@ test "buildSummaryText includes availability sections" {
     defer std.testing.allocator.free(summary);
 
     try std.testing.expect(std.mem.indexOf(u8, summary, "Available in this runtime") != null);
+    try std.testing.expect(std.mem.indexOf(u8, summary, "channels:\n    key          status\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, summary, "    webhook") != null);
+    const dingtalk_idx = std.mem.indexOf(u8, summary, "    dingtalk") orelse unreachable;
+    const discord_idx = std.mem.indexOf(u8, summary, "    discord") orelse unreachable;
+    try std.testing.expect(dingtalk_idx < discord_idx);
+    try std.testing.expect(std.mem.indexOfScalar(u8, summary, '\x1b') == null);
     try std.testing.expect(std.mem.indexOf(u8, summary, "Not available in this runtime") != null);
+}
+
+test "buildSummaryTextWithColor includes ANSI escapes" {
+    const summary = try buildSummaryTextWithColor(std.testing.allocator, null, null, true);
+    defer std.testing.allocator.free(summary);
+
+    try std.testing.expect(std.mem.indexOf(u8, summary, "\x1b[32m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, summary, "\x1b[0m") != null);
 }

--- a/src/capabilities.zig
+++ b/src/capabilities.zig
@@ -3,17 +3,12 @@ const build_options = @import("build_options");
 const channel_catalog = @import("channel_catalog.zig");
 const config_mod = @import("config.zig");
 const memory_registry = @import("memory/engines/registry.zig");
+const terminal_color = @import("terminal_color.zig");
 const tools_mod = @import("tools/root.zig");
 
 const Config = config_mod.Config;
 const Tool = tools_mod.Tool;
-
-const Color = struct {
-    const reset = "\x1b[0m";
-    const green = "\x1b[32m";
-    const yellow = "\x1b[33m";
-    const red = "\x1b[31m";
-};
+const Color = terminal_color.Color;
 
 const core_tool_names = [_][]const u8{
     "shell",

--- a/src/doctor.zig
+++ b/src/doctor.zig
@@ -16,7 +16,6 @@ const channel_catalog = @import("channel_catalog.zig");
 const daemon = @import("daemon.zig");
 const cron = @import("cron.zig");
 const fs_compat = @import("fs_compat.zig");
-const builtin = @import("builtin");
 const health = @import("health.zig");
 const json_util = @import("json_util.zig");
 const admin_output = @import("admin_output.zig");
@@ -24,6 +23,7 @@ const version = @import("version.zig");
 const bootstrap_mod = @import("bootstrap/root.zig");
 const BootstrapProvider = bootstrap_mod.BootstrapProvider;
 const memory_root = @import("memory/root.zig");
+const terminal_color = @import("terminal_color.zig");
 
 /// Staleness thresholds (seconds).
 const DAEMON_STALE_SECONDS: i64 = 30;
@@ -35,50 +35,10 @@ const NO_NON_CLI_CHANNELS_CONFIGURED_MESSAGE = "no non-CLI channels configured -
 const CLI_ALWAYS_AVAILABLE_MESSAGE = "CLI always available";
 // ── ANSI color support ──────────────────────────────────────────
 
-extern "kernel32" fn GetStdHandle(nStdHandle: std.os.windows.DWORD) callconv(.winapi) ?std.os.windows.HANDLE;
-extern "kernel32" fn GetConsoleMode(
-    hConsoleHandle: std.os.windows.HANDLE,
-    lpMode: *std.os.windows.DWORD,
-) callconv(.winapi) std.os.windows.BOOL;
-extern "kernel32" fn SetConsoleMode(
-    hConsoleHandle: std.os.windows.HANDLE,
-    dwMode: std.os.windows.DWORD,
-) callconv(.winapi) std.os.windows.BOOL;
-const STD_OUTPUT_HANDLE: std.os.windows.DWORD = @bitCast(@as(i32, -11));
-
-const Color = struct {
-    const reset = "\x1b[0m";
-    const green = "\x1b[32m";
-    const yellow = "\x1b[33m";
-    const red = "\x1b[31m";
-};
+const Color = terminal_color.Color;
 
 pub fn shouldColorize(file: std_compat.fs.File) bool {
-    // Respect NO_COLOR convention (https://no-color.org/)
-    if (comptime builtin.os.tag != .windows and builtin.link_libc) {
-        if (std.c.getenv("NO_COLOR")) |_| return false;
-    }
-
-    // Never colorize if stdout is redirected to a file/pipe
-    if (!file.isTty()) return false;
-
-    // On Windows, attempt to enable Virtual Terminal Processing.
-    // If that fails, fall back to no color.
-    if (builtin.os.tag == .windows) {
-        return enableWindowsVT100() catch false;
-    }
-
-    return true;
-}
-
-/// Windows-specific: enable ENABLE_VIRTUAL_TERMINAL_PROCESSING on stdout.
-fn enableWindowsVT100() !bool {
-    const windows = std.os.windows;
-    const handle = GetStdHandle(STD_OUTPUT_HANDLE) orelse return false;
-    var mode: windows.DWORD = 0;
-    if (GetConsoleMode(handle, &mode) == .FALSE) return false;
-    mode |= 0x0004; // ENABLE_VIRTUAL_TERMINAL_PROCESSING
-    return SetConsoleMode(handle, mode) != .FALSE;
+    return terminal_color.shouldColorize(file);
 }
 
 // ── Diagnostic types ────────────────────────────────────────────

--- a/src/main.zig
+++ b/src/main.zig
@@ -3182,11 +3182,12 @@ fn runCapabilities(allocator: std.mem.Allocator, sub_args: []const []const u8) !
     var cfg_opt: ?yc.config.Config = yc.config.Config.load(allocator) catch null;
     defer if (cfg_opt) |*cfg| cfg.deinit();
     const cfg_ptr: ?*const yc.config.Config = if (cfg_opt) |*cfg| cfg else null;
+    const colorize = yc.doctor.shouldColorize(std_compat.fs.File.stdout());
 
     const output = if (as_json)
         try yc.capabilities.buildManifestJson(allocator, cfg_ptr, null)
     else
-        try yc.capabilities.buildSummaryText(allocator, cfg_ptr, null);
+        try yc.capabilities.buildSummaryTextWithColor(allocator, cfg_ptr, null, colorize);
     defer allocator.free(output);
 
     try yc.admin_output.writeStdoutBytes(output);

--- a/src/terminal_color.zig
+++ b/src/terminal_color.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const std_compat = @import("compat");
+const builtin = @import("builtin");
+
+extern "kernel32" fn GetStdHandle(nStdHandle: std.os.windows.DWORD) callconv(.winapi) ?std.os.windows.HANDLE;
+extern "kernel32" fn GetConsoleMode(
+    hConsoleHandle: std.os.windows.HANDLE,
+    lpMode: *std.os.windows.DWORD,
+) callconv(.winapi) std.os.windows.BOOL;
+extern "kernel32" fn SetConsoleMode(
+    hConsoleHandle: std.os.windows.HANDLE,
+    dwMode: std.os.windows.DWORD,
+) callconv(.winapi) std.os.windows.BOOL;
+const STD_OUTPUT_HANDLE: std.os.windows.DWORD = @bitCast(@as(i32, -11));
+
+pub const Color = struct {
+    pub const reset = "\x1b[0m";
+    pub const green = "\x1b[32m";
+    pub const yellow = "\x1b[33m";
+    pub const red = "\x1b[31m";
+};
+
+pub fn shouldColorize(file: std_compat.fs.File) bool {
+    // Respect NO_COLOR convention (https://no-color.org/)
+    if (comptime builtin.os.tag != .windows and builtin.link_libc) {
+        if (std.c.getenv("NO_COLOR")) |_| return false;
+    }
+
+    // Never colorize if stdout is redirected to a file/pipe.
+    if (!file.isTty()) return false;
+
+    // On Windows, attempt to enable Virtual Terminal Processing.
+    // If that fails, fall back to no color.
+    if (builtin.os.tag == .windows) {
+        return enableWindowsVT100() catch false;
+    }
+
+    return true;
+}
+
+/// Windows-specific: enable ENABLE_VIRTUAL_TERMINAL_PROCESSING on stdout.
+fn enableWindowsVT100() !bool {
+    const windows = std.os.windows;
+    const handle = GetStdHandle(STD_OUTPUT_HANDLE) orelse return false;
+    var mode: windows.DWORD = 0;
+    if (GetConsoleMode(handle, &mode) == .FALSE) return false;
+    mode |= 0x0004; // ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    return SetConsoleMode(handle, mode) != .FALSE;
+}
+
+test "Color exposes shared ANSI status colors" {
+    try std.testing.expectEqualStrings("\x1b[0m", Color.reset);
+    try std.testing.expectEqualStrings("\x1b[32m", Color.green);
+    try std.testing.expectEqualStrings("\x1b[33m", Color.yellow);
+    try std.testing.expectEqualStrings("\x1b[31m", Color.red);
+}


### PR DESCRIPTION
## Summary

###  EN:
   - Improved `nullclaw capabilities` output by replacing comma-separated lists with a readable sorted table format.
   - Added semantic color coding for channel status: green for enabled/configured, yellow for not configured, red for disabled.
   - Integrated TTY detection via `doctor.shouldColorize()` respecting the NO_COLOR convention.
   - Created `buildSummaryTextWithColor()` as the main entry point while maintaining backward compatibility.
   - Updated `main.zig` runCapabilities() to automatically detect TTY and apply colors.

###  ZH:
   - 改进了 `nullclaw capabilities` 输出，用可读的排序表格格式替换了逗号分隔的列表。
   - 为频道状态添加了语义颜色编码：绿色表示已启用/已配置，黄色表示未配置，红色表示已禁用。
   - 通过 `doctor.shouldColorize()` 集成了 TTY 检测，尊重 NO_COLOR 约定。
   - 创建了 `buildSummaryTextWithColor()` 作为主入口，同时保持向后兼容性。
   - 更新了 `main.zig` 的 runCapabilities() 以自动检测 TTY 并应用颜色。

##  Validation
   - zig build test --summary all: All 6658 tests passed, 0 leaks.
   - Manual verification: Verified colored output renders correctly in terminal and uncolored output when piped.
   - Table format verified: Channels are sorted alphabetically with aligned columns.

## Notes
   - Reused existing Color infrastructure and shouldColorize() pattern from doctor.zig for consistency.
   - Semantic colors enable rapid visual scanning of channel status without reading text.
   - Backward compatibility maintained: buildSummaryText() continues to return uncolored output.
   - ANSI codes only applied when output is TTY; automatically disabled for pipes (Unix convention).

Fixes #860