### PR TITLE
probe: resolve executable before spawning child process

### DIFF
--- a/src/security/probe.zig
+++ b/src/security/probe.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const std_compat = @import("compat");
+const fs_compat = @import("../fs_compat.zig");
 const builtin = @import("builtin");
 
 /// Run a probe command with stdio suppressed and treat exit code 0 as success.
@@ -19,13 +20,13 @@ pub fn runQuietCommand(argv: []const []const u8) bool {
     };
 }
 
-/// Check whether an executable name can be found — either as an absolute
-/// path or by searching each PATH directory for an executable file.
+/// Check whether an executable name can be found -- either as an absolute or
+/// relative path, or by searching each PATH directory for an executable file.
 fn canResolveExecutable(name: []const u8) bool {
     if (name.len == 0) return false;
 
-    // Absolute or relative path — check directly.
-    if (name[0] == '/' or std.mem.indexOfScalar(u8, name, '/') != null) {
+    // Absolute or relative path -- check directly.
+    if (std_compat.fs.path.isAbsolute(name) or std.mem.indexOfAny(u8, name, "/\\") != null) {
         return fileIsExecutable(name);
     }
 
@@ -33,23 +34,36 @@ fn canResolveExecutable(name: []const u8) bool {
     const path_env = std_compat.process.getEnvVarOwned(std.heap.page_allocator, "PATH") catch return false;
     defer std.heap.page_allocator.free(path_env);
 
-    var it = std.mem.splitScalar(u8, path_env, if (comptime builtin.os.tag == .windows) ';' else ':');
+    var it = std.mem.splitScalar(u8, path_env, std_compat.fs.path.delimiter);
     while (it.next()) |dir| {
         if (dir.len == 0) continue;
-        // Build "dir/name" on the stack when possible.
-        var buf: [std.fs.max_path_bytes]u8 = undefined;
-        if (dir.len + 1 + name.len >= buf.len) continue;
-        @memcpy(buf[0..dir.len], dir);
-        buf[dir.len] = '/';
-        @memcpy(buf[dir.len + 1 ..][0..name.len], name);
-        const full = buf[0 .. dir.len + 1 + name.len];
-        if (fileIsExecutable(full)) return true;
+        if (executableInDirectory(dir, name)) return true;
     }
     return false;
 }
 
+fn executableInDirectory(dir: []const u8, name: []const u8) bool {
+    var buf: [std_compat.fs.max_path_bytes]u8 = undefined;
+    const needs_sep = dir.len > 0 and !std_compat.fs.path.isSep(dir[dir.len - 1]);
+    const sep_len = if (needs_sep) std_compat.fs.path.sep_str.len else 0;
+    if (dir.len + sep_len + name.len > buf.len) return false;
+
+    @memcpy(buf[0..dir.len], dir);
+    var len = dir.len;
+    if (needs_sep) {
+        @memcpy(buf[len..][0..std_compat.fs.path.sep_str.len], std_compat.fs.path.sep_str);
+        len += std_compat.fs.path.sep_str.len;
+    }
+    @memcpy(buf[len..][0..name.len], name);
+    len += name.len;
+
+    return fileIsExecutable(buf[0..len]);
+}
+
 fn fileIsExecutable(path: []const u8) bool {
-    std_compat.fs.accessAbsolute(path, .{ .execute = true }) catch return false;
+    const stat = fs_compat.statPath(path) catch return false;
+    if (stat.kind != .file) return false;
+    fs_compat.accessPath(path, .{ .execute = true }) catch return false;
     return true;
 }
 
@@ -68,9 +82,71 @@ test "canResolveExecutable finds absolute path" {
     try std.testing.expect(canResolveExecutable(platform.getShell()));
 }
 
+test "canResolveExecutable finds relative path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try std_compat.fs.Dir.wrap(tmp.dir).writeFile(.{
+        .sub_path = "probe-test-exe",
+        .data = "#!/bin/sh\nexit 0\n",
+        .flags = .{ .permissions = std_compat.fs.permissionsFromMode(0o755) },
+    });
+
+    const cwd_abs = try std_compat.fs.cwd().realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(cwd_abs);
+    const tmp_abs = try std_compat.fs.Dir.wrap(tmp.dir).realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(tmp_abs);
+    const tmp_rel = try std_compat.fs.path.relative(std.testing.allocator, cwd_abs, tmp_abs);
+    defer std.testing.allocator.free(tmp_rel);
+    const exe_rel = try std_compat.fs.path.join(std.testing.allocator, &.{ tmp_rel, "probe-test-exe" });
+    defer std.testing.allocator.free(exe_rel);
+
+    // Regression: relative argv[0] with a slash must not go through accessAbsolute.
+    try std.testing.expect(canResolveExecutable(exe_rel));
+}
+
 test "canResolveExecutable finds bare name on PATH" {
     const name = if (comptime builtin.os.tag == .windows) "cmd.exe" else "sh";
     try std.testing.expect(canResolveExecutable(name));
+}
+
+test "canResolveExecutable rejects directory on PATH" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try std_compat.fs.Dir.wrap(tmp.dir).makeDir("bin");
+    try std_compat.fs.Dir.wrap(tmp.dir).makeDir("bin/nullclaw_probe_dir");
+    const bin_abs = try std_compat.fs.Dir.wrap(tmp.dir).realpathAlloc(std.testing.allocator, "bin");
+    defer std.testing.allocator.free(bin_abs);
+
+    const platform = @import("../platform.zig");
+    const c = @cImport({
+        @cInclude("stdlib.h");
+    });
+
+    const key_z = try std.testing.allocator.dupeZ(u8, "PATH");
+    defer std.testing.allocator.free(key_z);
+
+    const old_path = platform.getEnvOrNull(std.testing.allocator, "PATH");
+    defer if (old_path) |path| std.testing.allocator.free(path);
+
+    const old_path_z = if (old_path) |path| try std.testing.allocator.dupeZ(u8, path) else null;
+    defer if (old_path_z) |path| std.testing.allocator.free(path);
+
+    defer {
+        if (old_path_z) |path| {
+            _ = c.setenv(key_z.ptr, path.ptr, 1);
+        } else {
+            _ = c.unsetenv(key_z.ptr);
+        }
+    }
+
+    const bin_z = try std.testing.allocator.dupeZ(u8, bin_abs);
+    defer std.testing.allocator.free(bin_z);
+    try std.testing.expectEqual(@as(c_int, 0), c.setenv(key_z.ptr, bin_z.ptr, 1));
+
+    // Regression: executable resolution must reject directories with execute access.
+    try std.testing.expect(!canResolveExecutable("nullclaw_probe_dir"));
 }
 
 test "canResolveExecutable rejects empty and nonexistent" {

--- a/src/security/probe.zig
+++ b/src/security/probe.zig
@@ -1,8 +1,12 @@
 const std = @import("std");
 const std_compat = @import("compat");
+const builtin = @import("builtin");
 
 /// Run a probe command with stdio suppressed and treat exit code 0 as success.
 pub fn runQuietCommand(argv: []const []const u8) bool {
+    if (argv.len == 0) return false;
+    if (!canResolveExecutable(argv[0])) return false;
+
     var child = std_compat.process.Child.init(argv, std.heap.page_allocator);
     child.stderr_behavior = .Ignore;
     child.stdout_behavior = .Ignore;
@@ -15,8 +19,61 @@ pub fn runQuietCommand(argv: []const []const u8) bool {
     };
 }
 
+/// Check whether an executable name can be found — either as an absolute
+/// path or by searching each PATH directory for an executable file.
+fn canResolveExecutable(name: []const u8) bool {
+    if (name.len == 0) return false;
+
+    // Absolute or relative path — check directly.
+    if (name[0] == '/' or std.mem.indexOfScalar(u8, name, '/') != null) {
+        return fileIsExecutable(name);
+    }
+
+    // Search PATH.
+    const path_env = std_compat.process.getEnvVarOwned(std.heap.page_allocator, "PATH") catch return false;
+    defer std.heap.page_allocator.free(path_env);
+
+    var it = std.mem.splitScalar(u8, path_env, if (comptime builtin.os.tag == .windows) ';' else ':');
+    while (it.next()) |dir| {
+        if (dir.len == 0) continue;
+        // Build "dir/name" on the stack when possible.
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        if (dir.len + 1 + name.len >= buf.len) continue;
+        @memcpy(buf[0..dir.len], dir);
+        buf[dir.len] = '/';
+        @memcpy(buf[dir.len + 1 ..][0..name.len], name);
+        const full = buf[0 .. dir.len + 1 + name.len];
+        if (fileIsExecutable(full)) return true;
+    }
+    return false;
+}
+
+fn fileIsExecutable(path: []const u8) bool {
+    std_compat.fs.accessAbsolute(path, .{ .execute = true }) catch return false;
+    return true;
+}
+
 test "runQuietCommand reports child exit status" {
     const platform = @import("../platform.zig");
     try std.testing.expect(runQuietCommand(&.{ platform.getShell(), platform.getShellFlag(), "exit 0" }));
     try std.testing.expect(!runQuietCommand(&.{ platform.getShell(), platform.getShellFlag(), "exit 9" }));
+}
+
+test "runQuietCommand rejects empty argv" {
+    try std.testing.expect(!runQuietCommand(&.{}));
+}
+
+test "canResolveExecutable finds absolute path" {
+    const platform = @import("../platform.zig");
+    try std.testing.expect(canResolveExecutable(platform.getShell()));
+}
+
+test "canResolveExecutable finds bare name on PATH" {
+    const name = if (comptime builtin.os.tag == .windows) "cmd.exe" else "sh";
+    try std.testing.expect(canResolveExecutable(name));
+}
+
+test "canResolveExecutable rejects empty and nonexistent" {
+    try std.testing.expect(!canResolveExecutable(""));
+    try std.testing.expect(!canResolveExecutable("__nonexistent_binary_nullclaw_test__"));
 }

--- a/src/security/probe.zig
+++ b/src/security/probe.zig
@@ -135,15 +135,25 @@ test "canResolveExecutable rejects directory on PATH" {
 
     defer {
         if (old_path_z) |path| {
-            _ = c.setenv(key_z.ptr, path.ptr, 1);
+            _ = if (comptime builtin.os.tag == .windows)
+                c._putenv_s(key_z.ptr, path.ptr)
+            else
+                c.setenv(key_z.ptr, path.ptr, 1);
         } else {
-            _ = c.unsetenv(key_z.ptr);
+            _ = if (comptime builtin.os.tag == .windows)
+                c._putenv_s(key_z.ptr, "")
+            else
+                c.unsetenv(key_z.ptr);
         }
     }
 
     const bin_z = try std.testing.allocator.dupeZ(u8, bin_abs);
     defer std.testing.allocator.free(bin_z);
-    try std.testing.expectEqual(@as(c_int, 0), c.setenv(key_z.ptr, bin_z.ptr, 1));
+    const set_rc = if (comptime builtin.os.tag == .windows)
+        c._putenv_s(key_z.ptr, bin_z.ptr)
+    else
+        c.setenv(key_z.ptr, bin_z.ptr, 1);
+    try std.testing.expectEqual(@as(c_int, 0), set_rc);
 
     // Regression: executable resolution must reject directories with execute access.
     try std.testing.expect(!canResolveExecutable("nullclaw_probe_dir"));


### PR DESCRIPTION
## Summary

Adds a pre-spawn executable resolution check to `runQuietCommand` in `src/security/probe.zig`. Before spawning a child process, we now verify the target executable exists on PATH (or at the given absolute/relative path).

## Problem

A Zig stdlib bug causes failed `execve` calls to leave zombie processes. When `runQuietCommand` was called for sandbox probes (docker, firejail, bwrap) and the executable wasn't installed, the spawn would fail but could leave zombies behind.

## Changes

- `canResolveExecutable()`: walks PATH (or checks absolute/relative paths) to verify the executable exists before spawning
- `fileIsExecutable()`: uses `accessAbsolute` with execute permission check
- Empty argv guard on `runQuietCommand`
- Platform-correct PATH separator (`:` on Unix, `;` on Windows)
- Tests for all new code paths

This is also a strict improvement independent of the Zig bug: sandbox probes no longer attempt to spawn processes for executables that don't exist.

## Testing

- `zig build test --summary all` — all tests pass, 0 leaks
- New tests: empty argv, absolute path resolution, bare name PATH lookup, nonexistent binary rejection

Related: #882