### PR TITLE
fix: Zig 0.16 Mattermost empty-body POST and gateway accept-loop CPU spin

### DIFF
--- a/src/channels/mattermost.zig
+++ b/src/channels/mattermost.zig
@@ -12,6 +12,71 @@ const Atomic = @import("../portable_atomic.zig").Atomic;
 
 const log = std.log.scoped(.mattermost);
 
+fn buildTypingRequestBody(
+    allocator: std.mem.Allocator,
+    channel_id: []const u8,
+    thread_id: ?[]const u8,
+) ![]u8 {
+    var body: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer body.deinit(allocator);
+    var body_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &body);
+    const bw = &body_writer.writer;
+    try bw.writeAll("{\"channel_id\":");
+    try root.appendJsonStringW(bw, channel_id);
+    if (thread_id) |tid| {
+        if (tid.len > 0) {
+            try bw.writeAll(",\"parent_id\":");
+            try root.appendJsonStringW(bw, tid);
+        }
+    }
+    try bw.writeByte('}');
+    body = body_writer.toArrayList();
+    return try body.toOwnedSlice(allocator);
+}
+
+fn buildPostRequestBody(
+    allocator: std.mem.Allocator,
+    channel_id: []const u8,
+    text: []const u8,
+    thread_id: ?[]const u8,
+) ![]u8 {
+    var body: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer body.deinit(allocator);
+    var body_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &body);
+    const bw = &body_writer.writer;
+    try bw.writeAll("{\"channel_id\":");
+    try root.appendJsonStringW(bw, channel_id);
+    try bw.writeAll(",\"message\":");
+    try root.appendJsonStringW(bw, text);
+    if (thread_id) |tid| {
+        if (tid.len > 0) {
+            try bw.writeAll(",\"root_id\":");
+            try root.appendJsonStringW(bw, tid);
+        }
+    }
+    try bw.writeByte('}');
+    body = body_writer.toArrayList();
+    return try body.toOwnedSlice(allocator);
+}
+
+fn buildDirectChannelRequestBody(
+    allocator: std.mem.Allocator,
+    bot_id: []const u8,
+    user_id: []const u8,
+) ![]u8 {
+    var body: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer body.deinit(allocator);
+    var body_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &body);
+    const bw = &body_writer.writer;
+    try bw.writeByte('[');
+    try root.appendJsonStringW(bw, bot_id);
+    try bw.writeByte(',');
+    try root.appendJsonStringW(bw, user_id);
+    try bw.writeByte(']');
+    body = body_writer.toArrayList();
+    return try body.toOwnedSlice(allocator);
+}
+
 const SocketFd = std_compat.net.Stream.Handle;
 const invalid_socket: SocketFd = switch (builtin.os.tag) {
     .windows => std_compat.net.invalidHandle(SocketFd),
@@ -188,26 +253,14 @@ pub const MattermostChannel = struct {
         const url = std.fmt.allocPrint(self.allocator, "{s}/api/v4/users/me/typing", .{self.base_url}) catch return;
         defer self.allocator.free(url);
 
-        var body: std.ArrayListUnmanaged(u8) = .empty;
-        defer body.deinit(self.allocator);
-        var body_writer: std.Io.Writer.Allocating = .fromArrayList(self.allocator, &body);
-        defer body = body_writer.toArrayList();
-        const bw = &body_writer.writer;
-        bw.writeAll("{\"channel_id\":") catch return;
-        root.appendJsonStringW(bw, channel_id) catch return;
-        if (parsed_target.thread_id) |tid| {
-            if (tid.len > 0) {
-                bw.writeAll(",\"parent_id\":") catch return;
-                root.appendJsonStringW(bw, tid) catch return;
-            }
-        }
-        bw.writeByte('}') catch return;
+        const body = buildTypingRequestBody(self.allocator, channel_id, parsed_target.thread_id) catch return;
+        defer self.allocator.free(body);
 
         const auth_header = std.fmt.allocPrint(self.allocator, "Authorization: Bearer {s}", .{self.bot_token}) catch return;
         defer self.allocator.free(auth_header);
         const headers = [_][]const u8{auth_header};
 
-        const resp = root.http_util.curlPost(self.allocator, url, body.items, &headers) catch return;
+        const resp = root.http_util.curlPost(self.allocator, url, body, &headers) catch return;
         self.allocator.free(resp);
     }
 
@@ -222,28 +275,14 @@ pub const MattermostChannel = struct {
         const url = try std.fmt.allocPrint(self.allocator, "{s}/api/v4/posts", .{self.base_url});
         defer self.allocator.free(url);
 
-        var body: std.ArrayListUnmanaged(u8) = .empty;
-        defer body.deinit(self.allocator);
-        var body_writer: std.Io.Writer.Allocating = .fromArrayList(self.allocator, &body);
-        defer body = body_writer.toArrayList();
-        const bw = &body_writer.writer;
-        try bw.writeAll("{\"channel_id\":");
-        try root.appendJsonStringW(bw, channel_id);
-        try bw.writeAll(",\"message\":");
-        try root.appendJsonStringW(bw, text);
-        if (thread_id) |tid| {
-            if (tid.len > 0) {
-                try bw.writeAll(",\"root_id\":");
-                try root.appendJsonStringW(bw, tid);
-            }
-        }
-        try bw.writeByte('}');
+        const body = try buildPostRequestBody(self.allocator, channel_id, text, thread_id);
+        defer self.allocator.free(body);
 
         const auth_header = try std.fmt.allocPrint(self.allocator, "Authorization: Bearer {s}", .{self.bot_token});
         defer self.allocator.free(auth_header);
         const headers = [_][]const u8{auth_header};
 
-        const resp = root.http_util.curlPost(self.allocator, url, body.items, &headers) catch return error.MattermostApiError;
+        const resp = root.http_util.curlPost(self.allocator, url, body, &headers) catch return error.MattermostApiError;
         defer self.allocator.free(resp);
 
         if (std.mem.indexOf(u8, resp, "\"id\"") == null) {
@@ -279,22 +318,14 @@ pub const MattermostChannel = struct {
         const url = try std.fmt.allocPrint(self.allocator, "{s}/api/v4/channels/direct", .{self.base_url});
         defer self.allocator.free(url);
 
-        var body: std.ArrayListUnmanaged(u8) = .empty;
-        defer body.deinit(self.allocator);
-        var body_writer: std.Io.Writer.Allocating = .fromArrayList(self.allocator, &body);
-        defer body = body_writer.toArrayList();
-        const bw = &body_writer.writer;
-        try bw.writeByte('[');
-        try root.appendJsonStringW(bw, bot_id);
-        try bw.writeByte(',');
-        try root.appendJsonStringW(bw, user_id);
-        try bw.writeByte(']');
+        const body = try buildDirectChannelRequestBody(self.allocator, bot_id, user_id);
+        defer self.allocator.free(body);
 
         const auth_header = try std.fmt.allocPrint(self.allocator, "Authorization: Bearer {s}", .{self.bot_token});
         defer self.allocator.free(auth_header);
         const headers = [_][]const u8{auth_header};
 
-        const resp = root.http_util.curlPost(self.allocator, url, body.items, &headers) catch return error.MattermostApiError;
+        const resp = root.http_util.curlPost(self.allocator, url, body, &headers) catch return error.MattermostApiError;
         defer self.allocator.free(resp);
 
         const parsed = std.json.parseFromSlice(std.json.Value, self.allocator, resp, .{}) catch return error.MattermostApiError;
@@ -949,6 +980,28 @@ test "mattermost parseTarget supports prefixes and thread suffix" {
     const f = try parseTarget("#town-square");
     try std.testing.expect(f.kind == .channel);
     try std.testing.expectEqualStrings("town-square", f.value);
+}
+
+test "mattermost buildTypingRequestBody includes channel and thread" {
+    const alloc = std.testing.allocator;
+    const body = try buildTypingRequestBody(alloc, "town", "root-9");
+    defer alloc.free(body);
+    try std.testing.expectEqualStrings("{\"channel_id\":\"town\",\"parent_id\":\"root-9\"}", body);
+}
+
+test "mattermost buildPostRequestBody includes non-empty message body" {
+    const alloc = std.testing.allocator;
+    // Regression: Zig 0.16 allocating writer migration must finalize before POST, or Mattermost receives EOF.
+    const body = try buildPostRequestBody(alloc, "town", "hello", null);
+    defer alloc.free(body);
+    try std.testing.expectEqualStrings("{\"channel_id\":\"town\",\"message\":\"hello\"}", body);
+}
+
+test "mattermost buildDirectChannelRequestBody includes both user ids" {
+    const alloc = std.testing.allocator;
+    const body = try buildDirectChannelRequestBody(alloc, "bot-1", "user-2");
+    defer alloc.free(body);
+    try std.testing.expectEqualStrings("[\"bot-1\",\"user-2\"]", body);
 }
 
 test "mattermost sendTypingIndicator is no-op in tests" {

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -230,7 +230,12 @@ pub const time = struct {
 
 pub const thread = struct {
     pub fn sleep(nanoseconds: u64) void {
-        std.Io.sleep(io(), .fromNanoseconds(@intCast(nanoseconds)), .awake) catch {};
+        if (nanoseconds == 0) return;
+        const rqtp = std.c.timespec{
+            .sec = @intCast(nanoseconds / std.time.ns_per_s),
+            .nsec = @intCast(nanoseconds % std.time.ns_per_s),
+        };
+        _ = std.c.nanosleep(&rqtp, null);
     }
 };
 

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -231,11 +231,18 @@ pub const time = struct {
 pub const thread = struct {
     pub fn sleep(nanoseconds: u64) void {
         if (nanoseconds == 0) return;
-        const rqtp = std.c.timespec{
-            .sec = @intCast(nanoseconds / std.time.ns_per_s),
-            .nsec = @intCast(nanoseconds % std.time.ns_per_s),
-        };
-        _ = std.c.nanosleep(&rqtp, null);
+        if (comptime @import("builtin").os.tag == .windows) {
+            // Windows: std.Io.sleep routes through IOCP and reliably suspends here.
+            std.Io.sleep(io(), .fromNanoseconds(@intCast(nanoseconds)), .awake) catch {};
+        } else {
+            // POSIX: call nanosleep directly to bypass std.Io.sleep's cooperative
+            // yield, which does not actually suspend the OS thread in Threaded IO context.
+            const rqtp = std.c.timespec{
+                .sec = @intCast(nanoseconds / std.time.ns_per_s),
+                .nsec = @intCast(nanoseconds % std.time.ns_per_s),
+            };
+            _ = std.c.nanosleep(&rqtp, null);
+        }
     }
 };
 

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -5221,6 +5221,13 @@ pub fn run(allocator: std.mem.Allocator, host: []const u8, port: u16, config_ptr
                 std_compat.thread.sleep(ACCEPT_POLL_INTERVAL_MS * std.time.ns_per_ms);
                 continue;
             },
+            // In non-debug builds, std.Io.Threaded's netAcceptPosix maps EAGAIN
+            // from a non-blocking accept4() to error.Unexpected via errnoBug()
+            // instead of error.WouldBlock. Treat it identically: sleep and retry.
+            error.Unexpected => {
+                std_compat.thread.sleep(ACCEPT_POLL_INTERVAL_MS * std.time.ns_per_ms);
+                continue;
+            },
             else => continue,
         };
         var close_conn = true;

--- a/src/mcp_admin.zig
+++ b/src/mcp_admin.zig
@@ -137,7 +137,7 @@ test "buildServersJson redacts env values and preserves names" {
             .name = "context7",
             .transport = "stdio",
             .command = "npx",
-            .args = &.{"-y", "@upstash/context7-mcp"},
+            .args = &.{ "-y", "@upstash/context7-mcp" },
             .env = &env,
             .headers = &headers,
             .timeout_ms = 12_000,
@@ -160,7 +160,7 @@ test "buildServerJson includes full args for one server" {
             .name = "context7",
             .transport = "stdio",
             .command = "npx",
-            .args = &.{"-y", "@upstash/context7-mcp"},
+            .args = &.{ "-y", "@upstash/context7-mcp" },
         },
     };
 
@@ -176,7 +176,7 @@ test "appendServerSummary serializes tool_count when known" {
         .name = "context7",
         .transport = "stdio",
         .command = "npx",
-        .args = &.{"-y", "@upstash/context7-mcp"},
+        .args = &.{ "-y", "@upstash/context7-mcp" },
     };
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;


### PR DESCRIPTION
> [!CAUTION]
> **High-severity regression** — both issues affect all Mattermost-connected agents in production since the Zig 0.16 migration:
> - **100% CPU utilisation** on the gateway thread (busy-spin on EAGAIN) — affects all platforms in daemon mode
> - **Silent Mattermost messaging failure** — all bot messages silently dropped (empty POST body)

## Summary

Two bugs introduced by the Zig 0.16 migration, both observed on live hardware (OrangePi RV2 / riscv64, Radxa Zero 3W / aarch64).

**Mattermost silent failure** (`src/channels/mattermost.zig`): `std.Io.Writer.Allocating` does not flush to its backing `ArrayList` until `toArrayList()` is called. The previous code passed `body.items` to `curlPost()` before calling `toArrayList()`, so every POST was sent with an empty body and Mattermost silently rejected all messages. Fixed by extracting `buildTypingRequestBody`, `buildPostRequestBody`, and `buildDirectChannelRequestBody` helpers that each call `toArrayList()` before returning an owned slice.

**Gateway 100% CPU spin** (`src/gateway.zig`, `src/compat.zig`): In daemon mode the listen socket is set non-blocking (`force_nonblocking = daemon_mode`). Under Zig 0.16 `std.Io.Threaded`, `netAcceptPosix` maps `EAGAIN` from `accept4()` to `errnoBug()` instead of `error.WouldBlock`. In non-debug builds `errnoBug` returns `error.Unexpected`, which the accept loop's `else => continue` caught without sleeping — producing a tight spin of ~9,600 `accept4` calls/second and ~100% CPU on the gateway thread. Fixed by adding an explicit `error.Unexpected` arm that sleeps `ACCEPT_POLL_INTERVAL_MS` (100 ms) identically to the `error.WouldBlock` arm. Also replaced `std_compat.thread.sleep`'s `std.Io.sleep` call with a direct `std.c.nanosleep` call on POSIX (reliably suspends the OS thread; `std.Io.sleep` does not yield the CPU in the Threaded IO context). Windows retains `std.Io.sleep` via IOCP which works correctly there.

## Commits

- `style: format mcp_admin.zig` — pre-existing fmt issue caught by pre-commit hook
- `fix(channels/mattermost): finalize allocating writer body before curlPost`
- `fix(gateway, compat): CPU spin from EAGAIN on non-blocking accept socket`
- `fix(compat): Windows sleep guard (std.Io.sleep via IOCP on Windows, std.c.nanosleep on POSIX)`

## Validation

```
zig build test --summary all
→ 6603 pass, 9 skip, 1 fail (6613 total)
```

The 1 failure (`tools.web_search` — aggregate error message check) is pre-existing on the base commit. The 9 failures seen inside the git hook environment (`skills.installSkillFromGit` — inherits `GIT_DIR`) are also pre-existing. Regression tests added for all three Mattermost body builders.

Verified on live hardware: CPU dropped from ~98% sustained to ~0% idle on both arm boards after deploying the fix.

## Notes

- The `netAcceptPosix` EAGAIN→`errnoBug` mapping is a Zig 0.16 stdlib issue; this fix is a targeted workaround at the accept loop. A proper fix would require patching `std/Io/Threaded.zig`.
- Risk tier: **High** (`gateway.zig`) + **Medium** (`channels/mattermost.zig`, `compat.zig`).