### PR TITLE
Fix/add crit tests

### DIFF
--- a/src/agent/compaction.zig
+++ b/src/agent/compaction.zig
@@ -100,10 +100,12 @@ pub fn autoCompactHistory(
     if (!count_trigger and !token_trigger) return false;
 
     const keep_recent = @min(config.keep_recent, @as(u32, @intCast(non_system_count)));
-    const compact_count = non_system_count - keep_recent;
+    var compact_count = non_system_count - keep_recent;
     if (compact_count == 0) return false;
 
-    const compact_end = start + compact_count;
+    const compact_end = adjustKeepStartForToolResultPair(history.items, start, start + compact_count);
+    compact_count = compact_end - start;
+    if (compact_count == 0) return false;
 
     // Multi-part strategy: if >10 messages to summarize, split into halves
     const summary = if (compact_count > 10) blk: {
@@ -168,8 +170,22 @@ pub fn autoCompactHistory(
     return true;
 }
 
+fn adjustKeepStartForToolResultPair(
+    history: []const OwnedMessage,
+    start: usize,
+    keep_start: usize,
+) usize {
+    var adjusted = keep_start;
+    while (adjusted > start and adjusted < history.len and history[adjusted].role == .tool) {
+        adjusted -= 1;
+    }
+    return adjusted;
+}
+
 /// Force-compress history for context exhaustion recovery.
-/// Keeps system prompt (if any) + last CONTEXT_RECOVERY_KEEP messages.
+/// Keeps system prompt (if any) + last CONTEXT_RECOVERY_KEEP messages. If the
+/// keep window would start with a tool result, it is extended backward so the
+/// result is not orphaned from the assistant turn that produced it.
 /// Everything in between is dropped without LLM summarization (we can't call
 /// the LLM since the context is exhausted). Returns true if compression was performed.
 pub fn forceCompressHistory(
@@ -182,7 +198,12 @@ pub fn forceCompressHistory(
 
     if (non_system_count <= CONTEXT_RECOVERY_KEEP) return false;
 
-    const keep_start = history.items.len - CONTEXT_RECOVERY_KEEP;
+    const keep_start = adjustKeepStartForToolResultPair(
+        history.items,
+        start,
+        history.items.len - CONTEXT_RECOVERY_KEEP,
+    );
+    if (keep_start == start) return false;
     const to_remove = keep_start - start;
 
     // Free messages being removed
@@ -214,7 +235,10 @@ pub fn trimHistory(
 
     if (non_system_count <= max) return;
 
-    const to_remove = non_system_count - max;
+    var to_remove = non_system_count - max;
+    const keep_start = adjustKeepStartForToolResultPair(history.items, start, start + to_remove);
+    to_remove = keep_start - start;
+    if (to_remove == 0) return;
     // Free the messages being removed
     for (history.items[start .. start + to_remove]) |*msg| {
         msg.deinit(allocator);
@@ -633,6 +657,104 @@ test "autoCompactHistory no-op below count and token thresholds" {
     try std.testing.expectEqual(@as(usize, 2), agent.history.items.len);
 }
 
+test "autoCompactHistory does not orphan leading tool result" {
+    const SummarizingProvider = struct {
+        const Self = @This();
+
+        calls: usize = 0,
+
+        fn chatWithSystem(_: *anyopaque, allocator: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator.dupe(u8, "");
+        }
+
+        fn chat(ptr: *anyopaque, allocator: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            const self: *Self = @ptrCast(@alignCast(ptr));
+            self.calls += 1;
+            return .{
+                .content = try allocator.dupe(u8, "auto summary"),
+            };
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return false;
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "summarizing-test-provider";
+        }
+
+        fn deinit(_: *anyopaque) void {}
+    };
+
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = SummarizingProvider.chatWithSystem,
+        .chat = SummarizingProvider.chat,
+        .supportsNativeTools = SummarizingProvider.supportsNativeTools,
+        .getName = SummarizingProvider.getName,
+        .deinit = SummarizingProvider.deinit,
+    };
+
+    const allocator = std.testing.allocator;
+    var provider_state = SummarizingProvider{};
+    const provider = Provider{
+        .ptr = @ptrCast(&provider_state),
+        .vtable = &provider_vtable,
+    };
+    var agent = try makeTestAgent(allocator);
+    agent.provider = provider;
+    defer agent.deinit();
+
+    try agent.history.append(allocator, .{
+        .role = .system,
+        .content = try allocator.dupe(u8, "system prompt"),
+    });
+    for (0..7) |i| {
+        try agent.history.append(allocator, .{
+            .role = .user,
+            .content = try std.fmt.allocPrint(allocator, "filler-{d}", .{i}),
+        });
+    }
+    try agent.history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "assistant tool-call"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .tool,
+        .content = try allocator.dupe(u8, "tool result"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "after tool"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "final reply"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "next prompt"),
+    });
+
+    const compacted = try autoCompactHistory(allocator, &agent.history, provider, agent.model_name, .{
+        .keep_recent = 4,
+        .max_history_messages = 4,
+        .workspace_dir = null,
+    });
+
+    try std.testing.expect(compacted);
+    try std.testing.expectEqual(@as(usize, 1), provider_state.calls);
+    try std.testing.expectEqual(@as(usize, 7), agent.history.items.len);
+    try std.testing.expect(agent.history.items[0].role == .system);
+    try std.testing.expect(agent.history.items[1].role == .assistant);
+    try std.testing.expect(std.mem.indexOf(u8, agent.history.items[1].content, "[Compaction summary]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, agent.history.items[1].content, "auto summary") != null);
+    try std.testing.expect(agent.history.items[2].role == .assistant);
+    try std.testing.expectEqualStrings("assistant tool-call", agent.history.items[2].content);
+    try std.testing.expect(agent.history.items[3].role == .tool);
+    try std.testing.expectEqualStrings("tool result", agent.history.items[3].content);
+    try std.testing.expectEqualStrings("next prompt", agent.history.items[6].content);
+}
+
 test "DEFAULT_TOKEN_LIMIT constant" {
     try std.testing.expectEqual(config_types.DEFAULT_AGENT_TOKEN_LIMIT, DEFAULT_TOKEN_LIMIT);
 }
@@ -664,6 +786,100 @@ test "forceCompressHistory keeps system + last 4 messages" {
     try std.testing.expectEqualStrings("system prompt", agent.history.items[0].content);
     try std.testing.expectEqualStrings("msg-4", agent.history.items[1].content);
     try std.testing.expectEqualStrings("msg-7", agent.history.items[4].content);
+}
+
+test "forceCompressHistory does not orphan leading tool result" {
+    const allocator = std.testing.allocator;
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+
+    try agent.history.append(allocator, .{
+        .role = .system,
+        .content = try allocator.dupe(u8, "system prompt"),
+    });
+    for (0..7) |i| {
+        try agent.history.append(allocator, .{
+            .role = .user,
+            .content = try std.fmt.allocPrint(allocator, "filler-{d}", .{i}),
+        });
+    }
+    try agent.history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "assistant tool-call"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .tool,
+        .content = try allocator.dupe(u8, "tool result"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "after tool"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "final reply"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "next prompt"),
+    });
+
+    const compressed = forceCompressHistory(allocator, &agent.history);
+    try std.testing.expect(compressed);
+
+    try std.testing.expectEqual(@as(usize, 6), agent.history.items.len);
+    try std.testing.expect(agent.history.items[0].role == .system);
+    try std.testing.expect(agent.history.items[1].role == .assistant);
+    try std.testing.expectEqualStrings("assistant tool-call", agent.history.items[1].content);
+    try std.testing.expect(agent.history.items[2].role == .tool);
+    try std.testing.expectEqualStrings("tool result", agent.history.items[2].content);
+    try std.testing.expectEqualStrings("next prompt", agent.history.items[5].content);
+}
+
+test "trimHistory does not orphan leading tool result" {
+    const allocator = std.testing.allocator;
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+
+    try agent.history.append(allocator, .{
+        .role = .system,
+        .content = try allocator.dupe(u8, "system prompt"),
+    });
+    for (0..7) |i| {
+        try agent.history.append(allocator, .{
+            .role = .user,
+            .content = try std.fmt.allocPrint(allocator, "filler-{d}", .{i}),
+        });
+    }
+    try agent.history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "assistant tool-call"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .tool,
+        .content = try allocator.dupe(u8, "tool result"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "after tool"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "final reply"),
+    });
+    try agent.history.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "next prompt"),
+    });
+
+    trimHistory(allocator, &agent.history, 4);
+
+    try std.testing.expectEqual(@as(usize, 6), agent.history.items.len);
+    try std.testing.expect(agent.history.items[0].role == .system);
+    try std.testing.expect(agent.history.items[1].role == .assistant);
+    try std.testing.expectEqualStrings("assistant tool-call", agent.history.items[1].content);
+    try std.testing.expect(agent.history.items[2].role == .tool);
+    try std.testing.expectEqualStrings("tool result", agent.history.items[2].content);
 }
 
 test "forceCompressHistory without system prompt" {

--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -10153,3 +10153,136 @@ test "globMatch handles prefix wildcard" {
     try std.testing.expect(Agent.globMatch("shell", "shell"));
     try std.testing.expect(!Agent.globMatch("shell", "shell_extra"));
 }
+
+test "loop honors max_tool_iterations limit" {
+    // Verifies that when a provider always returns a tool call, the agent loop
+    // stops at exactly max_tool_iterations and emits tool_iterations_exhausted.
+    const NoopTool = struct {
+        const Self = @This();
+        pub const tool_name = "noop_iter";
+        pub const tool_description = "noop for iteration cap test";
+        pub const tool_params = "{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}";
+        pub const vtable = tools_mod.ToolVTable(Self);
+
+        fn tool(self: *Self) Tool {
+            return .{ .ptr = @ptrCast(self), .vtable = &vtable };
+        }
+
+        pub fn execute(_: *Self, allocator: std.mem.Allocator, _: tools_mod.JsonObjectMap) !tools_mod.ToolResult {
+            return .{ .success = true, .output = try allocator.dupe(u8, "noop ok") };
+        }
+    };
+
+    // Provider always returns a tool call so it never completes voluntarily.
+    // On the summary call (after cap is hit) it returns a plain text response.
+    const LoopingProvider = struct {
+        const Self = @This();
+        calls: usize = 0,
+        cap: usize,
+
+        fn chatWithSystem(_: *anyopaque, allocator: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator.dupe(u8, "");
+        }
+
+        fn chat(ptr: *anyopaque, allocator: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            const self: *Self = @ptrCast(@alignCast(ptr));
+            self.calls += 1;
+            // Within the cap: always return a tool call to keep the loop going.
+            // On the summary call (calls > cap): return plain text.
+            if (self.calls <= self.cap) {
+                const tool_calls = try allocator.alloc(providers.ToolCall, 1);
+                tool_calls[0] = .{
+                    .id = try allocator.dupe(u8, "call-noop-iter"),
+                    .name = try allocator.dupe(u8, "noop_iter"),
+                    .arguments = try allocator.dupe(u8, "{}"),
+                };
+                return .{
+                    .content = try allocator.dupe(u8, "calling tool"),
+                    .tool_calls = tool_calls,
+                    .usage = .{},
+                    .model = try allocator.dupe(u8, "test-model"),
+                };
+            }
+            return .{
+                .content = try allocator.dupe(u8, "summary after cap"),
+                .tool_calls = &.{},
+                .usage = .{},
+                .model = try allocator.dupe(u8, "test-model"),
+            };
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn getTraceId(_: *anyopaque) ?[32]u8 {
+            return null;
+        }
+        fn setTraceId(_: *anyopaque, _: [32]u8) void {}
+        fn getName(_: *anyopaque) []const u8 {
+            return "looping-provider";
+        }
+
+        fn deinitFn(_: *anyopaque) void {}
+    };
+
+    const max_iters: u32 = 2;
+    const allocator = std.testing.allocator;
+
+    var provider_state = LoopingProvider{ .cap = max_iters };
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = LoopingProvider.chatWithSystem,
+        .chat = LoopingProvider.chat,
+        .supportsNativeTools = LoopingProvider.supportsNativeTools,
+        .getName = LoopingProvider.getName,
+        .deinit = LoopingProvider.deinitFn,
+    };
+    const provider = Provider{
+        .ptr = @ptrCast(&provider_state),
+        .vtable = &provider_vtable,
+    };
+
+    var noop_tool = NoopTool{};
+    const tool_list = [_]Tool{noop_tool.tool()};
+    var specs = try allocator.alloc(ToolSpec, tool_list.len);
+    for (tool_list, 0..) |t, i| {
+        specs[i] = .{
+            .name = t.name(),
+            .description = t.description(),
+            .parameters_json = t.parametersJson(),
+        };
+    }
+
+    var observer = RecordingObserver{};
+    var agent = Agent{
+        .allocator = allocator,
+        .provider = provider,
+        .tools = &tool_list,
+        .tool_specs = specs,
+        .mem = null,
+        .observer = observer.observer(),
+        .model_name = "test-model",
+        .temperature = 0.7,
+        .workspace_dir = "/tmp",
+        .max_tool_iterations = max_iters,
+        .max_history_messages = 50,
+        .auto_save = false,
+        .history = .empty,
+        .total_tokens = 0,
+        .has_system_prompt = false,
+    };
+    defer agent.deinit();
+
+    const response = try agent.turn("loop forever");
+    defer allocator.free(response);
+
+    // Loop must stop — not infinite loop.
+    // tool_iterations_exhausted event fired exactly once.
+    try std.testing.expectEqual(@as(usize, 1), observer.tool_iterations_exhausted_count);
+    // turn_complete fired exactly once.
+    try std.testing.expectEqual(@as(usize, 1), observer.turn_complete_count);
+    // Provider called max_iters times for tool iterations + 1 for the summary call.
+    try std.testing.expectEqual(max_iters + 1, @as(u32, @intCast(provider_state.calls)));
+    // Response contains the iteration-limit prefix.
+    try std.testing.expect(std.mem.indexOf(u8, response, "[Tool iteration limit:") != null);
+}

--- a/src/channel_catalog.zig
+++ b/src/channel_catalog.zig
@@ -343,3 +343,53 @@ test "findByKey finds known channels" {
     try std.testing.expectEqual(ChannelId.mattermost, mattermost.?.id);
     try std.testing.expect(findByKey("unknown") == null);
 }
+
+test "every known_channel has non-empty unique key and label" {
+    var seen = std.StringHashMap(void).init(std.testing.allocator);
+    defer seen.deinit();
+
+    for (known_channels) |meta| {
+        try std.testing.expect(meta.key.len > 0);
+        try std.testing.expect(meta.label.len > 0);
+        try std.testing.expect(meta.configured_message.len > 0);
+
+        const gop = try seen.getOrPut(meta.key);
+        try std.testing.expect(!gop.found_existing);
+    }
+}
+
+test "every enabled channel has non-empty configured_message text" {
+    for (known_channels) |meta| {
+        if (!isBuildEnabled(meta.id)) continue;
+        try std.testing.expect(meta.configured_message.len > 0);
+        const has_label = std.ascii.indexOfIgnoreCase(meta.configured_message, meta.label) != null;
+        const has_configured = std.ascii.indexOfIgnoreCase(meta.configured_message, "configured") != null or
+            std.ascii.indexOfIgnoreCase(meta.configured_message, "enabled") != null;
+        try std.testing.expect(has_label or has_configured);
+    }
+}
+
+test "channel listener modes preserve daemon lifecycle semantics" {
+    // CLI and the generic webhook endpoint do not need the channel supervisor
+    // or an agent runtime.
+    try std.testing.expect(!contributesToDaemonSupervision(.cli));
+    try std.testing.expect(!requiresRuntime(.cli));
+    try std.testing.expect(!contributesToDaemonSupervision(.webhook));
+    try std.testing.expect(!requiresRuntime(.webhook));
+
+    // Send-only channels still need supervisor registration for outbound
+    // delivery, but must not force provider credentials or agent sessions.
+    try std.testing.expect(contributesToDaemonSupervision(.email));
+    try std.testing.expect(!requiresRuntime(.email));
+    try std.testing.expect(contributesToDaemonSupervision(.maixcam));
+    try std.testing.expect(!requiresRuntime(.maixcam));
+
+    // Inbound channels, regardless of transport style, require an agent runtime
+    // so inbound messages can be routed into sessions.
+    try std.testing.expect(contributesToDaemonSupervision(.signal));
+    try std.testing.expect(requiresRuntime(.signal));
+    try std.testing.expect(contributesToDaemonSupervision(.discord));
+    try std.testing.expect(requiresRuntime(.discord));
+    try std.testing.expect(contributesToDaemonSupervision(.line));
+    try std.testing.expect(requiresRuntime(.line));
+}

--- a/src/channels/cli.zig
+++ b/src/channels/cli.zig
@@ -390,3 +390,19 @@ test "loadHistory enforces max entries limit" {
 test "MAX_HISTORY_LINES is 500" {
     try std.testing.expectEqual(@as(usize, 500), MAX_HISTORY_LINES);
 }
+
+test "CliChannel create + healthCheck + stop leaks zero bytes" {
+    const alloc = std.testing.allocator;
+
+    // CliChannel has no config — allocator only.
+    var ch_struct = CliChannel.init(alloc);
+
+    // Acquire vtable interface.
+    const ch = ch_struct.channel();
+
+    // healthCheck must be callable in any state.
+    _ = ch.healthCheck();
+
+    // stop without start must be safe (per Channel contract).
+    ch.stop();
+}

--- a/src/channels/dingtalk.zig
+++ b/src/channels/dingtalk.zig
@@ -2191,3 +2191,16 @@ test "healthCheck requires running and connection" {
     channel.connected.store(true, .release);
     try std.testing.expect(channel.healthCheck());
 }
+
+test "DingTalkChannel create + healthCheck + stop leaks zero bytes" {
+    // DingTalkChannel uses clearEphemeralState() as its teardown method.
+    var ch_struct = DingTalkChannel.initFromConfig(std.testing.allocator, .{
+        .client_id = "test-client-id",
+        .client_secret = "test-client-secret",
+    });
+    defer ch_struct.clearEphemeralState();
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/discord.zig
+++ b/src/channels/discord.zig
@@ -2041,3 +2041,14 @@ test "discord intent bitmask guilds" {
     // Default intents = 1|512|32768|4096 = 37377
     try std.testing.expectEqual(@as(u32, 37377), 1 | 512 | 32768 | 4096);
 }
+
+test "DiscordChannel create + healthCheck + stop leaks zero bytes" {
+    // DiscordChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = DiscordChannel.initFromConfig(std.testing.allocator, .{
+        .token = "test-bot-token",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/email.zig
+++ b/src/channels/email.zig
@@ -818,3 +818,12 @@ test "markMessageSeen method exists" {
     const info = @typeInfo(@TypeOf(EmailChannel.markMessageSeen));
     try std.testing.expect(info == .@"fn");
 }
+
+test "EmailChannel create + healthCheck + stop leaks zero bytes" {
+    var ch_struct = EmailChannel.initFromConfig(std.testing.allocator, .{});
+    defer ch_struct.deinit();
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/external.zig
+++ b/src/channels/external.zig
@@ -667,3 +667,15 @@ test "handleInboundMessage publishes nested notification to bus with injected ac
     try std.testing.expect(std.mem.indexOf(u8, msg.metadata_json.?, "\"account_id\":\"main\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, msg.metadata_json.?, "\"peer_kind\":\"group\"") != null);
 }
+
+test "ExternalChannel create + healthCheck + stop leaks zero bytes" {
+    // ExternalChannel holds no heap allocations at init-time.  No deinit needed.
+    // healthCheckLocked() returns false immediately when running=false and no child process.
+    var ch_struct = ExternalChannel.initFromConfig(std.testing.allocator, .{
+        .runtime_name = "test-external",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/imessage.zig
+++ b/src/channels/imessage.zig
@@ -917,3 +917,25 @@ test "imessage publishInboundMessage emits direct session key and dm metadata" {
     try std.testing.expect(!meta.value.object.get("is_group").?.bool);
     try std.testing.expect(meta.value.object.get("channel_id") == null);
 }
+
+test "IMessageChannel create + healthCheck + stop leaks zero bytes" {
+    // IMessageChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = IMessageChannel.initFromConfig(std.testing.allocator, .{});
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "IMessageChannel start + stop under is_test leaks zero bytes" {
+    // vtableStart has `if (builtin.is_test) return;` — no poll thread is
+    // spawned.  Double stop must be idempotent per Channel contract
+    // (poll_thread stays null, so the join path is never reached).
+    var ch_struct = IMessageChannel.initFromConfig(std.testing.allocator, .{});
+
+    const ch = ch_struct.channel();
+    try ch.start();
+    ch.stop();
+    // Double stop — must not double-free or crash.
+    ch.stop();
+}

--- a/src/channels/irc.zig
+++ b/src/channels/irc.zig
@@ -1086,3 +1086,15 @@ test "irc disconnect without connection is safe" {
     try std.testing.expect(ch.stream == null);
     try std.testing.expect(ch.tls_state == null);
 }
+
+test "IrcChannel create + healthCheck + stop leaks zero bytes" {
+    // IrcChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = IrcChannel.initFromConfig(std.testing.allocator, .{
+        .host = "irc.example.com",
+        .nick = "test-bot",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/lark.zig
+++ b/src/channels/lark.zig
@@ -3535,3 +3535,33 @@ test "lark build card action callback response returns raw card" {
     try std.testing.expect(std.mem.indexOf(u8, response, "\"card\":{\"type\":\"raw\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, response, "yes") != null);
 }
+
+test "LarkChannel create + healthCheck + stop leaks zero bytes" {
+    // LarkChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = LarkChannel.initFromConfig(std.testing.allocator, .{
+        .app_id = "test-app-id",
+        .app_secret = "test-app-secret",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "LarkChannel start + stop under is_test leaks zero bytes" {
+    // In .webhook receive_mode, vtableStart returns immediately after setting
+    // atomics — no websocket thread is spawned.  Double stop must be
+    // idempotent per Channel contract (ws_fd stays invalid_socket, ws_thread
+    // stays null, so the stop path is a no-op on the second call).
+    var ch_struct = LarkChannel.initFromConfig(std.testing.allocator, .{
+        .app_id = "test-app-id",
+        .app_secret = "test-app-secret",
+        .receive_mode = .webhook,
+    });
+
+    const ch = ch_struct.channel();
+    try ch.start();
+    ch.stop();
+    // Double stop — must not double-free or crash.
+    ch.stop();
+}

--- a/src/channels/line.zig
+++ b/src/channels/line.zig
@@ -1008,3 +1008,36 @@ test "line parseAndFilterEvents empty allow_from passes all" {
 
     try std.testing.expectEqual(@as(usize, 1), events.len);
 }
+
+test "LineChannel create + healthCheck + stop leaks zero bytes" {
+    // LineChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = LineChannel.initFromConfig(std.testing.allocator, .{
+        .access_token = "test-access-token",
+        .channel_secret = "test-channel-secret",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "verifyLineSignature rejects tampered body" {
+    // Compute a valid sig for the original body, then verify that presenting
+    // the same sig with a different body is rejected.  Guards against future
+    // regressions where the HMAC input is silently short-circuited.
+    const secret = "channel-secret-abc";
+    const original_body = "webhook-body-content";
+    const tampered_body = "webhook-body-content_tampered";
+
+    const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+    var mac: [HmacSha256.mac_length]u8 = undefined;
+    HmacSha256.create(&mac, original_body, secret);
+
+    var encoded_buf: [44]u8 = undefined;
+    const valid_sig = std.base64.standard.Encoder.encode(&encoded_buf, &mac);
+
+    // Correct body + correct sig: must accept.
+    try std.testing.expect(verifyLineSignature(original_body, valid_sig, secret));
+    // Tampered body + original sig: must reject.
+    try std.testing.expect(!verifyLineSignature(tampered_body, valid_sig, secret));
+}

--- a/src/channels/maixcam.zig
+++ b/src/channels/maixcam.zig
@@ -738,3 +738,12 @@ test "maixcam client count starts at zero" {
     var ch = MaixCamChannel.init(std.testing.allocator, .{});
     try std.testing.expectEqual(@as(usize, 0), ch.clientCount());
 }
+
+test "MaixCamChannel create + healthCheck + stop leaks zero bytes" {
+    var ch_struct = MaixCamChannel.initFromConfig(std.testing.allocator, .{});
+    defer ch_struct.deinit();
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/matrix.zig
+++ b/src/channels/matrix.zig
@@ -1518,3 +1518,32 @@ test "MatrixChannel parseSyncResponse with empty room_id accepts multiple rooms"
     try std.testing.expect(saw_a);
     try std.testing.expect(saw_b);
 }
+
+test "MatrixChannel create + healthCheck + stop leaks zero bytes" {
+    // MatrixChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = MatrixChannel.initFromConfig(std.testing.allocator, .{
+        .homeserver = "https://matrix.example.com",
+        .access_token = "test-access-token",
+        .room_id = "!test-room:example.com",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "MatrixChannel start + stop under is_test leaks zero bytes" {
+    // vtableStart sets self.running = true only — no I/O, no thread.
+    // Double stop must be idempotent per Channel contract.
+    var ch_struct = MatrixChannel.initFromConfig(std.testing.allocator, .{
+        .homeserver = "https://matrix.example.com",
+        .access_token = "test-access-token",
+        .room_id = "!test-room:example.com",
+    });
+
+    const ch = ch_struct.channel();
+    try ch.start();
+    ch.stop();
+    // Double stop — must not double-free or crash.
+    ch.stop();
+}

--- a/src/channels/mattermost.zig
+++ b/src/channels/mattermost.zig
@@ -1262,3 +1262,15 @@ test "mattermost chatmode onchar strips configured prefix before publish" {
     try std.testing.expectEqualStrings("mattermost:mm-main:channel:town", msg.session_key);
     try std.testing.expect(eb.consumeInbound() == null);
 }
+
+test "MattermostChannel create + healthCheck + stop leaks zero bytes" {
+    // MattermostChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = MattermostChannel.initFromConfig(std.testing.allocator, .{
+        .bot_token = "test-bot-token",
+        .base_url = "https://mattermost.example.com",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/max.zig
+++ b/src/channels/max.zig
@@ -2219,6 +2219,34 @@ test "parseCallbackPayload parses token and option index" {
     try std.testing.expect(parseCallbackPayload("plain") == null);
 }
 
+test "MaxChannel create + healthCheck + stop leaks zero bytes" {
+    // MaxChannel holds no heap allocations at init-time.  No deinit needed.
+    // healthCheck() returns true in test mode (builtin.is_test guard).
+    var ch_struct = MaxChannel.initFromConfig(std.testing.allocator, .{
+        .bot_token = "test-bot-token",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "MaxChannel start + stop under is_test leaks zero bytes" {
+    // In .polling mode (default), vtableStart skips the unsubscribe call
+    // (!builtin.is_test guard) and fetchBotIdentity returns early
+    // (comptime builtin.is_test guard) — no network I/O, no thread.
+    // Double stop must be idempotent per Channel contract.
+    var ch_struct = MaxChannel.initFromConfig(std.testing.allocator, .{
+        .bot_token = "test-bot-token",
+    });
+
+    const ch = ch_struct.channel();
+    try ch.start();
+    ch.stop();
+    // Double stop — must not double-free or crash.
+    ch.stop();
+}
+
 test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/channels/onebot.zig
+++ b/src/channels/onebot.zig
@@ -1204,3 +1204,12 @@ test "getJsonInt extracts integer" {
     try std.testing.expect(getJsonInt(parsed.value, "name") == null);
     try std.testing.expect(getJsonInt(parsed.value, "missing") == null);
 }
+
+test "OneBotChannel create + healthCheck + stop leaks zero bytes" {
+    // OneBotChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = OneBotChannel.initFromConfig(std.testing.allocator, .{});
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/qq.zig
+++ b/src/channels/qq.zig
@@ -2960,3 +2960,31 @@ test "qq handleGatewayEvent GROUP_AT_MESSAGE_CREATE drops when group id missing"
 
     try std.testing.expectEqual(@as(usize, 0), event_bus_inst.inboundDepth());
 }
+
+test "QQChannel create + healthCheck + stop leaks zero bytes" {
+    // Use websocket receive_mode so healthCheck checks atomics only (no network I/O).
+    // QQChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = QQChannel.initFromConfig(std.testing.allocator, .{
+        .receive_mode = .websocket,
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "QQChannel start + stop under is_test leaks zero bytes" {
+    // In .webhook receive_mode, vtableStart returns after setting running
+    // only — no gateway thread is spawned.  Double stop must be idempotent
+    // per Channel contract (ws_fd stays invalid_socket, gateway_thread stays
+    // null, dedup_set stays empty so second deinit is a no-op).
+    var ch_struct = QQChannel.initFromConfig(std.testing.allocator, .{
+        .receive_mode = .webhook,
+    });
+
+    const ch = ch_struct.channel();
+    try ch.start();
+    ch.stop();
+    // Double stop — must not double-free or crash.
+    ch.stop();
+}

--- a/src/channels/signal.zig
+++ b/src/channels/signal.zig
@@ -1353,6 +1353,7 @@ pub const SignalChannel = struct {
         self.sse_next_retry_at = 0;
         // Clean up SSE buffer
         self.sse_buffer.deinit(self.allocator);
+        self.sse_buffer = .empty;
         // Clean up typing indicator threads
         self.stopAllTyping();
     }
@@ -3412,6 +3413,17 @@ test "nextEventBoundary handles lf and crlf delimiters" {
     try std.testing.expectEqual(@as(usize, 13), crlf_boundary.next);
 }
 
+test "nextEventBoundary leaves incomplete trailing event buffered" {
+    const partial = "data: partial";
+    try std.testing.expect(SignalChannel.nextEventBoundary(partial, 0) == null);
+
+    const mixed = "data: complete\n\ndata: partial";
+    const boundary = SignalChannel.nextEventBoundary(mixed, 0).?;
+    try std.testing.expectEqual(@as(usize, 14), boundary.end);
+    try std.testing.expectEqual(@as(usize, 16), boundary.next);
+    try std.testing.expect(SignalChannel.nextEventBoundary(mixed, boundary.next) == null);
+}
+
 test "parseSSEEnvelope accepts multiline SSE data payload" {
     const users = [_][]const u8{"*"};
     const ch = SignalChannel.init(
@@ -3652,4 +3664,31 @@ test "parseSSEEnvelope ignores Note to Self sync from linked device" {
     ;
     const msg_opt = try ch.parseSSEEnvelope(std.testing.allocator, raw_json);
     try std.testing.expect(msg_opt == null);
+}
+
+test "SignalChannel create + healthCheck + stop leaks zero bytes" {
+    // SignalChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = SignalChannel.initFromConfig(std.testing.allocator, .{
+        .http_url = "http://localhost:8080",
+        .account = "+15550001111",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "SignalChannel start + stop under is_test leaks zero bytes" {
+    // vtableStart has `if (builtin.is_test) return;` — no network I/O, no thread.
+    // Double stop must be idempotent per Channel contract.
+    var ch_struct = SignalChannel.initFromConfig(std.testing.allocator, .{
+        .http_url = "http://localhost:8080",
+        .account = "+15550001111",
+    });
+
+    const ch = ch_struct.channel();
+    try ch.start();
+    ch.stop();
+    // Double stop — must not double-free or crash.
+    ch.stop();
 }

--- a/src/channels/slack.zig
+++ b/src/channels/slack.zig
@@ -126,6 +126,7 @@ pub const SlackChannel = struct {
     running: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     connected: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     socket_fallback_to_polling: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    lifecycle_mu: std_compat.sync.Mutex = .{},
     poll_thread: ?std.Thread = null,
     socket_thread: ?std.Thread = null,
     ws_fd: std.atomic.Value(SocketFd) = std.atomic.Value(SocketFd).init(invalid_socket),
@@ -487,6 +488,7 @@ pub const SlackChannel = struct {
     }
 
     fn fetchBotUserId(self: *SlackChannel) !void {
+        if (builtin.is_test) return;
         const url = API_BASE ++ "/auth.test";
         const auth_header = try std.fmt.allocPrint(self.allocator, "Authorization: Bearer {s}", .{self.normalizedBotToken()});
         defer self.allocator.free(auth_header);
@@ -1236,6 +1238,9 @@ pub const SlackChannel = struct {
 
     fn vtableStart(ptr: *anyopaque) anyerror!void {
         const self: *SlackChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
+
         if (self.running.load(.acquire)) return;
         if (!self.hasValidBotToken()) return error.SlackBotTokenRequired;
 
@@ -1281,6 +1286,9 @@ pub const SlackChannel = struct {
 
     fn vtableStop(ptr: *anyopaque) void {
         const self: *SlackChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
+
         self.running.store(false, .release);
         self.connected.store(false, .release);
 
@@ -2344,4 +2352,74 @@ test "parseSocketConnectParts extracts host port and path" {
     try std.testing.expectEqualStrings("wss-primary.slack.com", parts.host);
     try std.testing.expectEqual(@as(u16, 443), parts.port);
     try std.testing.expectEqualStrings("/link/?ticket=abc123", parts.path);
+}
+
+test "SlackChannel create + healthCheck + stop leaks zero bytes" {
+    // SlackChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = SlackChannel.initFromConfig(std.testing.allocator, .{
+        .bot_token = "test-bot-token",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "markdownToSlackMrkdwn converts repeated formatted markdown consistently" {
+    var input: std.ArrayListUnmanaged(u8) = .empty;
+    defer input.deinit(std.testing.allocator);
+
+    const repetitions = 5000;
+    for (0..repetitions) |_| {
+        try input.appendSlice(std.testing.allocator, "**bold** ~~strike~~ `code` [link](http://x) ");
+    }
+
+    const mrkdwn = try markdownToSlackMrkdwn(std.testing.allocator, input.items);
+    defer std.testing.allocator.free(mrkdwn);
+
+    const expected_unit = "*bold* ~strike~ `code` <http://x|link> ";
+    try std.testing.expectEqual(expected_unit.len * repetitions, mrkdwn.len);
+    try std.testing.expect(std.mem.startsWith(u8, mrkdwn, expected_unit));
+    try std.testing.expect(std.mem.endsWith(u8, mrkdwn, expected_unit));
+    try std.testing.expect(std.mem.indexOf(u8, mrkdwn, "**bold**") == null);
+    try std.testing.expect(std.mem.indexOf(u8, mrkdwn, "~~strike~~") == null);
+    try std.testing.expect(std.mem.indexOf(u8, mrkdwn, "[link](http://x)") == null);
+}
+
+test "SlackChannel start + stop concurrency stress test" {
+    // We use HTTP mode here to avoid the thread spawning and auth.test
+    // making real network calls. Under is_test, start/stop shouldn't
+    // cause actual side-effects, but the flags running/connected
+    // are mutated and the lifecycle_mu protects them.
+    var ch_struct = SlackChannel.initFromConfig(std.testing.allocator, .{
+        .account_id = "test",
+        .mode = .http,
+        .bot_token = "xoxb-test",
+        .signing_secret = "secret",
+    });
+
+    const ThreadFn = struct {
+        fn run(channel: root.Channel) void {
+            for (0..100) |_| {
+                _ = channel.start() catch {};
+                channel.stop();
+            }
+        }
+    };
+
+    var threads: [10]std.Thread = undefined;
+    for (&threads) |*t| {
+        t.* = try std.Thread.spawn(.{}, ThreadFn.run, .{ch_struct.channel()});
+    }
+
+    for (threads) |t| {
+        t.join();
+    }
+
+    // Ensure cleanup
+    ch_struct.channel().stop();
+    try std.testing.expect(!ch_struct.running.load(.acquire));
+    try std.testing.expect(!ch_struct.connected.load(.acquire));
+    try std.testing.expect(ch_struct.socket_thread == null);
+    try std.testing.expect(ch_struct.poll_thread == null);
 }

--- a/src/channels/teams.zig
+++ b/src/channels/teams.zig
@@ -821,3 +821,16 @@ test "vtableSend preserves message without nc_choices" {
         msg;
     try std.testing.expectEqualStrings("Hello, how can I help?", clean);
 }
+
+test "TeamsChannel create + healthCheck + stop leaks zero bytes" {
+    // TeamsChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = TeamsChannel.initFromConfig(std.testing.allocator, .{
+        .client_id = "test-client-id",
+        .client_secret = "test-client-secret",
+        .tenant_id = "test-tenant-id",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/channels/telegram.zig
+++ b/src/channels/telegram.zig
@@ -2906,11 +2906,20 @@ pub const TelegramChannel = struct {
         // Clean up buffered media group messages to prevent shutdown leaks.
         self.resetPendingMediaBuffers();
         self.resetPendingTextBuffers();
+        // Reset to .empty after deinit so a second stop() (e.g. supervisor
+        // restart on .gateway_loop transitions, or test harnesses) does not
+        // call deinit on an undefined ArrayListUnmanaged. Same pattern as
+        // SignalChannel.vtableStop and TelegramChannel.deinitDraftBuffers.
         self.pending_media_messages.deinit(self.allocator);
+        self.pending_media_messages = .empty;
         self.pending_media_group_ids.deinit(self.allocator);
+        self.pending_media_group_ids = .empty;
         self.pending_media_received_at.deinit(self.allocator);
+        self.pending_media_received_at = .empty;
         self.pending_text_messages.deinit(self.allocator);
+        self.pending_text_messages = .empty;
         self.pending_text_received_at.deinit(self.allocator);
+        self.pending_text_received_at = .empty;
         if (self.bot_username) |name| {
             self.allocator.free(name);
             self.bot_username = null;
@@ -5867,4 +5876,39 @@ test "makeSink returns null for topic targets" {
 test "createForumTopicFromTarget rejects empty name" {
     var ch = TelegramChannel.init(std.testing.allocator, "test-token", &.{}, &.{}, "allowlist");
     try std.testing.expectError(error.InvalidTopicName, ch.createForumTopicFromTarget("-100123#topic:77", "   "));
+}
+
+test "TelegramChannel create + healthCheck + stop leaks zero bytes" {
+    // TelegramChannel holds no heap allocations at init-time (all fields are
+    // slices into caller-owned config data).  No deinit needed.
+    var ch_struct = TelegramChannel.initFromConfig(std.testing.allocator, .{
+        .bot_token = "test-token",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "TelegramChannel double stop is safe" {
+    // Regression: TelegramChannel.vtableStop used to deinit pending_media_messages,
+    // pending_media_group_ids, pending_media_received_at, pending_text_messages,
+    // and pending_text_received_at WITHOUT resetting them to .empty.
+    // ArrayListUnmanaged.deinit sets self.* = undefined, so a second
+    // vtableStop() call would deinit undefined memory — the same latent UB
+    // SignalChannel had before its own .empty fix (signal.zig:1356).
+    //
+    // Unlike Signal, Telegram is .listener_mode = .polling so the supervisor
+    // does not double-call vtableStop today, but a refactor that promotes
+    // Telegram to .gateway_loop or a test harness that exercises stop+stop
+    // would trigger the bug. This test pins the idempotent-stop contract
+    // alongside the fix.
+    var ch_struct = TelegramChannel.initFromConfig(std.testing.allocator, .{
+        .bot_token = "test-token",
+    });
+
+    const ch = ch_struct.channel();
+    ch.stop();
+    // Second stop must be a no-op, not a deinit-on-undefined.
+    ch.stop();
 }

--- a/src/channels/web.zig
+++ b/src/channels/web.zig
@@ -2544,6 +2544,17 @@ test "WebChannel relay user_message without access token is rejected" {
     try std.testing.expectEqual(@as(usize, 0), bus.inboundDepth());
 }
 
+test "WebChannel create + healthCheck + stop leaks zero bytes" {
+    // WebChannel (local transport) holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = WebChannel.initFromConfig(std.testing.allocator, .{
+        .transport = "local",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
 test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/channels/wechat.zig
+++ b/src/channels/wechat.zig
@@ -505,3 +505,95 @@ test "wechat smoke basic channel contract" {
     try std.testing.expectEqualStrings("wechat", ch.channel().name());
     try std.testing.expect(!ch.channel().healthCheck());
 }
+
+test "WeChatChannel create + healthCheck + stop leaks zero bytes" {
+    // WeChatChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = WeChatChannel.initFromConfig(std.testing.allocator, .{
+        .callback_token = "test-callback-token",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "WeChatChannel start + stop under is_test leaks zero bytes" {
+    // vtableStart sets self.running = true only — no I/O, no thread.
+    // Double stop must be idempotent per Channel contract.
+    var ch_struct = WeChatChannel.initFromConfig(std.testing.allocator, .{
+        .callback_token = "test-callback-token",
+    });
+
+    const ch = ch_struct.channel();
+    try ch.start();
+    ch.stop();
+    // Double stop — must not double-free or crash.
+    ch.stop();
+}
+
+test "verifySignature rejects tampered token" {
+    // Compute a valid SHA-1 signature for a fixed set of parameters, then
+    // verify that substituting a different token causes rejection.
+    const token = "correct-token";
+    const tampered_token = "evil-token";
+    const timestamp = "1710000000";
+    const nonce = "nonce42";
+
+    var parts = [3][]const u8{ token, timestamp, nonce };
+    var i: usize = 0;
+    while (i < parts.len) : (i += 1) {
+        var j: usize = i + 1;
+        while (j < parts.len) : (j += 1) {
+            if (std.mem.lessThan(u8, parts[j], parts[i])) {
+                const tmp = parts[i];
+                parts[i] = parts[j];
+                parts[j] = tmp;
+            }
+        }
+    }
+
+    var sha1 = std.crypto.hash.Sha1.init(.{});
+    for (parts) |p| sha1.update(p);
+    var digest: [std.crypto.hash.Sha1.digest_length]u8 = undefined;
+    sha1.final(&digest);
+    const sig = std.fmt.bytesToHex(digest, .lower);
+
+    // Correct params: must accept.
+    try std.testing.expect(verifySignature(token, timestamp, nonce, sig[0..]));
+    // Tampered token: must reject.
+    try std.testing.expect(!verifySignature(tampered_token, timestamp, nonce, sig[0..]));
+}
+
+test "verifyMessageSignature rejects tampered encrypted field" {
+    // Compute a valid SHA-1 signature covering the encrypted ciphertext, then
+    // verify that a modified ciphertext causes rejection.
+    const token = "wechat-token";
+    const timestamp = "1710000001";
+    const nonce = "nonce99";
+    const encrypted = "CORRECT_ENCRYPTED_PAYLOAD";
+    const tampered_encrypted = "TAMPERED_ENCRYPTED_PAYLOAD";
+
+    var parts = [4][]const u8{ token, timestamp, nonce, encrypted };
+    var i: usize = 0;
+    while (i < parts.len) : (i += 1) {
+        var j: usize = i + 1;
+        while (j < parts.len) : (j += 1) {
+            if (std.mem.lessThan(u8, parts[j], parts[i])) {
+                const tmp = parts[i];
+                parts[i] = parts[j];
+                parts[j] = tmp;
+            }
+        }
+    }
+
+    var sha1 = std.crypto.hash.Sha1.init(.{});
+    for (parts) |p| sha1.update(p);
+    var digest: [std.crypto.hash.Sha1.digest_length]u8 = undefined;
+    sha1.final(&digest);
+    const sig = std.fmt.bytesToHex(digest, .lower);
+
+    // Correct encrypted field: must accept.
+    try std.testing.expect(verifyMessageSignature(token, timestamp, nonce, encrypted, sig[0..]));
+    // Tampered encrypted field + original sig: must reject.
+    try std.testing.expect(!verifyMessageSignature(token, timestamp, nonce, tampered_encrypted, sig[0..]));
+}

--- a/src/channels/wecom.zig
+++ b/src/channels/wecom.zig
@@ -474,3 +474,49 @@ test "wecom smoke basic channel contract" {
     try std.testing.expectEqualStrings("wecom", ch.channel().name());
     try std.testing.expect(!ch.channel().healthCheck());
 }
+
+test "WeComChannel create + healthCheck + stop leaks zero bytes" {
+    // WeComChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = WeComChannel.initFromConfig(std.testing.allocator, .{
+        .webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=test",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "verifySignature rejects tampered encrypted field" {
+    // Compute a valid SHA-1 signature for the original encrypted ciphertext,
+    // then verify that a modified ciphertext is rejected.  Guards against
+    // regressions where the encrypted field is omitted from the digest input.
+    const token = "wecom-token";
+    const timestamp = "1710000000";
+    const nonce = "nonce123";
+    const encrypted = "CORRECT_WECOM_PAYLOAD";
+    const tampered_encrypted = "TAMPERED_WECOM_PAYLOAD";
+
+    var parts = [4][]const u8{ token, timestamp, nonce, encrypted };
+    var i: usize = 0;
+    while (i < parts.len) : (i += 1) {
+        var j: usize = i + 1;
+        while (j < parts.len) : (j += 1) {
+            if (std.mem.lessThan(u8, parts[j], parts[i])) {
+                const tmp = parts[i];
+                parts[i] = parts[j];
+                parts[j] = tmp;
+            }
+        }
+    }
+
+    var sha1 = std.crypto.hash.Sha1.init(.{});
+    for (parts) |p| sha1.update(p);
+    var digest: [std.crypto.hash.Sha1.digest_length]u8 = undefined;
+    sha1.final(&digest);
+    const sig = std.fmt.bytesToHex(digest, .lower);
+
+    // Correct encrypted field: must accept.
+    try std.testing.expect(verifySignature(token, timestamp, nonce, encrypted, sig[0..]));
+    // Tampered encrypted field + original sig: must reject.
+    try std.testing.expect(!verifySignature(token, timestamp, nonce, tampered_encrypted, sig[0..]));
+}

--- a/src/channels/weixin.zig
+++ b/src/channels/weixin.zig
@@ -903,3 +903,30 @@ test "sendMessage rejects empty target" {
     var ch = WeixinChannel.init(std.testing.allocator, .{ .token = "test-token" });
     try std.testing.expectError(error.InvalidTarget, ch.sendMessage("", "hello"));
 }
+
+test "WeixinChannel create + healthCheck + stop leaks zero bytes" {
+    var ch_struct = WeixinChannel.initFromConfig(std.testing.allocator, .{
+        .token = "test-token",
+    });
+    defer ch_struct.deinit();
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}
+
+test "WeixinChannel start + stop under is_test leaks zero bytes" {
+    // vtableStart sets self.running = true only — no I/O, no thread.
+    // Double stop must be idempotent per Channel contract.
+    // deinit() releases the context_tokens HashMap (always empty at init-time).
+    var ch_struct = WeixinChannel.initFromConfig(std.testing.allocator, .{
+        .token = "test-token",
+    });
+    defer ch_struct.deinit();
+
+    const ch = ch_struct.channel();
+    try ch.start();
+    ch.stop();
+    // Double stop — must not double-free or crash.
+    ch.stop();
+}

--- a/src/channels/whatsapp.zig
+++ b/src/channels/whatsapp.zig
@@ -992,3 +992,16 @@ test "whatsapp normalize phone buffer too small" {
     // Phone "123" needs 4 bytes ("+123"), but buf is only 2 bytes
     try std.testing.expectEqualStrings("123", WhatsAppChannel.normalizePhone(&buf, "123"));
 }
+
+test "WhatsAppChannel create + healthCheck + stop leaks zero bytes" {
+    // WhatsAppChannel holds no heap allocations at init-time.  No deinit needed.
+    var ch_struct = WhatsAppChannel.initFromConfig(std.testing.allocator, .{
+        .access_token = "test-access-token",
+        .phone_number_id = "test-phone-id",
+        .verify_token = "test-verify-token",
+    });
+
+    const ch = ch_struct.channel();
+    _ = ch.healthCheck();
+    ch.stop();
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -7728,3 +7728,21 @@ test "validation accepts named agent provider aliases from configured providers"
 
     try cfg.validate();
 }
+
+test "Config parseJson rejects truncated JSON" {
+    const alloc = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    // Truncated JSON must fail before partially parsed config is accepted.
+    const malformed_json = "{\"models\":{\"providers\":{\"openai\":";
+
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .allocator = allocator,
+    };
+    const result = cfg.parseJson(malformed_json);
+    try std.testing.expect(std.meta.isError(result));
+}

--- a/src/cron.zig
+++ b/src/cron.zig
@@ -3724,3 +3724,99 @@ test "buildSchedulerStatusJson reports scheduler summary" {
     try std.testing.expect(std.mem.indexOf(u8, json, "\"active_jobs\":2") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"paused_jobs\":1") != null);
 }
+
+test "cron register + cancel leaks zero bytes for every job kind" {
+    // Uses the leak-detecting GPA (std.testing.allocator). Any allocation
+    // in addJob / addOnce / addAgentJob / addAgentOnce that is not freed
+    // by removeJob will be reported as a leak when the test runner tears
+    // down the allocator.
+    //
+    // The agent-job path is the most leak-prone — it allocates id,
+    // expression, command, prompt, model (optional), delivery.channel,
+    // delivery.account_id, delivery.to, delivery.peer_id, and
+    // delivery.thread_id, each behind its own _owned flag in freeJobOwned.
+    // The original new test only covered addJob + addOnce and would have
+    // missed a regression in any of those agent-only fields.
+    const alloc = std.testing.allocator;
+
+    var sched = CronScheduler.init(alloc, 10, true);
+    defer sched.deinit();
+
+    // Recurring shell job.
+    const recurring = try sched.addJob("*/5 * * * *", "echo recurring");
+    // dupe the id because removeJob takes ownership of (frees) the matched
+    // job's heap-owned id; passing the original `recurring.id` slice would
+    // be a use-after-free pattern.
+    const recurring_id = try alloc.dupe(u8, recurring.id);
+    defer alloc.free(recurring_id);
+    try std.testing.expect(sched.removeJob(recurring_id));
+    try std.testing.expectEqual(@as(usize, 0), sched.listJobs().len);
+
+    // One-shot shell job: extra `@once:<delay>` expression allocation.
+    const once = try sched.addOnce("10m", "echo once");
+    const once_id = try alloc.dupe(u8, once.id);
+    defer alloc.free(once_id);
+    try std.testing.expect(sched.removeJob(once_id));
+    try std.testing.expectEqual(@as(usize, 0), sched.listJobs().len);
+
+    // Recurring agent job: every delivery field non-null to exercise the
+    // full _owned-flag matrix in freeJobOwned.
+    const agent_recurring = try sched.addAgentJob("*/15 * * * *", "be helpful", "claude-sonnet", .{
+        .mode = .always,
+        .channel = "telegram",
+        .account_id = "main",
+        .to = "12345",
+        .peer_kind = .direct,
+        .peer_id = "user-99",
+        .thread_id = "topic-7",
+        .best_effort = false,
+    });
+    const agent_recurring_id = try alloc.dupe(u8, agent_recurring.id);
+    defer alloc.free(agent_recurring_id);
+    try std.testing.expect(sched.removeJob(agent_recurring_id));
+    try std.testing.expectEqual(@as(usize, 0), sched.listJobs().len);
+
+    // One-shot agent job: same field matrix, plus the `@once:<delay>` expr.
+    // Pass `null` for model to exercise the optional-skip path.
+    const agent_once = try sched.addAgentOnce("5m", "remind me", null, .{
+        .mode = .on_success,
+        .channel = "discord",
+        .account_id = "guild-42",
+        .to = "channel-7",
+        .peer_kind = .group,
+        .peer_id = "guild-42",
+        .thread_id = null,
+        .best_effort = true,
+    });
+    const agent_once_id = try alloc.dupe(u8, agent_once.id);
+    defer alloc.free(agent_once_id);
+    try std.testing.expect(sched.removeJob(agent_once_id));
+    try std.testing.expectEqual(@as(usize, 0), sched.listJobs().len);
+
+    // removeJob on an unknown id must return false without leaking or
+    // crashing, regardless of whether jobs are present.
+    try std.testing.expect(!sched.removeJob("nonexistent-id"));
+}
+
+test "cron rejects obviously malformed expressions" {
+    // Each input exercises a distinct branch in parseCronExpression /
+    // parseCronField. Note: "* * * * * * *" (7 fields) is valid per the
+    // spec and is excluded.
+    const malformed = [_][]const u8{
+        "", // empty
+        "garbage", // single non-cron token
+        "* * *", // wrong field count (3, not 5/6/7)
+        "60 * * * *", // minute out of range
+        "* 24 * * *", // hour out of range
+        "* * 32 * *", // day-of-month out of range
+        "* * * 13 *", // month out of range
+        "* * * * 8", // day-of-week out of range (allow_sunday_7 caps at 7)
+        "*/0 * * * *", // step = 0 — divide-by-zero classic
+        "5-3 * * * *", // reversed range (start > end)
+        "abc * * * *", // alphabetic in numeric field
+    };
+    for (malformed) |input| {
+        const result = nextRunForCronExpression(input, 0);
+        try std.testing.expect(std.meta.isError(result));
+    }
+}

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -880,6 +880,47 @@ fn resolveInboundRouteSessionKey(
     return resolveInboundRouteSessionKeyWithMetadata(allocator, config, msg, parsed_meta.fields);
 }
 
+const InboundRoutingPlan = struct {
+    session_key: []const u8,
+    session_key_owned: bool,
+    outbound_channel: []const u8,
+    outbound_account_id: ?[]const u8,
+    outbound_chat_id: []const u8,
+    conversation_context: ?ConversationContext,
+
+    fn deinit(self: *InboundRoutingPlan, allocator: std.mem.Allocator) void {
+        if (self.session_key_owned) allocator.free(self.session_key);
+    }
+};
+
+fn buildInboundRoutingPlan(
+    allocator: std.mem.Allocator,
+    config: *const Config,
+    msg: *const bus_mod.InboundMessage,
+    meta: channel_adapters.InboundMetadata,
+) InboundRoutingPlan {
+    const routed_session_key = resolveInboundMainSessionKeyWithMetadata(
+        allocator,
+        config,
+        msg,
+        meta,
+    ) orelse resolveInboundRouteSessionKeyWithMetadata(
+        allocator,
+        config,
+        msg,
+        meta,
+    );
+
+    return .{
+        .session_key = routed_session_key orelse msg.session_key,
+        .session_key_owned = routed_session_key != null,
+        .outbound_channel = msg.channel,
+        .outbound_account_id = meta.account_id,
+        .outbound_chat_id = msg.chat_id,
+        .conversation_context = buildInboundConversationContext(msg, meta),
+    };
+}
+
 const SlackStatusTarget = struct {
     channel_id: []const u8,
     thread_ts: []const u8,
@@ -1231,41 +1272,29 @@ fn processInboundMessage(
     var parsed_meta = parseInboundMetadata(allocator, msg.metadata_json);
     defer parsed_meta.deinit();
 
-    const outbound_account_id = parsed_meta.fields.account_id;
-    const routed_session_key = resolveInboundMainSessionKeyWithMetadata(
-        allocator,
-        runtime.config,
-        msg,
-        parsed_meta.fields,
-    ) orelse resolveInboundRouteSessionKeyWithMetadata(
-        allocator,
-        runtime.config,
-        msg,
-        parsed_meta.fields,
-    );
-    defer if (routed_session_key) |key| allocator.free(key);
-    const session_key = routed_session_key orelse msg.session_key;
+    var routing_plan = buildInboundRoutingPlan(allocator, runtime.config, msg, parsed_meta.fields);
+    defer routing_plan.deinit(allocator);
 
-    const outbound_channel = resolveOutboundChannel(registry, msg.channel, outbound_account_id);
+    const outbound_channel = resolveOutboundChannel(registry, routing_plan.outbound_channel, routing_plan.outbound_account_id);
     if (outbound_channel) |channel| {
         markInboundMessageRead(channel, buildInboundMessageRef(msg, parsed_meta.fields));
     }
 
-    if (runtime.session_mgr.routeInbound(session_key, msg.content) == .skip) return;
+    if (runtime.session_mgr.routeInbound(routing_plan.session_key, msg.content) == .skip) return;
 
     const typing_recipient = sendInboundProcessingIndicator(
         allocator,
         registry,
-        msg.channel,
-        outbound_account_id,
-        msg.chat_id,
+        routing_plan.outbound_channel,
+        routing_plan.outbound_account_id,
+        routing_plan.outbound_chat_id,
         parsed_meta.fields,
     );
     defer clearInboundProcessingIndicator(
         allocator,
         registry,
-        msg.channel,
-        outbound_account_id,
+        routing_plan.outbound_channel,
+        routing_plan.outbound_account_id,
         typing_recipient,
     );
 
@@ -1281,9 +1310,9 @@ fn processInboundMessage(
     var streaming_ctx = StreamingOutboundCtx{
         .allocator = allocator,
         .event_bus = event_bus,
-        .channel = msg.channel,
-        .account_id = outbound_account_id,
-        .chat_id = msg.chat_id,
+        .channel = routing_plan.outbound_channel,
+        .account_id = routing_plan.outbound_account_id,
+        .chat_id = routing_plan.outbound_chat_id,
         .draft_id = outbound_draft_id,
     };
     var stream_sink: ?streaming.Sink = null;
@@ -1301,12 +1330,10 @@ fn processInboundMessage(
         defer channels_mod.max.setInteractiveOwnerContext(null);
     }
 
-    const conversation_context = buildInboundConversationContext(msg, parsed_meta.fields);
-
     const reply = runtime.session_mgr.processMessageStreaming(
-        session_key,
+        routing_plan.session_key,
         msg.content,
-        conversation_context,
+        routing_plan.conversation_context,
         stream_sink,
         null,
     ) catch |err| {
@@ -1320,10 +1347,10 @@ fn processInboundMessage(
             error.OutOfMemory => "Out of memory.",
             else => "An error occurred. Try again.",
         };
-        var err_out = if (outbound_account_id) |aid|
-            bus_mod.makeOutboundWithAccount(allocator, msg.channel, aid, msg.chat_id, err_msg) catch return
+        var err_out = if (routing_plan.outbound_account_id) |aid|
+            bus_mod.makeOutboundWithAccount(allocator, routing_plan.outbound_channel, aid, routing_plan.outbound_chat_id, err_msg) catch return
         else
-            bus_mod.makeOutbound(allocator, msg.channel, msg.chat_id, err_msg) catch return;
+            bus_mod.makeOutbound(allocator, routing_plan.outbound_channel, routing_plan.outbound_chat_id, err_msg) catch return;
         err_out.draft_id = outbound_draft_id;
         event_bus.publishOutbound(err_out) catch {
             err_out.deinit(allocator);
@@ -1338,9 +1365,9 @@ fn processInboundMessage(
                 log.warn("failed to build edit payload: {}", .{err});
                 const out = makeAssistantReplyOutbound(
                     allocator,
-                    msg.channel,
-                    outbound_account_id,
-                    msg.chat_id,
+                    routing_plan.outbound_channel,
+                    routing_plan.outbound_account_id,
+                    routing_plan.outbound_chat_id,
                     reply,
                     outbound_draft_id,
                 ) catch return;
@@ -1366,9 +1393,9 @@ fn processInboundMessage(
 
     const out = makeAssistantReplyOutbound(
         allocator,
-        msg.channel,
-        outbound_account_id,
-        msg.chat_id,
+        routing_plan.outbound_channel,
+        routing_plan.outbound_account_id,
+        routing_plan.outbound_chat_id,
         reply,
         outbound_draft_id,
     ) catch |err| {
@@ -2919,6 +2946,57 @@ test "makeAssistantReplyOutbound extracts structured choices from assistant repl
     try std.testing.expectEqualStrings("yes", msg.choices[0].id);
     try std.testing.expectEqualStrings("No", msg.choices[1].label);
     try std.testing.expectEqual(@as(u64, 17), msg.draft_id);
+}
+
+test "buildInboundRoutingPlan keeps inbound origin through outbound planning" {
+    const allocator = std.testing.allocator;
+    const bindings = [_]agent_routing.AgentBinding{
+        .{
+            .agent_id = "custom-agent",
+            .match = .{
+                .channel = "custom",
+                .account_id = "custom-main",
+                .peer = .{ .kind = .direct, .id = "user-7" },
+            },
+        },
+    };
+    const config = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .allocator = allocator,
+        .agent_bindings = &bindings,
+    };
+    const inbound = bus_mod.InboundMessage{
+        .channel = "custom",
+        .sender_id = "sender-1",
+        .chat_id = "delivery-chat",
+        .content = "hello",
+        .session_key = "custom:legacy",
+        .metadata_json = "{\"account_id\":\"custom-main\",\"peer_kind\":\"direct\",\"peer_id\":\"user-7\",\"sender_username\":\"alice\",\"sender_display_name\":\"Alice\"}",
+    };
+    var parsed_meta = parseInboundMetadata(allocator, inbound.metadata_json);
+    defer parsed_meta.deinit();
+
+    var plan = buildInboundRoutingPlan(allocator, &config, &inbound, parsed_meta.fields);
+    defer plan.deinit(allocator);
+
+    try std.testing.expect(plan.session_key_owned);
+    try std.testing.expectEqualStrings("agent:custom-agent:custom:direct:user-7", plan.session_key);
+    try std.testing.expectEqualStrings("custom", plan.outbound_channel);
+    try std.testing.expectEqualStrings("custom-main", plan.outbound_account_id.?);
+    try std.testing.expectEqualStrings("delivery-chat", plan.outbound_chat_id);
+
+    const context = plan.conversation_context orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("custom", context.channel.?);
+    try std.testing.expectEqualStrings("custom-main", context.account_id.?);
+    try std.testing.expectEqualStrings("sender-1", context.sender_id.?);
+    try std.testing.expectEqualStrings("alice", context.sender_username.?);
+    try std.testing.expectEqualStrings("Alice", context.sender_display_name.?);
+    try std.testing.expectEqualStrings("delivery-chat", context.delivery_chat_id.?);
+    try std.testing.expectEqualStrings("user-7", context.peer_id.?);
+    try std.testing.expect(context.is_group != null);
+    try std.testing.expect(!context.is_group.?);
+    try std.testing.expect(context.group_id == null);
 }
 
 test "nextOutboundDraftId stays unique across concurrent callers" {

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -438,6 +438,10 @@ pub const IdempotencyStore = struct {
     }
 
     pub fn deinit(self: *IdempotencyStore, allocator: std.mem.Allocator) void {
+        var iter = self.keys.iterator();
+        while (iter.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+        }
         self.keys.deinit(allocator);
     }
 
@@ -457,14 +461,21 @@ pub const IdempotencyStore = struct {
             }
         }
         for (to_remove.items) |k| {
-            _ = self.keys.remove(k);
+            if (self.keys.fetchRemove(k)) |kv| {
+                allocator.free(kv.key);
+            }
         }
 
-        // Check if already present
+        // Check if already present after removing expired entries. Idempotency
+        // keys are exact identifiers; do not truncate or prefix-match them.
         if (self.keys.get(key)) |_| return false;
 
         // Record new key
-        self.keys.put(allocator, key, now) catch return true;
+        const duped_key = allocator.dupe(u8, key) catch return true;
+        self.keys.put(allocator, duped_key, now) catch {
+            allocator.free(duped_key);
+            return true;
+        };
         return true;
     }
 };
@@ -993,6 +1004,12 @@ pub fn jsonStringField(json: []const u8, key: []const u8) ?[]const u8 {
         }
     }
     return null;
+}
+
+fn isJsonObjectPayload(allocator: std.mem.Allocator, body: []const u8) bool {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch return false;
+    defer parsed.deinit();
+    return parsed.value == .object;
 }
 
 /// Extract an integer field from a JSON blob.
@@ -3263,6 +3280,13 @@ fn handleWhatsAppWebhookRoute(ctx: *WebhookHandlerContext) void {
     }
 
     const wa_body = extractBody(ctx.raw_request);
+    if (wa_body) |body| {
+        if (!isJsonObjectPayload(ctx.req_allocator, body)) {
+            ctx.response_status = "400 Bad Request";
+            ctx.response_body = "{\"error\":\"invalid json payload\"}";
+            return;
+        }
+    }
     var wa_app_secret = ctx.state.whatsapp_app_secret;
     var wa_access_token = ctx.state.whatsapp_access_token;
     var wa_allow_from = ctx.state.whatsapp_allow_from;
@@ -4719,6 +4743,49 @@ fn handleMaxWebhookRoute(ctx: *WebhookHandlerContext) void {
     ctx.response_body = "{\"status\":\"ok\"}";
 }
 
+test "handleWhatsAppWebhookRoute rejects malformed JSON before sender extraction" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const whatsapp_accounts = [_]config_types.WhatsAppConfig{
+        .{
+            .account_id = "main",
+            .phone_number_id = "phone-1",
+            .access_token = "token",
+            .verify_token = "verify",
+            .allow_from = &.{"user-1"},
+        },
+    };
+
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .allocator = allocator,
+        .channels = .{ .whatsapp = &whatsapp_accounts },
+    };
+
+    const raw_request = "POST /whatsapp HTTP/1.1\r\nContent-Length: 27\r\n\r\n{\"from\":\"user-1\",\"text\":\"hi\"";
+
+    var state = GatewayState.init(std.testing.allocator);
+    defer state.deinit();
+
+    var ctx = WebhookHandlerContext{
+        .root_allocator = allocator,
+        .req_allocator = allocator,
+        .raw_request = raw_request,
+        .method = "POST",
+        .target = "/whatsapp",
+        .config_opt = &cfg,
+        .state = &state,
+        .session_mgr_opt = null,
+    };
+
+    handleWhatsAppWebhookRoute(&ctx);
+    try std.testing.expectEqualStrings("400 Bad Request", ctx.response_status);
+    try std.testing.expectEqualStrings("{\"error\":\"invalid json payload\"}", ctx.response_body);
+}
+
 fn handleTeamsWebhookRoute(ctx: *WebhookHandlerContext) void {
     if (!build_options.enable_channel_teams) {
         ctx.response_status = "404 Not Found";
@@ -4756,6 +4823,11 @@ fn handleTeamsWebhookRoute(ctx: *WebhookHandlerContext) void {
         ctx.response_body = "{\"error\":\"empty body\"}";
         return;
     };
+    if (!isJsonObjectPayload(ctx.req_allocator, body)) {
+        ctx.response_status = "400 Bad Request";
+        ctx.response_body = "{\"error\":\"invalid json payload\"}";
+        return;
+    }
 
     // Parse Bot Framework Activity JSON
     const activity_type = jsonStringField(body, "type") orelse {
@@ -6403,6 +6475,37 @@ test "idempotency store duplicate after many inserts" {
     try std.testing.expect(store.recordIfNew(std.testing.allocator, "third"));
     // First key should still be duplicate
     try std.testing.expect(!store.recordIfNew(std.testing.allocator, "first"));
+}
+
+test "idempotency store allows expired key again" {
+    var store = IdempotencyStore.init(1);
+    defer store.deinit(std.testing.allocator);
+
+    try std.testing.expect(store.recordIfNew(std.testing.allocator, "expires"));
+    const entry = store.keys.getPtr("expires") orelse return error.TestUnexpectedResult;
+    entry.* = std_compat.time.nanoTimestamp() - store.ttl_ns - 1;
+
+    try std.testing.expect(store.recordIfNew(std.testing.allocator, "expires"));
+    try std.testing.expect(!store.recordIfNew(std.testing.allocator, "expires"));
+}
+
+test "idempotency store keeps long keys exact" {
+    var store = IdempotencyStore.init(300);
+    defer store.deinit(std.testing.allocator);
+
+    var long_key_a: [200]u8 = undefined;
+    @memset(&long_key_a, 'A');
+    var long_key_b: [200]u8 = undefined;
+    @memset(&long_key_b, 'A');
+    long_key_b[199] = 'B';
+
+    try std.testing.expect(store.recordIfNew(std.testing.allocator, &long_key_a));
+    try std.testing.expect(!store.recordIfNew(std.testing.allocator, &long_key_a));
+
+    // Same first 199 bytes, different final byte: still a distinct idempotency key.
+    try std.testing.expect(store.recordIfNew(std.testing.allocator, &long_key_b));
+    // Prefix is also distinct from the longer key.
+    try std.testing.expect(store.recordIfNew(std.testing.allocator, long_key_a[0..128]));
 }
 
 test "rate limiter window_ns calculation" {
@@ -8457,6 +8560,53 @@ test "handleTeamsWebhookRoute requires configured webhook secret after JWT valid
     try std.testing.expectEqualStrings("{\"error\":\"unauthorized\"}", ctx.response_body);
 }
 
+test "handleTeamsWebhookRoute rejects malformed JSON payload" {
+    if (!build_options.enable_channel_teams) return;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const teams_accounts = [_]config_types.TeamsConfig{
+        .{
+            .account_id = "default",
+            .client_id = "test-app-id",
+            .client_secret = "teams-secret",
+            .tenant_id = "tenant-1",
+            .webhook_secret = "teams-webhook-secret-012345",
+        },
+    };
+
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .allocator = allocator,
+        .channels = .{ .teams = &teams_accounts },
+    };
+
+    const body = "{\"type\":\"message\",\"text\":"; // Unclosed JSON
+    const raw_request = try buildTeamsWebhookRequest(allocator, botframework_auth.fixtureTokenForTest(), null, body);
+
+    var state = GatewayState.init(std.testing.allocator);
+    defer state.deinit();
+    try state.teams_auth_cache.seedFixtureForTest(std.testing.allocator);
+
+    var ctx = WebhookHandlerContext{
+        .root_allocator = allocator,
+        .req_allocator = allocator,
+        .raw_request = raw_request,
+        .method = "POST",
+        .target = "/api/messages",
+        .config_opt = &cfg,
+        .state = &state,
+        .session_mgr_opt = null,
+    };
+
+    handleTeamsWebhookRoute(&ctx);
+    try std.testing.expectEqualStrings("400 Bad Request", ctx.response_status);
+    try std.testing.expectEqualStrings("{\"error\":\"invalid json payload\"}", ctx.response_body);
+}
+
 test "isValidBotFrameworkServiceUrl accepts documented Teams traffic manager host" {
     try std.testing.expect(isValidBotFrameworkServiceUrl("https://smba.trafficmanager.net/amer/"));
     try std.testing.expect(isValidBotFrameworkServiceUrl("https://SMBA.TRAFFICMANAGER.NET/teams/"));
@@ -8738,7 +8888,10 @@ test "nextAcceptSleepMs resets to poll interval on WouldBlock" {
 }
 
 test "nextAcceptSleepMs exponentially backs off and caps for non-WouldBlock errors" {
+    // Regression #851: repeated accept errors must back off instead of busy-looping.
     const unexpected = error.Unexpected;
+    try std.testing.expectEqual(@as(u64, 200), nextAcceptSleepMs(0, unexpected));
+    try std.testing.expectEqual(@as(u64, 200), nextAcceptSleepMs(50, unexpected));
     try std.testing.expectEqual(@as(u64, 200), nextAcceptSleepMs(100, unexpected));
     try std.testing.expectEqual(@as(u64, 800), nextAcceptSleepMs(400, unexpected));
     try std.testing.expectEqual(ACCEPT_ERROR_BACKOFF_MAX_MS, nextAcceptSleepMs(900, unexpected));
@@ -9066,6 +9219,44 @@ test "verifySlackSignature rejects stale timestamp" {
     }
 
     try std.testing.expect(!verifySlackSignature(std.testing.allocator, body, ts, &sig_buf, secret));
+}
+
+test "verifySlackSignature rejects tampered body" {
+    // Compute a valid Slack v0 HMAC-SHA256 signature over the original body,
+    // then verify that presenting the same signature with a different body is
+    // rejected.  Guards against regressions where body is excluded from the
+    // "v0:ts:body" signing input.
+    const secret = "slack-signing-secret";
+    const original_body = "{\"type\":\"event_callback\",\"event\":{\"text\":\"hello\"}}";
+    const tampered_body = "{\"type\":\"event_callback\",\"event\":{\"text\":\"evil\"}}";
+
+    var ts_buf: [32]u8 = undefined;
+    const ts = std.fmt.bufPrint(&ts_buf, "{d}", .{std_compat.time.timestamp()}) catch unreachable;
+
+    var signed: std.ArrayListUnmanaged(u8) = .empty;
+    defer signed.deinit(std.testing.allocator);
+    var signed_writer: std.Io.Writer.Allocating = .fromArrayList(std.testing.allocator, &signed);
+    const sw = &signed_writer.writer;
+    try sw.print("v0:{s}:", .{ts});
+    try sw.writeAll(original_body);
+    signed = signed_writer.toArrayList();
+
+    const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+    var mac: [HmacSha256.mac_length]u8 = undefined;
+    HmacSha256.create(&mac, signed.items, secret);
+
+    var sig_buf: [67]u8 = undefined; // "v0=" + 64 hex chars
+    @memcpy(sig_buf[0..3], "v0=");
+    for (0..32) |idx| {
+        const byte = mac[idx];
+        sig_buf[3 + idx * 2] = "0123456789abcdef"[byte >> 4];
+        sig_buf[3 + idx * 2 + 1] = "0123456789abcdef"[byte & 0x0f];
+    }
+
+    // Original body + correct sig: must accept.
+    try std.testing.expect(verifySlackSignature(std.testing.allocator, original_body, ts, &sig_buf, secret));
+    // Tampered body + original sig: must reject.
+    try std.testing.expect(!verifySlackSignature(std.testing.allocator, tampered_body, ts, &sig_buf, secret));
 }
 
 test "hasSlackHttpEndpoint respects mode and webhook_path" {

--- a/src/memory/engines/contract_test.zig
+++ b/src/memory/engines/contract_test.zig
@@ -331,3 +331,118 @@ test "contract: kg session_id" {
     defer mem.deinit();
     try contractSessionId(mem.memory());
 }
+
+// ── Recall-after-store contract ──────────────────────────────────────
+
+fn recallAfterStoreContract(m: Memory) !void {
+    const allocator = std.testing.allocator;
+    const unique_key = "recall_probe";
+    // The query must be a single FTS5 token — sqlite's FTS5 unicode61
+    // tokenizer treats `_` as a separator, so a query like "recall_probe"
+    // would split into the phrase ["recall", "probe"] and miss the
+    // sqlite/kg FTS path entirely. KG has no LIKE fallback, so a
+    // multi-token query would silently fail there. `xyz123uniquecontent`
+    // is a single alphanumeric token that all three search paths
+    // (FTS5 phrase, markdown substring, LRU substring) match identically.
+    const unique_content = "xyz123uniquecontent recall_probe_content";
+    try m.store(unique_key, unique_content, .core, null);
+
+    const query = "xyz123uniquecontent";
+    const results = try m.recall(allocator, query, 10, null);
+    defer root.freeEntries(allocator, results);
+
+    try std.testing.expect(results.len >= 1);
+    var found = false;
+    for (results) |e| {
+        if (std.mem.indexOf(u8, e.content, query) != null) {
+            found = true;
+            break;
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "stateful memory backends recall stored entries" {
+    // NoneMemory is intentionally covered by "contract: none noop"; it must
+    // not recall stored entries because writes are explicit no-ops.
+    if (build_options.enable_sqlite) {
+        var sql = try SqliteMemory.init(std.testing.allocator, ":memory:");
+        defer sql.deinit();
+        try recallAfterStoreContract(sql.memory());
+    }
+    {
+        var dir = std.testing.tmpDir(.{});
+        defer dir.cleanup();
+        const path = try @import("compat").fs.Dir.wrap(dir.dir).realpathAlloc(std.testing.allocator, ".");
+        defer std.testing.allocator.free(path);
+        var md = try MarkdownMemory.init(std.testing.allocator, path);
+        defer md.deinit();
+        try recallAfterStoreContract(md.memory());
+    }
+    {
+        var lru = InMemoryLruMemory.init(std.testing.allocator, 100);
+        defer lru.deinit();
+        try recallAfterStoreContract(lru.memory());
+    }
+    if (build_options.enable_memory_kg) {
+        var kg = try KgMemory.init(std.testing.allocator, ":memory:");
+        defer kg.deinit();
+        try recallAfterStoreContract(kg.memory());
+    }
+}
+
+// ── Deinit-after-store contract ──────────────────────────────────────
+
+/// Validates that deinit is safe after a successful store call —
+/// post-store internal state must not require any extra "close" /
+/// "flush" call before deinit. AGENTS.md §3.4 fail-fast: no UB, no
+/// double-free, no leak.
+///
+/// Note: the Memory vtable has no `close()` method. An earlier draft of
+/// this comment referenced one ("close not called") — that was wrong.
+/// The contract being checked is simply that deinit alone is sufficient
+/// teardown after a mutation.
+fn contractDeinitAfterStore(m: Memory) !void {
+    try m.store("ownership_probe", "content", .core, null);
+}
+
+test "every engine survives store-then-deinit" {
+    // sqlite
+    if (build_options.enable_sqlite) {
+        var mem = try SqliteMemory.init(std.testing.allocator, ":memory:");
+        defer mem.deinit();
+        try contractDeinitAfterStore(mem.memory());
+    }
+
+    // markdown
+    {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(std.testing.allocator, ".");
+        defer std.testing.allocator.free(base);
+        var mem = try MarkdownMemory.init(std.testing.allocator, base);
+        defer mem.deinit();
+        try contractDeinitAfterStore(mem.memory());
+    }
+
+    // lru
+    {
+        var mem = InMemoryLruMemory.init(std.testing.allocator, 100);
+        defer mem.deinit();
+        try contractDeinitAfterStore(mem.memory());
+    }
+
+    // none — no-op store, but contract still applies
+    {
+        var mem = NoneMemory.init();
+        defer mem.deinit();
+        try contractDeinitAfterStore(mem.memory());
+    }
+
+    // kg
+    if (build_options.enable_memory_kg) {
+        var mem = try KgMemory.init(std.testing.allocator, ":memory:");
+        defer mem.deinit();
+        try contractDeinitAfterStore(mem.memory());
+    }
+}

--- a/src/memory/engines/sqlite.zig
+++ b/src/memory/engines/sqlite.zig
@@ -228,6 +228,7 @@ pub const SqliteMemory = struct {
         }
 
         var self_ = Self{ .db = db, .allocator = allocator };
+        errdefer self_.deinit();
         try self_.configurePragmas(use_wal);
         try self_.migrate();
         try self_.migrateSessionId();
@@ -2626,4 +2627,42 @@ test "sqlite clearMessages does not affect other sessions" {
     const s2_msgs = try mem.loadMessages(std.testing.allocator, "s2");
     defer root.freeMessages(std.testing.allocator, s2_msgs);
     try std.testing.expectEqual(@as(usize, 1), s2_msgs.len);
+}
+
+test "SqliteMemory.init on non-sqlite file errors and frees the partially-opened db handle" {
+    // The errdefer added in init() (`errdefer self_.deinit();`) closes the
+    // sqlite3 handle when migrate() / migrateSessionId() / migrateAgentNamespace()
+    // fail. std.testing.allocator only sees Zig-heap allocations and CANNOT
+    // observe the native sqlite3 handle leak directly — but a future refactor
+    // that adds Zig-heap allocations between `sqlite3_open` and the migrations
+    // (e.g. caching the path) would surface here as a leak, and a regression
+    // that removed the errdefer would manifest as a quiet handle leak that
+    // CI's "fd count" or `lsof` reveals only on long-running test runs.
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Write a plain text file where the DB would be opened.
+    // sqlite3_open succeeds on any file; migrate() fails with SQLITE_NOTADB.
+    try @import("compat").fs.Dir.wrap(tmp.dir).writeFile(.{ .sub_path = "blocker.db", .data = "not a sqlite database" });
+
+    const blocker_path = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(alloc, "blocker.db");
+    defer alloc.free(blocker_path);
+
+    const blocker_pathz = try alloc.dupeZ(u8, blocker_path);
+    defer alloc.free(blocker_pathz);
+
+    // Expect SOME error from the migrations layer. We accept a small set of
+    // errors rather than pinning the exact tag, because different sqlite
+    // versions classify the failure differently (CORRUPT vs NOTADB at
+    // different operations).
+    if (SqliteMemory.init(alloc, blocker_pathz)) |opened_value| {
+        var opened = opened_value;
+        defer opened.deinit();
+        return error.TestExpectedError;
+    } else |err| switch (err) {
+        error.MigrationFailed, error.PrepareFailed => {},
+        else => return err,
+    }
 }

--- a/src/net_security.zig
+++ b/src/net_security.zig
@@ -806,3 +806,73 @@ test "resolveConnectHost returns literal for global ipv4" {
     defer std.testing.allocator.free(resolved);
     try std.testing.expectEqualStrings("8.8.8.8", resolved);
 }
+
+// ── URL scheme validation ────────────────────────────────────────────
+
+/// Outbound URL validation error. The runtime rejects any non-HTTPS URL at
+/// the tool boundary per AGENTS.md §3.5 (Secure by Default).
+pub const UrlValidationError = error{
+    InsecureScheme,
+    UnsupportedScheme,
+    MalformedUrl,
+};
+
+/// Validate an outbound URL for HTTP/browser tools. Accepts only `https://`.
+/// Rejects `http://`, `ws://`, `wss://`, `file://`, `data:`, `ftp://`, and
+/// any other scheme. WebSocket callers should use a separate helper once a
+/// concrete outbound WebSocket tool needs it.
+/// Case-insensitive on the scheme prefix per RFC 3986 §3.1.
+pub fn validateOutboundUrl(url: []const u8) UrlValidationError!void {
+    if (url.len == 0) return error.MalformedUrl;
+
+    const scheme_end = std.mem.indexOf(u8, url, "://") orelse {
+        if (std.mem.indexOfScalar(u8, url, ':')) |colon| {
+            const scheme = url[0..colon];
+            if (std.ascii.eqlIgnoreCase(scheme, "data") or
+                std.ascii.eqlIgnoreCase(scheme, "javascript") or
+                std.ascii.eqlIgnoreCase(scheme, "blob"))
+            {
+                return error.UnsupportedScheme;
+            }
+            return error.MalformedUrl;
+        }
+        return error.MalformedUrl;
+    };
+
+    const scheme = url[0..scheme_end];
+    if (std.ascii.eqlIgnoreCase(scheme, "https")) return;
+    if (std.ascii.eqlIgnoreCase(scheme, "http")) return error.InsecureScheme;
+    if (std.ascii.eqlIgnoreCase(scheme, "ws")) return error.InsecureScheme;
+    return error.UnsupportedScheme;
+}
+
+test "validateOutboundUrl accepts https" {
+    try validateOutboundUrl("https://example.com");
+    try validateOutboundUrl("https://example.com/path");
+    try validateOutboundUrl("https://example.com:8443/p?q=1");
+    try validateOutboundUrl("HTTPS://example.com");
+    try validateOutboundUrl("https://[::1]/");
+}
+
+test "validateOutboundUrl rejects http with InsecureScheme" {
+    try std.testing.expectError(error.InsecureScheme, validateOutboundUrl("http://example.com"));
+    try std.testing.expectError(error.InsecureScheme, validateOutboundUrl("HTTP://example.com"));
+    try std.testing.expectError(error.InsecureScheme, validateOutboundUrl("ws://example.com"));
+}
+
+test "validateOutboundUrl rejects unsupported schemes" {
+    try std.testing.expectError(error.UnsupportedScheme, validateOutboundUrl("file:///etc/passwd"));
+    try std.testing.expectError(error.UnsupportedScheme, validateOutboundUrl("ftp://example.com"));
+    try std.testing.expectError(error.UnsupportedScheme, validateOutboundUrl("gopher://example.com"));
+    try std.testing.expectError(error.UnsupportedScheme, validateOutboundUrl("wss://example.com"));
+    try std.testing.expectError(error.UnsupportedScheme, validateOutboundUrl("WSS://example.com"));
+    try std.testing.expectError(error.UnsupportedScheme, validateOutboundUrl("data:,Hello"));
+    try std.testing.expectError(error.UnsupportedScheme, validateOutboundUrl("javascript:alert(1)"));
+    try std.testing.expectError(error.UnsupportedScheme, validateOutboundUrl("blob:https://example.com/id"));
+}
+
+test "validateOutboundUrl rejects malformed input" {
+    try std.testing.expectError(error.MalformedUrl, validateOutboundUrl(""));
+    try std.testing.expectError(error.MalformedUrl, validateOutboundUrl("not a url"));
+    try std.testing.expectError(error.MalformedUrl, validateOutboundUrl("/absolute/path"));
+}

--- a/src/providers/factory.zig
+++ b/src/providers/factory.zig
@@ -517,6 +517,57 @@ pub const ProviderHolder = union(enum) {
 // Tests
 // ════════════════════════════════════════════════════════════════════════════
 
+const ProviderHolderTag = std.meta.Tag(ProviderHolder);
+
+const ProviderHolderCase = struct {
+    name: []const u8,
+    expected_name_substr: []const u8,
+    expected_tag: ProviderHolderTag,
+    base_url: ?[]const u8 = null,
+};
+
+const provider_holder_cases = [_]ProviderHolderCase{
+    .{ .name = "openrouter", .expected_name_substr = "openrouter", .expected_tag = .openrouter },
+    .{ .name = "anthropic", .expected_name_substr = "anthropic", .expected_tag = .anthropic },
+    .{ .name = "openai", .expected_name_substr = "openai", .expected_tag = .openai },
+    .{ .name = "gemini", .expected_name_substr = "gemini", .expected_tag = .gemini },
+    .{ .name = "vertex", .expected_name_substr = "vertex", .expected_tag = .vertex },
+    .{ .name = "ollama", .expected_name_substr = "ollama", .expected_tag = .ollama },
+    .{ .name = "groq", .expected_name_substr = "groq", .expected_tag = .compatible },
+    .{ .name = "claude-cli", .expected_name_substr = "claude", .expected_tag = .claude_cli },
+    .{ .name = "codex-cli", .expected_name_substr = "codex", .expected_tag = .codex_cli },
+    .{ .name = "gemini-cli", .expected_name_substr = "gemini", .expected_tag = .gemini_cli },
+    .{ .name = "openai-codex", .expected_name_substr = "openai", .expected_tag = .openai_codex },
+};
+
+fn providerHolderForCase(allocator: std.mem.Allocator, c: ProviderHolderCase) ProviderHolder {
+    return switch (c.expected_tag) {
+        .claude_cli => .{ .claude_cli = .{
+            .allocator = allocator,
+            .model = "test-claude",
+        } },
+        .codex_cli => .{ .codex_cli = .{
+            .allocator = allocator,
+            .model = "test-codex",
+        } },
+        .gemini_cli => .{ .gemini_cli = .{
+            .allocator = allocator,
+            .model = "test-gemini",
+        } },
+        else => ProviderHolder.fromConfig(
+            allocator,
+            c.name,
+            "test-key",
+            c.base_url,
+            true,
+            null,
+            null,
+            false,
+            null,
+        ),
+    };
+}
+
 test "classifyProvider identifies known providers" {
     try std.testing.expect(classifyProvider("anthropic") == .anthropic_provider);
     try std.testing.expect(classifyProvider("openai") == .openai_provider);
@@ -1034,18 +1085,20 @@ test "detectProviderByApiKey short key" {
     try std.testing.expect(detectProviderByApiKey("ab") == .unknown);
 }
 
-test "ProviderHolder tagged union has all expected fields" {
-    try std.testing.expect(@hasField(ProviderHolder, "openrouter"));
-    try std.testing.expect(@hasField(ProviderHolder, "anthropic"));
-    try std.testing.expect(@hasField(ProviderHolder, "openai"));
-    try std.testing.expect(@hasField(ProviderHolder, "gemini"));
-    try std.testing.expect(@hasField(ProviderHolder, "vertex"));
-    try std.testing.expect(@hasField(ProviderHolder, "ollama"));
-    try std.testing.expect(@hasField(ProviderHolder, "compatible"));
-    try std.testing.expect(@hasField(ProviderHolder, "claude_cli"));
-    try std.testing.expect(@hasField(ProviderHolder, "codex_cli"));
-    try std.testing.expect(@hasField(ProviderHolder, "gemini_cli"));
-    try std.testing.expect(@hasField(ProviderHolder, "openai_codex"));
+test "ProviderHolder case table covers every union variant" {
+    const fields = @typeInfo(ProviderHolder).@"union".fields;
+    try std.testing.expectEqual(fields.len, provider_holder_cases.len);
+
+    inline for (fields) |field| {
+        var seen = false;
+        for (provider_holder_cases) |c| {
+            if (std.mem.eql(u8, field.name, @tagName(c.expected_tag))) {
+                try std.testing.expect(!seen);
+                seen = true;
+            }
+        }
+        try std.testing.expect(seen);
+    }
 }
 
 test "ProviderHolder.fromConfig routes to correct variant" {
@@ -1193,4 +1246,38 @@ test "fromConfigWithApiMode applies responses mode to compatible provider" {
     defer h.deinit();
     try std.testing.expect(h == .compatible);
     try std.testing.expectEqual(compatible.CompatibleApiMode.responses, h.compatible.api_mode);
+}
+
+test "ProviderHolder all variants deinit leaks zero bytes" {
+    const alloc = std.testing.allocator;
+
+    for (provider_holder_cases) |c| {
+        var holder = providerHolderForCase(alloc, c);
+        try std.testing.expectEqual(c.expected_tag, std.meta.activeTag(holder));
+
+        // Touch the vtable getter to ensure the interface is well-formed.
+        const provider = holder.provider();
+        _ = provider;
+        holder.deinit();
+    }
+}
+
+test "every ProviderHolder variant returns non-empty name matching key" {
+    const alloc = std.testing.allocator;
+
+    for (provider_holder_cases) |c| {
+        var holder = providerHolderForCase(alloc, c);
+
+        const provider = holder.provider();
+        const name = provider.getName();
+        try std.testing.expect(name.len > 0);
+
+        const lower_name = try std.ascii.allocLowerString(alloc, name);
+        defer alloc.free(lower_name);
+        const lower_substr = try std.ascii.allocLowerString(alloc, c.expected_name_substr);
+        defer alloc.free(lower_substr);
+        try std.testing.expect(std.mem.indexOf(u8, lower_name, lower_substr) != null);
+
+        holder.deinit();
+    }
 }

--- a/src/security/detect.zig
+++ b/src/security/detect.zig
@@ -203,6 +203,21 @@ test "sandbox storage default initialization" {
     try std.testing.expectEqualStrings(DockerSandbox.default_image, storage.docker.image);
 }
 
+test "detectBest fallback chain on host with no Linux backends" {
+    if (comptime builtin.os.tag == .linux) return error.SkipZigTest;
+    // Zero-init storage so createSandbox does not read undefined defaults
+    // when picking the fallback variant.
+    var storage = SandboxStorage{};
+    const sb = createSandbox(std.testing.allocator, .auto, "/tmp/workspace", &storage);
+    const name = sb.name();
+    try std.testing.expect(
+        std.mem.eql(u8, name, "docker") or std.mem.eql(u8, name, "none"),
+    );
+    try std.testing.expect(!std.mem.eql(u8, name, "landlock"));
+    try std.testing.expect(!std.mem.eql(u8, name, "firejail"));
+    try std.testing.expect(!std.mem.eql(u8, name, "bubblewrap"));
+}
+
 test "auto detect skips version-only linux sandbox shims" {
     if (comptime builtin.os.tag != .linux) return error.SkipZigTest;
 

--- a/src/security/external_content.zig
+++ b/src/security/external_content.zig
@@ -242,3 +242,13 @@ test "ContentSource labels" {
     try std.testing.expectEqualStrings("Web Fetch", ContentSource.web_fetch.label());
     try std.testing.expectEqualStrings("Web Search", ContentSource.web_search.label());
 }
+
+test "wrapExternalContent preserves multibyte UTF-8 content" {
+    const allocator = std.testing.allocator;
+    const utf8_content = "Hello, 世界! 🌍 Москва ñ";
+    const result = try wrapExternalContent(allocator, utf8_content, .web_fetch);
+    defer allocator.free(result);
+    try std.testing.expect(std.mem.indexOf(u8, result, "世界") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "🌍") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "Москва") != null);
+}

--- a/src/security/pairing.zig
+++ b/src/security/pairing.zig
@@ -892,3 +892,50 @@ test "hasPairedTokens false when pairing disabled and no tokens" {
     defer guard.deinit();
     try std.testing.expect(!guard.hasPairedTokens());
 }
+
+test "isAuthenticated rejects tampered, truncated, and substitute bearer tokens" {
+    // The token is SHA-256 hashed before constant-time comparison; any
+    // single-bit change produces an avalanche-different hash. Tampering
+    // only the last byte (as the original test did) would still pass if
+    // the comparator were buggy in a "prefix-match" direction. Tamper at
+    // first / middle / last positions to exercise the full hash boundary,
+    // and add several adversarial-shape negatives that would defeat naive
+    // comparators.
+    var guard = try PairingGuard.init(std.testing.allocator, true, &.{});
+    defer guard.deinit();
+    const code = guard.pairingCode().?;
+    const token = (try guard.tryPair(code)).?;
+    defer std.testing.allocator.free(token);
+
+    try std.testing.expect(guard.isAuthenticated(token));
+    try std.testing.expect(token.len > 4);
+
+    // Position-based tamper: first, middle, last byte.
+    const positions = [_]usize{ 0, token.len / 2, token.len - 1 };
+    for (positions) |pos| {
+        var tampered = try std.testing.allocator.dupe(u8, token);
+        defer std.testing.allocator.free(tampered);
+        tampered[pos] ^= 0xFF;
+        try std.testing.expect(!guard.isAuthenticated(tampered));
+    }
+
+    // Truncation: catches a buggy comparator that would prefix-match.
+    try std.testing.expect(!guard.isAuthenticated(token[0 .. token.len - 1]));
+
+    // Length-mismatch via suffix concatenation: catches a comparator that
+    // ignores trailing bytes.
+    var extended = try std.testing.allocator.alloc(u8, token.len + 1);
+    defer std.testing.allocator.free(extended);
+    @memcpy(extended[0..token.len], token);
+    extended[token.len] = 'x';
+    try std.testing.expect(!guard.isAuthenticated(extended));
+
+    // All-zero token of the same length: catches a default-value-accept bug.
+    const zeros = try std.testing.allocator.alloc(u8, token.len);
+    defer std.testing.allocator.free(zeros);
+    @memset(zeros, 0);
+    try std.testing.expect(!guard.isAuthenticated(zeros));
+
+    // Empty token: boundary case.
+    try std.testing.expect(!guard.isAuthenticated(""));
+}

--- a/src/security/policy.zig
+++ b/src/security/policy.zig
@@ -248,6 +248,7 @@ pub const SecurityPolicy = struct {
         while (iter.next()) |raw_segment| {
             const segment = std.mem.trim(u8, raw_segment, " \t");
             if (segment.len == 0) continue;
+            if (!envAssignmentPrefixesAllowed(segment)) return false;
 
             const cmd_part = skipShellPrefixes(skipEnvAssignments(segment));
             var words = std.mem.tokenizeScalar(u8, cmd_part, ' ');
@@ -508,6 +509,37 @@ fn skipEnvAssignments(s: []const u8) []const u8 {
         }
         return trimmed;
     }
+}
+
+fn envAssignmentPrefixesAllowed(s: []const u8) bool {
+    var rest = s;
+    while (true) {
+        const trimmed = std.mem.trim(u8, rest, " \t");
+        if (trimmed.len == 0) return true;
+
+        const word_end = std.mem.indexOfAny(u8, trimmed, " \t") orelse trimmed.len;
+        const word = trimmed[0..word_end];
+        const eq = std.mem.indexOfScalar(u8, word, '=') orelse return true;
+        if (word.len == 0 or (!std.ascii.isAlphabetic(word[0]) and word[0] != '_')) return true;
+
+        const name = word[0..eq];
+        if (!isSafeTransparentEnvName(name)) return false;
+        rest = if (word_end < trimmed.len) trimmed[word_end..] else "";
+    }
+}
+
+fn isSafeTransparentEnvName(name: []const u8) bool {
+    if (std.mem.eql(u8, name, "LANG")) return true;
+    if (std.mem.eql(u8, name, "LC_ALL")) return true;
+    if (std.mem.startsWith(u8, name, "LC_")) return true;
+    if (std.mem.eql(u8, name, "TZ")) return true;
+    if (std.mem.eql(u8, name, "TERM")) return true;
+    if (std.mem.eql(u8, name, "NO_COLOR")) return true;
+    if (std.mem.eql(u8, name, "CLICOLOR")) return true;
+    if (std.mem.eql(u8, name, "CLICOLOR_FORCE")) return true;
+    if (std.mem.eql(u8, name, "FORCE_COLOR")) return true;
+    if (std.mem.eql(u8, name, "COLORTERM")) return true;
+    return false;
 }
 
 /// Shell builtin prefixes that are transparent to the actual command.
@@ -917,6 +949,10 @@ test "empty command blocked" {
     const p = SecurityPolicy{};
     try std.testing.expect(!p.isCommandAllowed(""));
     try std.testing.expect(!p.isCommandAllowed("   "));
+    // Mixed whitespace (tab + newline) — newline gets normalized into a
+    // segment separator so segments-iterator yields empty entries that the
+    // `if (segment.len == 0) continue;` skip drops, leaving has_cmd = false.
+    try std.testing.expect(!p.isCommandAllowed("\t\n"));
 }
 
 test "command with pipes validates all segments" {
@@ -973,11 +1009,32 @@ test "command injection dollar brace blocked" {
     try std.testing.expect(!p.isCommandAllowed("echo ${IFS}cat${IFS}/etc/passwd"));
 }
 
-test "command env var prefix with allowed cmd" {
+test "command safe env var prefix with allowed cmd" {
     const p = SecurityPolicy{};
-    try std.testing.expect(p.isCommandAllowed("FOO=bar ls"));
     try std.testing.expect(p.isCommandAllowed("LANG=C grep pattern file"));
+    try std.testing.expect(p.isCommandAllowed("LC_ALL=C ls"));
     try std.testing.expect(!p.isCommandAllowed("FOO=bar rm -rf /"));
+}
+
+test "command unsafelisted env var prefix is denied" {
+    // Anything outside the safelist (LANG/LC_*/TZ/TERM/NO_COLOR/CLICOLOR*/
+    // FORCE_COLOR/COLORTERM) is denied per `envAssignmentPrefixesAllowed`.
+    // Each case here pairs the env prefix with `ls` (low-risk, on default
+    // allowlist) so the env-prefix gate is the ONLY thing that can deny —
+    // a previous version of this test used `curl`, which is not in the
+    // default allowlist and is medium-risk, so it was over-determined and
+    // would have passed even if `envAssignmentPrefixesAllowed` were deleted.
+    const p = SecurityPolicy{};
+    try std.testing.expect(!p.isCommandAllowed("FOO=bar ls"));
+    try std.testing.expect(!p.isCommandAllowed("API_KEY=secret ls"));
+    try std.testing.expect(!p.isCommandAllowed("PATH=/tmp ls"));
+    // LD_PRELOAD is the canonical sandbox-escape vector this gate exists to
+    // close. Linux dynamic loader; the macOS equivalent is DYLD_INSERT_LIBRARIES.
+    try std.testing.expect(!p.isCommandAllowed("LD_PRELOAD=/tmp/hook.so ls"));
+    try std.testing.expect(!p.isCommandAllowed("DYLD_INSERT_LIBRARIES=/tmp/hook.dylib ls"));
+    // BASH_ENV is sourced even by non-interactive bash invocations, so it
+    // can run attacker-controlled startup scripts before the real command.
+    try std.testing.expect(!p.isCommandAllowed("BASH_ENV=/tmp/evil.sh ls"));
 }
 
 test "command and chain validates both" {
@@ -2191,4 +2248,47 @@ test "prefix before high-risk command still triggers HighRiskBlocked" {
     try std.testing.expectError(error.HighRiskBlocked, p.validateCommandExecution("time rm -rf /tmp", false));
     try std.testing.expectError(error.HighRiskBlocked, p.validateCommandExecution("nohup rm -rf /tmp", false));
     try std.testing.expectError(error.HighRiskBlocked, p.validateCommandExecution("nice rm -rf /tmp", false));
+}
+
+test "SecurityPolicy denies command not in allowlist" {
+    var p = SecurityPolicy{
+        .allowed_commands = &.{ "ls", "cat" },
+        .block_high_risk_commands = false,
+    };
+    try std.testing.expect(!p.isCommandAllowed("totally_random_cmd"));
+    try std.testing.expectError(error.CommandNotAllowed, p.validateCommandExecution("totally_random_cmd", false));
+}
+
+test "allowlist substring vs token boundary" {
+    // Regression #866: allowlisted command names must not match command prefixes.
+    var p = SecurityPolicy{
+        .allowed_commands = &.{"curl"},
+        .block_high_risk_commands = false,
+    };
+    try std.testing.expect(!p.isCommandAllowed("curlfoo --help"));
+    try std.testing.expect(!p.isCommandAllowed("curlx"));
+    try std.testing.expect(p.isCommandAllowed("curl https://example.com"));
+    try std.testing.expect(p.isCommandAllowed("curl -X POST https://example.com"));
+}
+
+test "safe env-assignment prefix is stripped before allowlist check" {
+    var p = SecurityPolicy{
+        .allowed_commands = &.{"curl"},
+        .block_high_risk_commands = false,
+        .block_medium_risk_commands = false,
+    };
+    try std.testing.expect(p.isCommandAllowed("LANG=C curl https://example.com"));
+    try std.testing.expect(!p.isCommandAllowed("API_KEY=secret curl https://example.com"));
+}
+
+test "env and shell prefixes still reach medium-risk gate" {
+    var p = SecurityPolicy{
+        .allowed_commands = &.{"curl"},
+        .block_high_risk_commands = true,
+        .block_medium_risk_commands = true,
+    };
+    try std.testing.expectError(
+        error.MediumRiskBlocked,
+        p.validateCommandExecution("LANG=C exec curl https://example.com", false),
+    );
 }

--- a/src/security/secrets.zig
+++ b/src/security/secrets.zig
@@ -855,3 +855,39 @@ test "secret store encrypt decrypt multiple values same store" {
         try std.testing.expectEqualStrings(expected, dec);
     }
 }
+
+test "ChaCha20Poly1305.decrypt tag failure returns DecryptionFailed not segfault" {
+    const key: [32]u8 = [_]u8{1} ** 32;
+    const nonce: [12]u8 = [_]u8{2} ** 12;
+    const plaintext = "secret data";
+
+    // Encrypt to a stack buffer.
+    var ct_buf: [64]u8 = undefined;
+    const ct = try encrypt(key, nonce, plaintext, &ct_buf);
+
+    // Tamper the last byte (corrupts the auth tag).
+    var tampered: [64]u8 = ct_buf;
+    tampered[ct.len - 1] ^= 0xFF;
+
+    // Decrypt MUST return error, not segfault. Stack buffer is the
+    // only allowed output target per AGENTS.md §10.
+    var pt_buf: [64]u8 = undefined;
+    const result = decrypt(key, nonce, tampered[0..ct.len], &pt_buf);
+    try std.testing.expectError(error.DecryptionFailed, result);
+
+    // Tamper at start-of-tag boundary (offset = ct.len - 16, the first byte
+    // of Poly1305 tag) — catches a hypothetical regression where only the
+    // tag-trailing byte is checked.
+    var tampered2: [64]u8 = ct_buf;
+    const tag_start = ct.len - 16;
+    tampered2[tag_start] ^= 0xFF;
+    var pt_buf2: [64]u8 = undefined;
+    try std.testing.expectError(error.DecryptionFailed, decrypt(key, nonce, tampered2[0..ct.len], &pt_buf2));
+
+    // Tamper a ciphertext byte (before the tag) — the AEAD must reject
+    // the modification because it invalidates the Poly1305 MAC.
+    var tampered3: [64]u8 = ct_buf;
+    tampered3[0] ^= 0xFF;
+    var pt_buf3: [64]u8 = undefined;
+    try std.testing.expectError(error.DecryptionFailed, decrypt(key, nonce, tampered3[0..ct.len], &pt_buf3));
+}

--- a/src/security/tencent_crypto.zig
+++ b/src/security/tencent_crypto.zig
@@ -331,3 +331,37 @@ test "tc3Sign key too long returns error" {
         tc3Sign(long_key, "2026-03-16", "hunyuan", "payload"),
     );
 }
+
+test "tc3Sign is deterministic and routes every parameter into the digest" {
+    // The KAT in `tc3Sign matches official Tencent Cloud example` already
+    // pins the algorithm against a vendor-published vector — the most
+    // important correctness property. Asserting `differentKey -> differentSig`
+    // is tautological for HMAC-SHA256 and would only fail if the function
+    // ignored its key argument outright, which the KAT already rules out.
+    //
+    // The remaining gap is verifying that the OTHER parameters (date and
+    // service) actually flow into the derived signing key. Tencent's TC3-HMAC
+    // chains HMAC(key=secret, date) -> HMAC(key=hKey, service) -> HMAC(...,
+    // "tc3_request") -> sign. A regression that hard-codes the date or
+    // service salt would still pass a single-input KAT.
+    const key = "secret";
+    const date_a = "2026-05-01";
+    const date_b = "2026-05-02";
+    const service_a = "cvm";
+    const service_b = "hunyuan";
+    const message = "test_message";
+
+    const sig_baseline = try tc3Sign(key, date_a, service_a, message);
+
+    // Same inputs MUST yield the same signature (verifier-side determinism).
+    const sig_repeat = try tc3Sign(key, date_a, service_a, message);
+    try std.testing.expectEqualStrings(&sig_baseline, &sig_repeat);
+
+    // Date salt MUST flow into the derived key.
+    const sig_other_date = try tc3Sign(key, date_b, service_a, message);
+    try std.testing.expect(!std.mem.eql(u8, &sig_baseline, &sig_other_date));
+
+    // Service salt MUST flow into the derived key (multi-tenant isolation).
+    const sig_other_service = try tc3Sign(key, date_a, service_b, message);
+    try std.testing.expect(!std.mem.eql(u8, &sig_baseline, &sig_other_service));
+}

--- a/src/skillforge.zig
+++ b/src/skillforge.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const std_compat = @import("compat");
 const http_util = @import("http_util.zig");
 const json_miniparse = @import("json_miniparse.zig");
@@ -88,6 +89,8 @@ pub fn freeCandidates(allocator: std.mem.Allocator, candidates: []SkillCandidate
 pub fn scout(allocator: std.mem.Allocator, query: []const u8) !std.ArrayList(SkillCandidate) {
     var candidates: std.ArrayList(SkillCandidate) = .empty;
     errdefer candidates.deinit(allocator);
+
+    if (builtin.is_test) return candidates;
 
     // Build the search URL
     const encoded_query = try urlEncode(allocator, query);
@@ -390,9 +393,41 @@ pub fn evaluateCandidate(candidate: SkillCandidate, min_score: f64) EvalResult {
 
 // ── Integration ─────────────────────────────────────────────────
 
-/// Integrate a skill: clone repo to skills_dir/NAME/,
-/// verify structure (agent skill manifests, root.zig, or build.zig).
-pub fn integrate(allocator: std.mem.Allocator, candidate: SkillCandidate, skills_dir: []const u8) !IntegrationResult {
+const CloneRepoFn = *const fn (std.mem.Allocator, []const u8, []const u8) anyerror!void;
+
+fn cloneErrorMessage(err: anyerror) []const u8 {
+    return switch (err) {
+        error.CloneSpawnFailed => "Failed to spawn git clone",
+        error.CloneWaitFailed => "Failed to wait for git clone",
+        error.CloneNonZeroExit => "git clone exited with non-zero status",
+        error.CloneTerminated => "git clone terminated by signal",
+        else => "Failed to clone repository",
+    };
+}
+
+fn cloneRepoWithGit(allocator: std.mem.Allocator, repo_url: []const u8, target_path: []const u8) !void {
+    var child = std_compat.process.Child.init(
+        &.{ "git", "clone", "--depth", "1", repo_url, target_path },
+        allocator,
+    );
+    child.stderr_behavior = .Pipe;
+    child.stdout_behavior = .Pipe;
+
+    child.spawn() catch return error.CloneSpawnFailed;
+    const term = child.wait() catch return error.CloneWaitFailed;
+
+    switch (term) {
+        .exited => |code| if (code != 0) return error.CloneNonZeroExit,
+        else => return error.CloneTerminated,
+    }
+}
+
+fn integrateWithCloneFn(
+    allocator: std.mem.Allocator,
+    candidate: SkillCandidate,
+    skills_dir: []const u8,
+    clone_repo: CloneRepoFn,
+) !IntegrationResult {
     const safe_name = try sanitizePathComponent(candidate.result_name);
 
     // Ensure skills directory exists
@@ -410,47 +445,14 @@ pub fn integrate(allocator: std.mem.Allocator, candidate: SkillCandidate, skills
     const target_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ skills_dir, safe_name });
     defer allocator.free(target_path);
 
-    // Clone the repository using git
-    var child = std_compat.process.Child.init(
-        &.{ "git", "clone", "--depth", "1", candidate.repo_url, target_path },
-        allocator,
-    );
-    child.stderr_behavior = .Pipe;
-    child.stdout_behavior = .Pipe;
-
-    child.spawn() catch {
+    clone_repo(allocator, candidate.repo_url, target_path) catch |err| {
         return IntegrationResult{
             .skill_name = safe_name,
             .install_path = skills_dir,
             .success = false,
-            .error_message = "Failed to spawn git clone",
+            .error_message = cloneErrorMessage(err),
         };
     };
-    const term = child.wait() catch {
-        return IntegrationResult{
-            .skill_name = safe_name,
-            .install_path = skills_dir,
-            .success = false,
-            .error_message = "Failed to wait for git clone",
-        };
-    };
-
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            return IntegrationResult{
-                .skill_name = safe_name,
-                .install_path = skills_dir,
-                .success = false,
-                .error_message = "git clone exited with non-zero status",
-            };
-        },
-        else => return IntegrationResult{
-            .skill_name = safe_name,
-            .install_path = skills_dir,
-            .success = false,
-            .error_message = "git clone terminated by signal",
-        },
-    }
 
     if (!hasSupportedSkillStructure(target_path)) {
         // Remove the cloned directory since it lacks expected structure
@@ -468,6 +470,12 @@ pub fn integrate(allocator: std.mem.Allocator, candidate: SkillCandidate, skills
         .install_path = skills_dir,
         .success = true,
     };
+}
+
+/// Integrate a skill: clone repo to skills_dir/NAME/,
+/// verify structure (agent skill manifests, root.zig, or build.zig).
+pub fn integrate(allocator: std.mem.Allocator, candidate: SkillCandidate, skills_dir: []const u8) !IntegrationResult {
+    return integrateWithCloneFn(allocator, candidate, skills_dir, cloneRepoWithGit);
 }
 
 /// Check if a file exists in a directory.
@@ -800,6 +808,16 @@ test "sanitizePathComponent accepts valid names" {
     try std.testing.expectEqualStrings("test-skill", result);
 }
 
+test "sanitizePathComponent rejects traversal and injection payloads" {
+    try std.testing.expectError(error.EmptyName, sanitizePathComponent(".."));
+    try std.testing.expectError(error.UnsafePath, sanitizePathComponent("../foo"));
+    try std.testing.expectError(error.UnsafePath, sanitizePathComponent("foo/../bar"));
+    try std.testing.expectError(error.UnsafePath, sanitizePathComponent("/etc/passwd"));
+    try std.testing.expectError(error.UnsafePath, sanitizePathComponent("C:\\Windows"));
+    // NUL byte injection
+    try std.testing.expectError(error.UnsafePath, sanitizePathComponent("test\x00skill"));
+}
+
 test "sanitizePathComponent trims dots" {
     const result = try sanitizePathComponent(".hidden.");
     try std.testing.expectEqualStrings("hidden", result);
@@ -948,11 +966,44 @@ test "buildGitHubSearchUrl handles special chars" {
     try std.testing.expect(std.mem.indexOf(u8, url, "foo+%26+bar") != null);
 }
 
-test "scout returns empty list (no network)" {
+test "scout bypasses network in test mode" {
     const allocator = std.testing.allocator;
     var candidates = try scout(allocator, "test");
     defer candidates.deinit(allocator);
+    // builtin.is_test returns empty cleanly without initiating an HTTP request.
     try std.testing.expectEqual(@as(usize, 0), candidates.items.len);
+}
+
+test "parseGitHubSearchResults extracts candidate metadata" {
+    const allocator = std.testing.allocator;
+    var candidates: std.ArrayList(SkillCandidate) = .empty;
+    defer {
+        freeCandidates(allocator, candidates.items);
+        candidates.deinit(allocator);
+    }
+
+    const body =
+        \\{"items":[
+        \\  {"name":"zig-skill","full_name":"owner/zig-skill","html_url":"https://github.com/owner/zig-skill","description":"A Zig skill","language":"Zig","stargazers_count":42,"owner":{"login":"owner"},"license":{"key":"mit"}},
+        \\  {"name":"plain-skill","full_name":"owner/plain-skill","html_url":"https://github.com/owner/plain-skill","description":null,"language":null,"stargazers_count":0,"owner":{"login":"owner"},"license":null}
+        \\]}
+    ;
+
+    try parseGitHubSearchResults(allocator, body, &candidates);
+
+    try std.testing.expectEqual(@as(usize, 2), candidates.items.len);
+    try std.testing.expectEqualStrings("zig-skill", candidates.items[0].result_name);
+    try std.testing.expectEqualStrings("https://github.com/owner/zig-skill", candidates.items[0].repo_url);
+    try std.testing.expectEqualStrings("A Zig skill", candidates.items[0].description);
+    try std.testing.expectEqualStrings("Zig", candidates.items[0].language.?);
+    try std.testing.expectEqual(@as(u64, 42), candidates.items[0].stars);
+    try std.testing.expectEqualStrings("owner", candidates.items[0].owner);
+    try std.testing.expect(candidates.items[0].has_license);
+
+    try std.testing.expectEqualStrings("plain-skill", candidates.items[1].result_name);
+    try std.testing.expectEqualStrings("", candidates.items[1].description);
+    try std.testing.expect(candidates.items[1].language == null);
+    try std.testing.expect(!candidates.items[1].has_license);
 }
 
 test "evaluateCandidate with build.zig gets compatibility boost" {
@@ -1026,4 +1077,98 @@ test "IntegrationResult fields" {
     };
     try std.testing.expect(r.success);
     try std.testing.expect(r.error_message == null);
+}
+
+test "integrate verifies cloned skill structure before success" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const skills_dir = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(skills_dir);
+
+    const c = SkillCandidate{
+        .result_name = "test-skill-1",
+        .repo_url = "https://github.com/test/success",
+        .description = "desc",
+    };
+
+    const Clone = struct {
+        fn run(_: std.mem.Allocator, _: []const u8, target_path: []const u8) !void {
+            try std_compat.fs.makeDirAbsolute(target_path);
+            var buf: [std_compat.fs.max_path_bytes]u8 = undefined;
+            const full = try std.fmt.bufPrint(&buf, "{s}/SKILL.md", .{target_path});
+            const file = try std_compat.fs.createFileAbsolute(full, .{});
+            file.close();
+        }
+    };
+
+    const res = try integrateWithCloneFn(allocator, c, skills_dir, Clone.run);
+    try std.testing.expect(res.success);
+    try std.testing.expectEqualStrings("test-skill-1", res.skill_name);
+
+    const target_path = try std.fmt.allocPrint(allocator, "{s}/test-skill-1", .{skills_dir});
+    defer allocator.free(target_path);
+    try std_compat.fs.accessAbsolute(target_path, .{});
+}
+
+test "integrate reports clone failures before structure checks" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const skills_dir = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(skills_dir);
+
+    const c = SkillCandidate{
+        .result_name = "test-skill-2",
+        .repo_url = "https://github.com/test/source",
+        .description = "desc",
+    };
+
+    const Clone = struct {
+        fn run(_: std.mem.Allocator, _: []const u8, _: []const u8) !void {
+            return error.CloneNonZeroExit;
+        }
+    };
+
+    const res = try integrateWithCloneFn(allocator, c, skills_dir, Clone.run);
+    try std.testing.expect(!res.success);
+    try std.testing.expect(res.error_message != null);
+    try std.testing.expect(std.mem.indexOf(u8, res.error_message.?, "git clone") != null);
+}
+
+test "integrate cleans up repo if supported structure is missing" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const skills_dir = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(skills_dir);
+
+    const c = SkillCandidate{
+        .result_name = "test-skill-3",
+        .repo_url = "https://github.com/test/source",
+        .description = "desc",
+    };
+
+    const Clone = struct {
+        fn run(_: std.mem.Allocator, _: []const u8, target_path: []const u8) !void {
+            try std_compat.fs.makeDirAbsolute(target_path);
+        }
+    };
+
+    const res = try integrateWithCloneFn(allocator, c, skills_dir, Clone.run);
+    try std.testing.expect(!res.success);
+    try std.testing.expect(res.error_message != null);
+    try std.testing.expect(std.mem.indexOf(u8, res.error_message.?, "SKILL.md") != null);
+
+    // Ensure it was cleaned up
+    const target_path = try std.fmt.allocPrint(allocator, "{s}/test-skill-3", .{skills_dir});
+    defer allocator.free(target_path);
+    std_compat.fs.accessAbsolute(target_path, .{}) catch |err| {
+        try std.testing.expectEqual(error.FileNotFound, err);
+        return;
+    };
+    return error.TestExpectedError;
 }

--- a/src/sse_client.zig
+++ b/src/sse_client.zig
@@ -290,7 +290,17 @@ fn ownOrFreeList(list: *std.ArrayList(u8), allocator: std.mem.Allocator) ![]u8 {
 /// Returns a slice of events (caller must free each event.data and the slice itself)
 ///
 /// Safety: Truncates events larger than MAX_EVENT_SIZE to prevent memory exhaustion.
-/// Events are delimited by double newlines (\n\n).
+/// Events are dispatched on double newline delimiters (\n\n). Two non-spec
+/// extensions are deliberate, to support providers that do not strictly
+/// follow the W3C SSE spec on stream termination:
+/// 1. A single trailing newline (\n with no following blank line) flushes
+///    the pending event — many real-world providers (OpenAI/Anthropic
+///    streaming endpoints) end the final event this way after the
+///    `[DONE]` sentinel.
+/// 2. End-of-buffer with a non-empty pending event (no terminating
+///    newline) is also flushed.
+/// Strict W3C consumers can detect this by checking whether the buffer
+/// the parser was handed already had a terminating `\n\n`.
 /// Each data: line contributes to the event data, with newlines preserved.
 ///
 /// Per the W3C SSE specification:
@@ -553,4 +563,56 @@ test "parseField parses field:value correctly" {
     const r4 = parseField("data:");
     try std.testing.expectEqualStrings("data", r4.field);
     try std.testing.expectEqualStrings("", r4.value);
+}
+
+test "parseEvents flushes pending event on single trailing newline" {
+    // The Zig multiline literal below ends with one `\n` (no following blank
+    // line), so the buffer is `event: update\nid: evt-1\ndata: hello\n` —
+    // exactly the shape OpenAI/Anthropic emit for the final event of a
+    // stream. The parser must flush it; a strict W3C parser would discard.
+    // See the parseEvents docstring for the rationale.
+    const allocator = std.testing.allocator;
+    const trailing =
+        \\event: update
+        \\id: evt-1
+        \\data: hello
+        \\
+    ;
+    const events = try parseEvents(allocator, trailing);
+    defer freeEvents(allocator, events);
+
+    try std.testing.expectEqual(@as(usize, 1), events.len);
+    try std.testing.expectEqualStrings("hello", events[0].data);
+    try std.testing.expectEqualStrings("update", events[0].event_type);
+    try std.testing.expectEqualStrings("evt-1", events[0].id);
+}
+
+test "parseEvents flushes pending event at end of buffer with no trailing newline" {
+    // No terminating `\n` at all — exercises the EOF-flush path explicitly,
+    // which the prior test does NOT (single `\n` triggers the empty-line
+    // dispatch path, not the EOF dispatch path).
+    const allocator = std.testing.allocator;
+    const partial = "event: ping\ndata: bye";
+    const events = try parseEvents(allocator, partial);
+    defer freeEvents(allocator, events);
+
+    try std.testing.expectEqual(@as(usize, 1), events.len);
+    try std.testing.expectEqualStrings("bye", events[0].data);
+    try std.testing.expectEqualStrings("ping", events[0].event_type);
+}
+
+test "parseEvents emits [DONE] sentinel as plain data (no special handling here)" {
+    // [DONE] is an OpenAI-specific terminator. parseEvents does NOT recognize
+    // it; the recognition lives in providers/sse.zig and providers/openai_codex.zig
+    // which inspect `event.data` after parsing. This test pins the contract that
+    // this layer is content-agnostic — any future caller that adds [DONE]
+    // handling here would change the behavior other layers depend on.
+    const allocator = std.testing.allocator;
+    const stream = "data: [DONE]\n\n";
+    const events = try parseEvents(allocator, stream);
+    defer freeEvents(allocator, events);
+
+    try std.testing.expectEqual(@as(usize, 1), events.len);
+    try std.testing.expectEqualStrings("[DONE]", events[0].data);
+    try std.testing.expectEqualStrings("", events[0].event_type);
 }

--- a/src/tools/browser.zig
+++ b/src/tools/browser.zig
@@ -61,9 +61,9 @@ pub const BrowserTool = struct {
         const url = root.getString(args, "url") orelse
             return ToolResult.fail("Missing 'url' parameter for open action");
 
-        if (!std.mem.startsWith(u8, url, "https://")) {
+        net_security.validateOutboundUrl(url) catch {
             return ToolResult.fail("Only https:// URLs are supported for security");
-        }
+        };
 
         // On Windows cmd.exe /c start interprets shell metacharacters in the URL.
         // On Unix, open/xdg-open receives the URL as a separate argv element (execvp),
@@ -116,11 +116,11 @@ pub const BrowserTool = struct {
         if (url.len > 0 and url[0] == '-') {
             return ToolResult.fail("Invalid URL for read action");
         }
+        net_security.validateOutboundUrl(url) catch {
+            return ToolResult.fail("Only https:// URLs are supported for security");
+        };
         const uri = std.Uri.parse(url) catch
             return ToolResult.fail("Invalid URL format");
-        if (!std.ascii.eqlIgnoreCase(uri.scheme, "https")) {
-            return ToolResult.fail("Only https:// URLs are supported for security");
-        }
 
         const host = net_security.extractHost(url) orelse
             return ToolResult.fail("Invalid URL: cannot extract host");
@@ -322,6 +322,32 @@ test "browser read rejects http" {
     const result = try t.execute(std.testing.allocator, parsed.value.object);
     try std.testing.expect(!result.success);
     try std.testing.expect(std.mem.indexOf(u8, result.error_msg.?, "https") != null);
+}
+
+test "browser read accepts uppercase https scheme before SSRF checks" {
+    var bt = BrowserTool{};
+    const t = bt.tool();
+    const parsed = try root.parseTestArgs("{\"action\": \"read\", \"url\": \"HTTPS://127.0.0.1/\"}");
+    defer parsed.deinit();
+    const result = try t.execute(std.testing.allocator, parsed.value.object);
+    try std.testing.expect(!result.success);
+    try std.testing.expect(std.mem.indexOf(u8, result.error_msg.?, "local") != null);
+}
+
+test "browser open accepts uppercase https scheme" {
+    // Regression: executeOpen previously used `std.mem.startsWith(u8, url, "https://")`
+    // which rejected `HTTPS://...` even though the scheme is valid per RFC 3986
+    // (case-insensitive). The fix routes through `validateOutboundUrl`. This test
+    // pairs with the same change in browser_open.zig / http_request.zig / web_fetch.zig
+    // and was missing from the original commit.
+    var bt = BrowserTool{};
+    const t = bt.tool();
+    const parsed = try root.parseTestArgs("{\"action\": \"open\", \"url\": \"HTTPS://example.com\"}");
+    defer parsed.deinit();
+    const result = try t.execute(std.testing.allocator, parsed.value.object);
+    defer if (result.output.len > 0) std.testing.allocator.free(result.output);
+    try std.testing.expect(result.success);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "example.com") != null);
 }
 
 test "browser read rejects option-like url" {

--- a/src/tools/browser_open.zig
+++ b/src/tools/browser_open.zig
@@ -32,10 +32,9 @@ pub const BrowserOpenTool = struct {
         const url = root.getString(args, "url") orelse
             return ToolResult.fail("Missing 'url' parameter");
 
-        // Validate URL
-        if (!std.mem.startsWith(u8, url, "https://")) {
+        net_security.validateOutboundUrl(url) catch {
             return ToolResult.fail("Only https:// URLs are allowed");
-        }
+        };
 
         const host = net_security.extractHost(url) orelse {
             return ToolResult.fail("URL must include a host");
@@ -133,6 +132,17 @@ test "browser_open rejects http" {
     const result = try t.execute(std.testing.allocator, parsed.value.object);
     try std.testing.expect(!result.success);
     try std.testing.expect(std.mem.indexOf(u8, result.error_msg.?, "https") != null);
+}
+
+test "browser_open accepts uppercase https scheme before allowlist checks" {
+    const domains = [_][]const u8{"allowed.example"};
+    var bo = BrowserOpenTool{ .allowed_domains = &domains };
+    const t = bo.tool();
+    const parsed = try root.parseTestArgs("{\"url\": \"HTTPS://blocked.example/path\"}");
+    defer parsed.deinit();
+    const result = try t.execute(std.testing.allocator, parsed.value.object);
+    try std.testing.expect(!result.success);
+    try std.testing.expect(std.mem.indexOf(u8, result.error_msg.?, "allowed_domains") != null);
 }
 
 test "browser_open rejects empty allowlist" {

--- a/src/tools/http_request.zig
+++ b/src/tools/http_request.zig
@@ -47,9 +47,9 @@ pub const HttpRequestTool = struct {
         };
 
         // Validate URL scheme - HTTPS only for security (AGENTS.md policy)
-        if (!std.mem.startsWith(u8, url, "https://")) {
+        net_security.validateOutboundUrl(url) catch {
             return ToolResult.fail("Only HTTPS URLs are allowed for security");
-        }
+        };
 
         // Build URI
         const uri = std.Uri.parse(url) catch
@@ -716,6 +716,17 @@ test "execute rejects non-http scheme" {
     const result = try t.execute(std.testing.allocator, parsed.value.object);
     try std.testing.expect(!result.success);
     try std.testing.expect(std.mem.indexOf(u8, result.error_msg.?, "HTTPS") != null);
+}
+
+test "execute accepts uppercase https scheme before allowlist checks" {
+    const domains = [_][]const u8{"allowed.example"};
+    var ht = HttpRequestTool{ .allowed_domains = &domains };
+    const t = ht.tool();
+    const parsed = try root.parseTestArgs("{\"url\": \"HTTPS://blocked.example/path\"}");
+    defer parsed.deinit();
+    const result = try t.execute(std.testing.allocator, parsed.value.object);
+    try std.testing.expect(!result.success);
+    try std.testing.expectEqualStrings("Host is not in http_request.allowed_domains", result.error_msg.?);
 }
 
 test "execute rejects localhost SSRF" {

--- a/src/tools/root.zig
+++ b/src/tools/root.zig
@@ -1366,6 +1366,107 @@ test "bindMemoryTools matches by vtable, not by colliding tool name" {
     try std.testing.expectEqual(@as(usize, 0xDEADBEEF), fake_memory_store_name.sentinel);
 }
 
+test "every tool from allTools exposes non-empty metadata and survives lifecycle" {
+    const alloc = std.testing.allocator;
+
+    // Use a tmp workspace to satisfy path-touching tools.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const ws_path = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(alloc, ".");
+    defer alloc.free(ws_path);
+
+    const tools = try allTools(alloc, ws_path, .{});
+    defer deinitTools(alloc, tools);
+
+    // The ToolVTable name/description/parameters_json slots take an
+    // anyopaque ptr but never dereference it — they return compile-time
+    // T.tool_name / T.tool_description / T.tool_params constants. So this
+    // loop verifies metadata-presence only; the ptr itself is exercised
+    // by `every tool from allTools has useful schema semantics` below
+    // (which calls execute() through the vtable). The leak-free lifecycle
+    // is enforced by std.testing.allocator at scope exit.
+    for (tools) |tool| {
+        const n = tool.name();
+        try std.testing.expect(n.len > 0);
+        const desc = tool.description();
+        try std.testing.expect(desc.len > 0);
+        const params = tool.parametersJson();
+        try std.testing.expect(params.len > 0);
+    }
+}
+
+fn toolSchemaHasRequiredFields(schema_value: JsonValue) !bool {
+    try std.testing.expect(schema_value == .object);
+
+    const type_field = schema_value.object.get("type") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(type_field == .string);
+    try std.testing.expectEqualStrings("object", type_field.string);
+
+    const properties = schema_value.object.get("properties") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(properties == .object);
+
+    const required = schema_value.object.get("required") orelse return false;
+    try std.testing.expect(required == .array);
+
+    var has_required = false;
+    for (required.array.items) |field| {
+        try std.testing.expect(field == .string);
+        has_required = true;
+        try std.testing.expect(properties.object.contains(field.string));
+    }
+
+    return has_required;
+}
+
+test "every tool from allTools has useful schema semantics" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const ws_path = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(alloc, ".");
+    defer alloc.free(ws_path);
+
+    const browser_domains = [_][]const u8{"example.com"};
+    const tools = try allTools(alloc, ws_path, .{
+        .http_enabled = true,
+        .browser_enabled = true,
+        .screenshot_enabled = true,
+        .browser_open_domains = &browser_domains,
+    });
+    defer deinitTools(alloc, tools);
+
+    var seen_names = std.StringHashMap(void).init(alloc);
+    defer seen_names.deinit();
+
+    for (tools) |tool| {
+        const name = tool.name();
+        try std.testing.expect(name.len > 0);
+        const gop = try seen_names.getOrPut(name);
+        try std.testing.expect(!gop.found_existing);
+
+        const description = tool.description();
+        try std.testing.expect(description.len > 0);
+        try std.testing.expectEqualStrings(description, std.mem.trim(u8, description, " \t\r\n"));
+
+        const params = tool.parametersJson();
+        try std.testing.expect(params.len > 0);
+
+        const parsed = try std.json.parseFromSlice(std.json.Value, alloc, params, .{});
+        defer parsed.deinit();
+
+        if (try toolSchemaHasRequiredFields(parsed.value)) {
+            const empty_args = try parseTestArgs("{}");
+            defer empty_args.deinit();
+
+            var result_arena = std.heap.ArenaAllocator.init(alloc);
+            defer result_arena.deinit();
+
+            const result = try tool.execute(result_arena.allocator(), empty_args.value.object);
+            try std.testing.expect(!result.success);
+            try std.testing.expect(result.output.len > 0 or (result.error_msg != null and result.error_msg.?.len > 0));
+        }
+    }
+}
+
 test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/tools/web_fetch.zig
+++ b/src/tools/web_fetch.zig
@@ -43,9 +43,9 @@ pub const WebFetchTool = struct {
             return ToolResult.fail("Missing required 'url' parameter");
 
         // Validate URL scheme - HTTPS only for security (AGENTS.md policy)
-        if (!std.mem.startsWith(u8, url, "https://")) {
+        net_security.validateOutboundUrl(url) catch {
             return ToolResult.fail("Only HTTPS URLs are allowed for security");
-        }
+        };
 
         const uri = std.Uri.parse(url) catch
             return ToolResult.fail("Invalid URL format");
@@ -64,7 +64,7 @@ pub const WebFetchTool = struct {
 
         // Reject non-allowlisted hosts when allowlist is configured
         if (self.allowed_domains.len > 0 and !is_allowlisted) {
-            return ToolResult.fail("Host is not in http_request.allowed_domains");
+            return ToolResult.fail("Host is not in web_fetch.allowed_domains");
         }
 
         // SSRF protection: skip for allowlisted hosts (fixes #393).
@@ -506,6 +506,16 @@ test "WebFetchTool non-HTTP scheme rejected" {
     try testing.expect(std.mem.indexOf(u8, result.error_msg.?, "HTTPS") != null);
 }
 
+test "WebFetchTool accepts uppercase https scheme before allowlist checks" {
+    const domains = [_][]const u8{"allowed.example"};
+    var wft = WebFetchTool{ .allowed_domains = &domains };
+    const parsed = try root.parseTestArgs("{\"url\":\"HTTPS://blocked.example/path\"}");
+    defer parsed.deinit();
+    const result = try wft.execute(testing.allocator, parsed.value.object);
+    try testing.expect(!result.success);
+    try testing.expectEqualStrings("Host is not in web_fetch.allowed_domains", result.error_msg.?);
+}
+
 test "WebFetchTool localhost blocked" {
     var wft = WebFetchTool{};
     const parsed = try root.parseTestArgs("{\"url\":\"https://localhost:8080/api\"}");
@@ -547,7 +557,7 @@ test "WebFetchTool blocked when host is not in allowlist" {
     defer parsed.deinit();
     const result = try wft.execute(testing.allocator, parsed.value.object);
     try testing.expect(!result.success);
-    try testing.expectEqualStrings("Host is not in http_request.allowed_domains", result.error_msg.?);
+    try testing.expectEqualStrings("Host is not in web_fetch.allowed_domains", result.error_msg.?);
 }
 
 test "WebFetchTool allowlisted local host is allowed (fixes #393)" {

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -3,6 +3,7 @@
 //! Supports both `wss://` and `ws://` transports.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const std_compat = @import("compat");
 
 const log = std.log.scoped(.websocket);
@@ -625,6 +626,72 @@ pub fn applyMask(payload: []u8, mask_key: [4]u8) void {
     for (payload, 0..) |*b, i| b.* ^= mask_key[i % 4];
 }
 
+fn createWsTestSocketPair() ![2]std.posix.socket_t {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
+        @TypeOf(std.posix.system.socketpair) == void)
+    {
+        return error.SkipZigTest;
+    } else {
+        var sockets: [2]std.posix.socket_t = undefined;
+        while (true) {
+            switch (std.posix.errno(std.posix.system.socketpair(
+                std.posix.AF.UNIX,
+                std.posix.SOCK.STREAM,
+                0,
+                &sockets,
+            ))) {
+                .SUCCESS => return sockets,
+                .INTR => continue,
+                else => return error.SkipZigTest,
+            }
+        }
+    }
+}
+
+fn writeAllFd(fd: std.posix.fd_t, bytes: []const u8) !void {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    } else {
+        var offset: usize = 0;
+        while (offset < bytes.len) {
+            const rc = std.posix.system.write(fd, bytes[offset..].ptr, bytes.len - offset);
+            switch (std.posix.errno(rc)) {
+                .SUCCESS => {
+                    const n: usize = @intCast(rc);
+                    if (n == 0) return error.Unexpected;
+                    offset += n;
+                },
+                .INTR => continue,
+                else => return error.Unexpected,
+            }
+        }
+    }
+}
+
+fn readExactFd(fd: std.posix.fd_t, buf: []u8) !void {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    } else {
+        var offset: usize = 0;
+        while (offset < buf.len) {
+            const n = try std.posix.read(fd, buf[offset..]);
+            if (n == 0) return error.ConnectionClosed;
+            offset += n;
+        }
+    }
+}
+
+fn writeServerFrame(fd: std.posix.fd_t, fin: bool, opcode: Opcode, payload: []const u8) !void {
+    if (payload.len > 125) return error.TestUnexpectedResult;
+
+    const header = [_]u8{
+        (if (fin) @as(u8, 0x80) else 0) | @as(u8, @intFromEnum(opcode)),
+        @intCast(payload.len),
+    };
+    try writeAllFd(fd, &header);
+    try writeAllFd(fd, payload);
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // Tests
 // ════════════════════════════════════════════════════════════════════════════
@@ -908,6 +975,65 @@ test "ws buildFrame zero-len payload close" {
     try std.testing.expectEqual(@as(u8, 0x80), buf[1]); // MASK=1, len=0
 }
 
+test "ws readMessage aggregates fragmented text and binary frames" {
+    const sockets = try createWsTestSocketPair();
+    defer std.Io.Threaded.closeFd(sockets[1]);
+
+    var client = WsClient{
+        .allocator = std.testing.allocator,
+        .stream = .{ .handle = sockets[0] },
+        .tls = null,
+        .write_mu = .{},
+    };
+    defer client.deinit();
+
+    try writeServerFrame(sockets[1], false, .text, "hel");
+    try writeServerFrame(sockets[1], true, .continuation, "lo");
+    try writeServerFrame(sockets[1], false, .binary, &.{ 0x01, 0x02 });
+    try writeServerFrame(sockets[1], true, .continuation, &.{ 0x03, 0x04 });
+
+    const text_msg = (try client.readMessage()) orelse return error.TestUnexpectedResult;
+    defer std.testing.allocator.free(text_msg.payload);
+    try std.testing.expectEqual(Opcode.text, text_msg.opcode);
+    try std.testing.expectEqualStrings("hello", text_msg.payload);
+
+    const binary_msg = (try client.readMessage()) orelse return error.TestUnexpectedResult;
+    defer std.testing.allocator.free(binary_msg.payload);
+    try std.testing.expectEqual(Opcode.binary, binary_msg.opcode);
+    try std.testing.expectEqualSlices(u8, &.{ 0x01, 0x02, 0x03, 0x04 }, binary_msg.payload);
+}
+
+test "ws readFrame auto-pongs ping and returns null on close frame" {
+    const sockets = try createWsTestSocketPair();
+    defer std.Io.Threaded.closeFd(sockets[1]);
+
+    var client = WsClient{
+        .allocator = std.testing.allocator,
+        .stream = .{ .handle = sockets[0] },
+        .tls = null,
+        .write_mu = .{},
+    };
+    defer client.deinit();
+
+    try writeServerFrame(sockets[1], true, .ping, "p");
+
+    const ping_frame = (try client.readFrame()) orelse return error.TestUnexpectedResult;
+    defer if (ping_frame.payload.len > 0) std.testing.allocator.free(ping_frame.payload);
+    try std.testing.expectEqual(Opcode.ping, ping_frame.opcode);
+    try std.testing.expectEqualStrings("p", ping_frame.payload);
+
+    var pong: [7]u8 = undefined;
+    try readExactFd(sockets[1], &pong);
+    try std.testing.expectEqual(@as(u8, 0x8A), pong[0]);
+    try std.testing.expect((pong[1] & 0x80) != 0);
+    try std.testing.expectEqual(@as(u8, 1), pong[1] & 0x7F);
+    try std.testing.expectEqual(@as(u8, 'p'), pong[6] ^ pong[2]);
+
+    try writeServerFrame(sockets[1], true, .close, &.{});
+    const closed = try client.readFrame();
+    try std.testing.expect(closed == null);
+}
+
 // Regression: v2026.3.12 applied a blanket `n == 0 → ConnectionClosed` check
 // to both TLS and plain socket paths. TLS readVec may return 0 while it
 // refills its internal buffer or processes post-handshake records, so only
@@ -998,4 +1124,32 @@ test "ws readExact plain reads data then ConnectionClosed on EOF" {
     // Next read hits EOF
     var buf2: [1]u8 = undefined;
     try std.testing.expectError(error.ConnectionClosed, client.readExact(&buf2));
+}
+
+test "readFrame rejects oversized payload claim before allocation" {
+    // Verifies the FrameTooLarge guard (readFrame line: payload_len > 4 MiB)
+    // triggers before any heap allocation. We send only the 10-byte header
+    // claiming 5 MiB — readFrame must return error.FrameTooLarge without
+    // attempting to allocate or read the (absent) payload bytes.
+    const sockets = try createWsTestSocketPair();
+    defer std.Io.Threaded.closeFd(sockets[1]);
+
+    var client = WsClient{
+        .allocator = std.testing.allocator,
+        .stream = .{ .handle = sockets[0] },
+        .tls = null,
+        .write_mu = .{},
+    };
+    defer client.deinit();
+
+    // 5 MiB = 5 * 1024 * 1024 = 0x00_00_00_00_00_50_00_00
+    const oversized_header = [_]u8{
+        0x82, // FIN=1, opcode=binary
+        0x7F, // payload_len=127 → 8-byte extended length follows
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x00, 0x00, // 5 MiB
+    };
+    try writeAllFd(sockets[1], &oversized_header);
+    (std_compat.net.Stream{ .handle = sockets[1] }).shutdown(.send) catch {};
+
+    try std.testing.expectError(error.FrameTooLarge, client.readFrame());
 }


### PR DESCRIPTION
## English

### Summary

This PR adds critical Zig coverage for nullclaw's high-risk runtime contracts and fixes a few production issues exposed by that coverage. The intent is not test volume; the added tests document expected behavior at ownership, lifecycle, security, routing, parser, and registry boundaries.

### What Changed

- Added contract sweeps for provider factories, tool schemas, channel catalog behavior, and stateful memory backends.
- Strengthened lifecycle coverage for agent compaction, daemon outbound routing, cron cleanup, Slack start/stop concurrency, and Telegram double-stop safety.
- Hardened security and network boundaries: HTTPS-only outbound URL validation, shell env-prefix policy, pairing token tamper cases, secret decryption tamper cases, gateway idempotency ownership, and malformed webhook JSON rejection.
- Added protocol/parser coverage for SSE EOF flushing semantics, WebSocket fragmentation/ping/close behavior, and SkillForge GitHub parsing/integration validation.
- Removed or rewrote low-signal tests that duplicated stricter coverage, asserted implementation trivia, or risked pinning incorrect behavior.

### Validation

- `zig build test --summary all` passed: `6962/6971` tests passed, `9` skipped; MaxRSS observed around `298M-300M`.
- `zig build -Doptimize=ReleaseSmall` passed.
- `wc -c zig-out/bin/nullclaw`: `4,682,648` bytes.
- `git diff --check` passed.

## 中文

### 概要

这个 PR 为 nullclaw 的高风险运行时契约补充了关键 Zig 测试，并修复了这些测试暴露出的少量生产代码问题。目标不是增加测试数量，而是用测试明确系统在所有权、生命周期、安全边界、路由、解析器和注册表边界上的正确行为。

### 主要变更

- 为 provider factory、tool schema、channel catalog 行为以及有状态 memory backend 增加契约级覆盖。
- 加强生命周期测试：agent compaction、daemon 出站路由、cron 清理、Slack start/stop 并发，以及 Telegram double-stop 安全性。
- 加固安全和网络边界：仅允许 HTTPS 的出站 URL 校验、shell 环境变量前缀策略、pairing token 篡改场景、secret 解密篡改场景、gateway idempotency key 所有权，以及畸形 webhook JSON 拒绝。
- 增加协议和解析器覆盖：SSE EOF flush 语义、WebSocket 分片/ping/close 行为，以及 SkillForge GitHub 解析和集成校验。
- 删除或重写低价值测试，避免重复已有更严格覆盖、断言实现细节，或把错误行为固化成测试契约。

### 验证

- `zig build test --summary all` 通过：`6962/6971` 个测试通过，`9` 个跳过；MaxRSS 约 `298M-300M`。
- `zig build -Doptimize=ReleaseSmall` 通过。
- `wc -c zig-out/bin/nullclaw`：`4,682,648` bytes。
- `git diff --check` 通过。