### PR TITLE
Add native ACP stdio adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ See [Gateway API docs](docs/en/gateway-api.md) for full A2A reference including 
 | `onboard --interactive` | Full interactive wizard |
 | `onboard --channels-only` | Reconfigure channels/allowlists only |
 | `agent -m "..."` | Single message mode |
+| `acp` | Start the Agent Client Protocol stdio adapter for ACP-compatible editors |
 | `agent` | Interactive chat mode |
 | `gateway` | Start long-running runtime (default: `127.0.0.1:3000`) |
 | `service install\|start\|stop\|restart\|status\|uninstall` | Manage background service |

--- a/docs/en/commands.md
+++ b/docs/en/commands.md
@@ -46,6 +46,8 @@ This page groups the NullClaw CLI by task so you can find the right command quic
 | `nullclaw agent --workspace /path/to/workspace -m "..."` | Run the agent against a specific workspace for this process |
 | `nullclaw agent --skill news-digest -m "..."` | Run a single prompt with a named skill active |
 | `nullclaw agent` | Start interactive chat mode |
+| `nullclaw acp` | Run the Agent Client Protocol stdio adapter for ACP-compatible editors |
+| `nullclaw acp --provider openai --model gpt-5.2` | Pin the ACP adapter to a provider/model for editor-launched sessions |
 
 ### Interactive model routing
 
@@ -59,6 +61,7 @@ This page groups the NullClaw CLI by task so you can find the right command quic
 - If no `model_routes` are configured, `/model auto` still clears the pin and returns the session to the configured default model.
 - Starting `nullclaw agent` with `--model` or `--provider` also pins the run and bypasses `model_routes`.
 - Starting `nullclaw agent` with `--skill <name>` activates that skill before the first message or REPL turn.
+- `nullclaw acp` speaks newline-delimited JSON-RPC on stdio. Editors create ACP sessions with an absolute `cwd`; NullClaw forwards that cwd as the workspace for `agent invoke`.
 
 ## Runtime and operations
 

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -32,6 +32,8 @@
 | `nullclaw agent --workspace /path/to/workspace -m "..."` | 本次进程使用指定 workspace 运行 agent |
 | `nullclaw agent --skill news-digest -m "..."` | 在指定 skill 激活的状态下执行单条消息 |
 | `nullclaw agent` | 交互会话模式 |
+| `nullclaw acp` | 启动面向 ACP 兼容编辑器的 stdio 适配器 |
+| `nullclaw acp --provider openai --model gpt-5.2` | 为编辑器启动的 ACP 会话固定 provider/model |
 
 ### 交互式模型路由
 
@@ -45,6 +47,7 @@
 - 如果没有配置 `model_routes`，`/model auto` 仍然会清除 pin，并把会话切回配置里的默认模型。
 - 通过 `--model` 或 `--provider` 启动 `nullclaw agent` 时，也会把该次运行 pin 到显式模型，从而绕过 `model_routes`。
 - 通过 `--skill <name>` 启动 `nullclaw agent` 时，会在第一条消息或 REPL 轮次前激活该 skill。
+- `nullclaw acp` 通过 stdio 使用按行分隔的 JSON-RPC。编辑器创建 ACP 会话时传入绝对 `cwd`；NullClaw 会把它作为 `agent invoke` 的 workspace。
 
 ## 运行与运维
 

--- a/src/acp.zig
+++ b/src/acp.zig
@@ -1,0 +1,793 @@
+const std = @import("std");
+const std_compat = @import("compat");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
+
+const protocol_version: i64 = 1;
+const max_line_bytes: usize = 1024 * 1024;
+const max_child_output: usize = 4 * 1024 * 1024;
+
+const Options = struct {
+    provider: ?[]const u8 = null,
+    model: ?[]const u8 = null,
+    temperature: ?[]const u8 = null,
+    agent_name: ?[]const u8 = null,
+    skill_name: ?[]const u8 = null,
+};
+
+const ParseOptionsResult = union(enum) {
+    serve: Options,
+    help,
+    version,
+};
+
+const Session = struct {
+    id: []const u8,
+    cwd: []const u8,
+
+    fn deinit(self: Session, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.cwd);
+    }
+};
+
+const EmptyObject = struct {};
+
+const Server = struct {
+    allocator: std.mem.Allocator,
+    options: Options,
+    sessions: std.StringHashMap(Session),
+    next_session: u64 = 1,
+    initialized: bool = false,
+
+    fn init(allocator: std.mem.Allocator, options: Options) Server {
+        return .{
+            .allocator = allocator,
+            .options = options,
+            .sessions = std.StringHashMap(Session).init(allocator),
+        };
+    }
+
+    fn deinit(self: *Server) void {
+        var it = self.sessions.valueIterator();
+        while (it.next()) |session| session.deinit(self.allocator);
+        self.sessions.deinit();
+    }
+
+    fn handleLine(self: *Server, out: anytype, raw_line: []const u8) !void {
+        const line = std.mem.trim(u8, raw_line, " \t\r\n");
+        if (line.len == 0) return;
+
+        var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, line, .{}) catch {
+            try writeErrorNull(self.allocator, out, -32700, "Parse error");
+            return;
+        };
+        defer parsed.deinit();
+
+        const root = switch (parsed.value) {
+            .object => |object| object,
+            else => {
+                try writeErrorNull(self.allocator, out, -32600, "Invalid request");
+                return;
+            },
+        };
+
+        const id = root.get("id");
+        const jsonrpc = getStringField(root, "jsonrpc") orelse {
+            if (id) |request_id| try writeError(self.allocator, out, request_id, -32600, "Missing jsonrpc");
+            return;
+        };
+        if (!std.mem.eql(u8, jsonrpc, "2.0")) {
+            if (id) |request_id| try writeError(self.allocator, out, request_id, -32600, "Invalid jsonrpc");
+            return;
+        }
+
+        const method = getStringField(root, "method") orelse {
+            if (id) |request_id| try writeError(self.allocator, out, request_id, -32600, "Missing method");
+            return;
+        };
+        const params = root.get("params");
+
+        if (std.mem.eql(u8, method, "initialize")) {
+            if (id) |request_id| try self.handleInitialize(out, request_id, params);
+            return;
+        }
+
+        if (!self.initialized) {
+            if (id) |request_id| try writeError(self.allocator, out, request_id, -32002, "Connection not initialized");
+            return;
+        }
+
+        if (std.mem.eql(u8, method, "session/new")) {
+            if (id) |request_id| try self.handleSessionNew(out, request_id, params);
+            return;
+        }
+        if (std.mem.eql(u8, method, "session/prompt")) {
+            if (id) |request_id| try self.handleSessionPrompt(out, request_id, params);
+            return;
+        }
+        if (std.mem.eql(u8, method, "session/cancel")) {
+            if (id) |request_id| try writeResult(self.allocator, out, request_id, @as(?[]const u8, null));
+            return;
+        }
+
+        if (id) |request_id| try writeError(self.allocator, out, request_id, -32601, "Method not found");
+    }
+
+    fn handleInitialize(self: *Server, out: anytype, id: std.json.Value, params: ?std.json.Value) !void {
+        _ = readProtocolVersion(params) catch |err| switch (err) {
+            error.MissingProtocolVersion => {
+                try writeError(self.allocator, out, id, -32602, "Missing protocolVersion");
+                return;
+            },
+            error.InvalidProtocolVersion => {
+                try writeError(self.allocator, out, id, -32602, "Invalid protocolVersion");
+                return;
+            },
+        };
+
+        self.initialized = true;
+        const result = .{
+            .protocolVersion = protocol_version,
+            .agentCapabilities = .{
+                .loadSession = false,
+                .promptCapabilities = .{
+                    .image = false,
+                    .audio = false,
+                    .embeddedContext = true,
+                },
+                .mcpCapabilities = .{
+                    .http = false,
+                    .sse = false,
+                },
+                .sessionCapabilities = EmptyObject{},
+            },
+            .agentInfo = .{
+                .name = "nullclaw",
+                .title = "NullClaw ACP",
+                .version = build_options.version,
+            },
+            .authMethods = [_][]const u8{},
+        };
+        try writeResult(self.allocator, out, id, result);
+    }
+
+    fn handleSessionNew(self: *Server, out: anytype, id: std.json.Value, params: ?std.json.Value) !void {
+        const cwd = readNewSessionCwd(params) catch |err| switch (err) {
+            error.MissingParams => {
+                try writeError(self.allocator, out, id, -32602, "Missing params");
+                return;
+            },
+            error.InvalidParams => {
+                try writeError(self.allocator, out, id, -32602, "Invalid params");
+                return;
+            },
+            error.MissingCwd => {
+                try writeError(self.allocator, out, id, -32602, "Missing cwd");
+                return;
+            },
+            error.RelativeCwd => {
+                try writeError(self.allocator, out, id, -32602, "cwd must be absolute");
+                return;
+            },
+        };
+
+        const session_id = try std.fmt.allocPrint(self.allocator, "acp-{d}", .{self.next_session});
+        self.next_session += 1;
+
+        const owned_cwd = self.allocator.dupe(u8, cwd) catch |err| {
+            self.allocator.free(session_id);
+            return err;
+        };
+        const session = Session{ .id = session_id, .cwd = owned_cwd };
+        self.sessions.put(session_id, session) catch |err| {
+            session.deinit(self.allocator);
+            return err;
+        };
+
+        try writeResult(self.allocator, out, id, .{ .sessionId = session_id });
+    }
+
+    fn handleSessionPrompt(self: *Server, out: anytype, id: std.json.Value, params: ?std.json.Value) !void {
+        const params_obj = switch (params orelse {
+            try writeError(self.allocator, out, id, -32602, "Missing params");
+            return;
+        }) {
+            .object => |object| object,
+            else => {
+                try writeError(self.allocator, out, id, -32602, "Invalid params");
+                return;
+            },
+        };
+
+        const session_id = getStringField(params_obj, "sessionId") orelse {
+            try writeError(self.allocator, out, id, -32602, "Missing sessionId");
+            return;
+        };
+        const session = self.sessions.get(session_id) orelse {
+            try writeError(self.allocator, out, id, -32602, "Unknown sessionId");
+            return;
+        };
+        const prompt_value = params_obj.get("prompt") orelse {
+            try writeError(self.allocator, out, id, -32602, "Missing prompt");
+            return;
+        };
+        const prompt = promptToText(self.allocator, prompt_value) catch |err| switch (err) {
+            error.InvalidPromptPayload => {
+                try writeError(self.allocator, out, id, -32602, "Invalid prompt");
+                return;
+            },
+            else => return err,
+        };
+        defer self.allocator.free(prompt);
+
+        try self.sendPlan(out, session_id);
+        try self.sendToolCall(out, session_id, "nullclaw-agent-invoke", "Run nullclaw agent turn", "pending");
+        try self.sendToolCallUpdate(out, session_id, "nullclaw-agent-invoke", "in_progress", "Running `nullclaw agent invoke --json`");
+
+        const invoked = invokeNullclaw(self.allocator, self.options, session, prompt) catch |err| {
+            const msg = try std.fmt.allocPrint(self.allocator, "nullclaw invocation failed: {s}", .{@errorName(err)});
+            defer self.allocator.free(msg);
+            try self.sendToolCallUpdate(out, session_id, "nullclaw-agent-invoke", "failed", msg);
+            try self.sendAgentText(out, session_id, msg);
+            try writeResult(self.allocator, out, id, .{ .stopReason = "refusal" });
+            return;
+        };
+        defer invoked.deinit(self.allocator);
+
+        if (invoked.ok) {
+            try self.sendToolCallUpdate(out, session_id, "nullclaw-agent-invoke", "completed", "nullclaw turn completed");
+            try self.sendAgentText(out, session_id, invoked.response);
+            try writeResult(self.allocator, out, id, .{ .stopReason = "end_turn" });
+        } else {
+            try self.sendToolCallUpdate(out, session_id, "nullclaw-agent-invoke", "failed", invoked.response);
+            try self.sendAgentText(out, session_id, invoked.response);
+            try writeResult(self.allocator, out, id, .{ .stopReason = "refusal" });
+        }
+    }
+
+    fn sendPlan(self: *Server, out: anytype, session_id: []const u8) !void {
+        try writeNotification(self.allocator, out, .{
+            .jsonrpc = "2.0",
+            .method = "session/update",
+            .params = .{
+                .sessionId = session_id,
+                .update = .{
+                    .sessionUpdate = "plan",
+                    .entries = .{
+                        .{ .content = "Translate ACP prompt into a nullclaw turn", .priority = "high", .status = "completed" },
+                        .{ .content = "Invoke the local nullclaw runtime", .priority = "high", .status = "in_progress" },
+                        .{ .content = "Return the response through ACP updates", .priority = "medium", .status = "pending" },
+                    },
+                },
+            },
+        });
+    }
+
+    fn sendToolCall(self: *Server, out: anytype, session_id: []const u8, tool_call_id: []const u8, title: []const u8, status: []const u8) !void {
+        try writeNotification(self.allocator, out, .{
+            .jsonrpc = "2.0",
+            .method = "session/update",
+            .params = .{
+                .sessionId = session_id,
+                .update = .{
+                    .sessionUpdate = "tool_call",
+                    .toolCallId = tool_call_id,
+                    .title = title,
+                    .kind = "execute",
+                    .status = status,
+                },
+            },
+        });
+    }
+
+    fn sendToolCallUpdate(self: *Server, out: anytype, session_id: []const u8, tool_call_id: []const u8, status: []const u8, text: []const u8) !void {
+        try writeNotification(self.allocator, out, .{
+            .jsonrpc = "2.0",
+            .method = "session/update",
+            .params = .{
+                .sessionId = session_id,
+                .update = .{
+                    .sessionUpdate = "tool_call_update",
+                    .toolCallId = tool_call_id,
+                    .status = status,
+                    .content = .{
+                        .{
+                            .type = "content",
+                            .content = .{ .type = "text", .text = text },
+                        },
+                    },
+                },
+            },
+        });
+    }
+
+    fn sendAgentText(self: *Server, out: anytype, session_id: []const u8, text: []const u8) !void {
+        try writeNotification(self.allocator, out, .{
+            .jsonrpc = "2.0",
+            .method = "session/update",
+            .params = .{
+                .sessionId = session_id,
+                .update = .{
+                    .sessionUpdate = "agent_message_chunk",
+                    .content = .{
+                        .type = "text",
+                        .text = text,
+                    },
+                },
+            },
+        });
+    }
+};
+
+const InvokeResult = struct {
+    ok: bool,
+    response: []const u8,
+    stdout: []const u8,
+    stderr: []const u8,
+
+    fn deinit(self: InvokeResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.response);
+        allocator.free(self.stdout);
+        allocator.free(self.stderr);
+    }
+};
+
+pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    const parsed_options = parseOptions(args) catch |err| {
+        try printOptionError(err);
+        std_compat.process.exit(1);
+    };
+
+    switch (parsed_options) {
+        .help => {
+            try printUsage(std_compat.fs.File.stdout());
+            return;
+        },
+        .version => {
+            try printVersion(std_compat.fs.File.stdout());
+            return;
+        },
+        .serve => |options| {
+            var server = Server.init(allocator, options);
+            defer server.deinit();
+            try serveStdio(allocator, &server);
+        },
+    }
+}
+
+fn serveStdio(allocator: std.mem.Allocator, server: *Server) !void {
+    var out_buffer: [64 * 1024]u8 = undefined;
+    var stdout = std_compat.fs.File.stdout().writer(&out_buffer);
+    const out = &stdout.interface;
+
+    var pending: std.ArrayListUnmanaged(u8) = .empty;
+    defer pending.deinit(allocator);
+
+    var read_buffer: [16 * 1024]u8 = undefined;
+    const stdin = std_compat.fs.File.stdin();
+    while (true) {
+        const n = try stdin.read(&read_buffer);
+        if (n == 0) break;
+
+        if (pending.items.len + n > max_line_bytes) return error.RequestTooLarge;
+        try pending.appendSlice(allocator, read_buffer[0..n]);
+
+        var start: usize = 0;
+        while (std.mem.indexOfScalar(u8, pending.items[start..], '\n')) |relative_pos| {
+            const pos = start + relative_pos;
+            try server.handleLine(out, pending.items[start..pos]);
+            start = pos + 1;
+        }
+        if (start > 0) {
+            const remaining = pending.items[start..];
+            std.mem.copyForwards(u8, pending.items[0..remaining.len], remaining);
+            pending.items.len = remaining.len;
+        }
+    }
+
+    if (std.mem.trim(u8, pending.items, " \t\r\n").len > 0) {
+        try server.handleLine(out, pending.items);
+    }
+
+    try out.flush();
+}
+
+fn parseOptions(args: []const []const u8) !ParseOptionsResult {
+    var options = Options{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--provider")) {
+            i += 1;
+            if (i >= args.len) return error.MissingProvider;
+            options.provider = args[i];
+        } else if (std.mem.eql(u8, arg, "--model")) {
+            i += 1;
+            if (i >= args.len) return error.MissingModel;
+            options.model = args[i];
+        } else if (std.mem.eql(u8, arg, "--temperature")) {
+            i += 1;
+            if (i >= args.len) return error.MissingTemperature;
+            options.temperature = args[i];
+        } else if (std.mem.eql(u8, arg, "--agent")) {
+            i += 1;
+            if (i >= args.len) return error.MissingAgent;
+            options.agent_name = args[i];
+        } else if (std.mem.eql(u8, arg, "--skill")) {
+            i += 1;
+            if (i >= args.len) return error.MissingSkill;
+            options.skill_name = args[i];
+        } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            return .help;
+        } else if (std.mem.eql(u8, arg, "--version")) {
+            return .version;
+        } else {
+            return error.UnknownOption;
+        }
+    }
+    return .{ .serve = options };
+}
+
+fn printOptionError(err: anyerror) !void {
+    var buffer: [512]u8 = undefined;
+    var writer = std_compat.fs.File.stderr().writer(&buffer);
+    const message = switch (err) {
+        error.MissingProvider => "Missing value for --provider",
+        error.MissingModel => "Missing value for --model",
+        error.MissingTemperature => "Missing value for --temperature",
+        error.MissingAgent => "Missing value for --agent",
+        error.MissingSkill => "Missing value for --skill",
+        error.UnknownOption => "Unknown option for nullclaw acp",
+        else => @errorName(err),
+    };
+    try writer.interface.print("{s}\n\n", .{message});
+    try writer.interface.flush();
+    try printUsage(std_compat.fs.File.stderr());
+}
+
+fn printUsage(file: std_compat.fs.File) !void {
+    var buffer: [2048]u8 = undefined;
+    var writer = file.writer(&buffer);
+    try writer.interface.writeAll(
+        \\Usage: nullclaw acp [--provider PROVIDER] [--model MODEL] [--temperature TEMP] [--agent NAME] [--skill NAME]
+        \\
+        \\Runs an Agent Client Protocol server over newline-delimited JSON-RPC on stdio.
+        \\Editors can launch this command as their local ACP agent.
+        \\
+    );
+    try writer.interface.flush();
+}
+
+fn printVersion(file: std_compat.fs.File) !void {
+    var buffer: [256]u8 = undefined;
+    var writer = file.writer(&buffer);
+    try writer.interface.print("nullclaw acp {s}\n", .{build_options.version});
+    try writer.interface.flush();
+}
+
+fn invokeNullclaw(
+    allocator: std.mem.Allocator,
+    options: Options,
+    session: Session,
+    prompt: []const u8,
+) !InvokeResult {
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer argv.deinit(allocator);
+
+    const exe_path = try std_compat.fs.selfExePathAlloc(allocator);
+    defer allocator.free(exe_path);
+
+    try argv.append(allocator, exe_path);
+    try argv.append(allocator, "agent");
+    try argv.append(allocator, "invoke");
+    try argv.append(allocator, "--message");
+    try argv.append(allocator, prompt);
+    try argv.append(allocator, "--session");
+    try argv.append(allocator, session.id);
+    try argv.append(allocator, "--workspace");
+    try argv.append(allocator, session.cwd);
+    if (options.provider) |provider| {
+        try argv.append(allocator, "--provider");
+        try argv.append(allocator, provider);
+    }
+    if (options.model) |model| {
+        try argv.append(allocator, "--model");
+        try argv.append(allocator, model);
+    }
+    if (options.temperature) |temperature| {
+        try argv.append(allocator, "--temperature");
+        try argv.append(allocator, temperature);
+    }
+    if (options.agent_name) |agent_name| {
+        try argv.append(allocator, "--agent");
+        try argv.append(allocator, agent_name);
+    }
+    if (options.skill_name) |skill_name| {
+        try argv.append(allocator, "--skill");
+        try argv.append(allocator, skill_name);
+    }
+    try argv.append(allocator, "--json");
+
+    const result = try std_compat.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv.items,
+        .cwd = session.cwd,
+        .max_output_bytes = max_child_output,
+    });
+    errdefer allocator.free(result.stdout);
+    errdefer allocator.free(result.stderr);
+
+    const ok = switch (result.term) {
+        .exited => |code| code == 0,
+        else => false,
+    };
+    const response = if (ok)
+        try parseNullclawResponse(allocator, result.stdout)
+    else
+        try childFailureText(allocator, result.stderr, result.stdout);
+
+    return .{
+        .ok = ok,
+        .response = response,
+        .stdout = result.stdout,
+        .stderr = result.stderr,
+    };
+}
+
+fn parseNullclawResponse(allocator: std.mem.Allocator, stdout: []const u8) ![]const u8 {
+    const trimmed = std.mem.trim(u8, stdout, " \t\r\n");
+    if (trimmed.len == 0) return try allocator.dupe(u8, "");
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch {
+        return try allocator.dupe(u8, trimmed);
+    };
+    defer parsed.deinit();
+
+    const object = switch (parsed.value) {
+        .object => |object| object,
+        else => return try allocator.dupe(u8, trimmed),
+    };
+    if (getStringField(object, "response")) |response| return try allocator.dupe(u8, response);
+    return try allocator.dupe(u8, trimmed);
+}
+
+fn childFailureText(allocator: std.mem.Allocator, stderr: []const u8, stdout: []const u8) ![]const u8 {
+    const err_text = std.mem.trim(u8, stderr, " \t\r\n");
+    if (err_text.len > 0) return try allocator.dupe(u8, err_text);
+    const out_text = std.mem.trim(u8, stdout, " \t\r\n");
+    if (out_text.len > 0) return try allocator.dupe(u8, out_text);
+    return try allocator.dupe(u8, "nullclaw exited without output");
+}
+
+fn promptToText(allocator: std.mem.Allocator, value: std.json.Value) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    switch (value) {
+        .array => |array| {
+            for (array.items, 0..) |item, index| {
+                if (index > 0) try out.appendSlice(allocator, "\n\n");
+                try appendContentBlock(allocator, &out, item);
+            }
+        },
+        else => return error.InvalidPromptPayload,
+    }
+
+    return try out.toOwnedSlice(allocator);
+}
+
+fn readProtocolVersion(params: ?std.json.Value) !i64 {
+    const value = params orelse return error.MissingProtocolVersion;
+    const object = switch (value) {
+        .object => |object| object,
+        else => return error.InvalidProtocolVersion,
+    };
+    const version = object.get("protocolVersion") orelse return error.MissingProtocolVersion;
+    return switch (version) {
+        .integer => |number| number,
+        else => error.InvalidProtocolVersion,
+    };
+}
+
+fn readNewSessionCwd(params: ?std.json.Value) ![]const u8 {
+    const value = params orelse return error.MissingParams;
+    const object = switch (value) {
+        .object => |object| object,
+        else => return error.InvalidParams,
+    };
+    const cwd = getStringField(object, "cwd") orelse return error.MissingCwd;
+    if (!std_compat.fs.path.isAbsolute(cwd)) return error.RelativeCwd;
+    return cwd;
+}
+
+fn appendContentBlock(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), item: std.json.Value) !void {
+    const object = switch (item) {
+        .object => |object| object,
+        else => return error.InvalidPromptPayload,
+    };
+    const kind = getStringField(object, "type") orelse return error.InvalidPromptPayload;
+
+    if (std.mem.eql(u8, kind, "text")) {
+        const text = getStringField(object, "text") orelse return error.InvalidPromptPayload;
+        try out.appendSlice(allocator, text);
+        return;
+    }
+
+    if (std.mem.eql(u8, kind, "resource")) {
+        const resource = object.get("resource") orelse return error.InvalidPromptPayload;
+        const resource_object = switch (resource) {
+            .object => |nested| nested,
+            else => return error.InvalidPromptPayload,
+        };
+        const uri = getStringField(resource_object, "uri") orelse return error.InvalidPromptPayload;
+        try out.print(allocator, "Context from {s}:\n", .{uri});
+        if (getStringField(resource_object, "text")) |text| {
+            try out.appendSlice(allocator, text);
+        } else {
+            try out.appendSlice(allocator, "(binary or unsupported resource content omitted)");
+        }
+        return;
+    }
+
+    if (std.mem.eql(u8, kind, "resource_link")) {
+        const uri = getStringField(object, "uri") orelse return error.InvalidPromptPayload;
+        try out.print(allocator, "Resource link: {s}", .{uri});
+        return;
+    }
+
+    try out.print(allocator, "Unsupported ACP content block: {s}", .{kind});
+}
+
+fn getStringField(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    return switch (value) {
+        .string => |text| text,
+        else => null,
+    };
+}
+
+fn writeResult(allocator: std.mem.Allocator, out: anytype, id: std.json.Value, result: anytype) !void {
+    const body = try std.json.Stringify.valueAlloc(allocator, .{
+        .jsonrpc = "2.0",
+        .id = id,
+        .result = result,
+    }, .{});
+    defer allocator.free(body);
+    try out.writeAll(body);
+    try out.writeAll("\n");
+    try out.flush();
+}
+
+fn writeNotification(allocator: std.mem.Allocator, out: anytype, value: anytype) !void {
+    const body = try std.json.Stringify.valueAlloc(allocator, value, .{});
+    defer allocator.free(body);
+    try out.writeAll(body);
+    try out.writeAll("\n");
+    try out.flush();
+}
+
+fn writeError(allocator: std.mem.Allocator, out: anytype, id: std.json.Value, code: i64, message: []const u8) !void {
+    const body = try std.json.Stringify.valueAlloc(allocator, .{
+        .jsonrpc = "2.0",
+        .id = id,
+        .@"error" = .{
+            .code = code,
+            .message = message,
+        },
+    }, .{});
+    defer allocator.free(body);
+    try out.writeAll(body);
+    try out.writeAll("\n");
+    try out.flush();
+}
+
+fn writeErrorNull(allocator: std.mem.Allocator, out: anytype, code: i64, message: []const u8) !void {
+    const body = try std.json.Stringify.valueAlloc(allocator, .{
+        .jsonrpc = "2.0",
+        .id = @as(?[]const u8, null),
+        .@"error" = .{
+            .code = code,
+            .message = message,
+        },
+    }, .{});
+    defer allocator.free(body);
+    try out.writeAll(body);
+    try out.writeAll("\n");
+    try out.flush();
+}
+
+test "parseOptions accepts ACP forwarding flags" {
+    const parsed = try parseOptions(&.{ "--provider", "openai", "--model", "gpt-x", "--temperature", "0.2", "--agent", "coder", "--skill", "review" });
+    const options = switch (parsed) {
+        .serve => |value| value,
+        else => return error.TestUnexpectedResult,
+    };
+
+    try std.testing.expectEqualStrings("openai", options.provider.?);
+    try std.testing.expectEqualStrings("gpt-x", options.model.?);
+    try std.testing.expectEqualStrings("0.2", options.temperature.?);
+    try std.testing.expectEqualStrings("coder", options.agent_name.?);
+    try std.testing.expectEqualStrings("review", options.skill_name.?);
+}
+
+test "promptToText extracts text and embedded resources" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\[
+        \\  {"type":"text","text":"Review this"},
+        \\  {"type":"resource","resource":{"uri":"file:///tmp/a.zig","text":"const x = 1;"}},
+        \\  {"type":"resource_link","uri":"file:///tmp/b.zig"}
+        \\]
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+
+    const text = try promptToText(allocator, parsed.value);
+    defer allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "Review this") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "file:///tmp/a.zig") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "const x = 1;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "file:///tmp/b.zig") != null);
+}
+
+test "parseNullclawResponse extracts response field" {
+    const allocator = std.testing.allocator;
+    const text = try parseNullclawResponse(allocator, "{\"session\":\"s\",\"response\":\"hello\",\"turn_count\":1}\n");
+    defer allocator.free(text);
+    try std.testing.expectEqualStrings("hello", text);
+}
+
+test "promptToText rejects non-array prompt payloads" {
+    const allocator = std.testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, "{\"type\":\"text\",\"text\":\"hello\"}", .{});
+    defer parsed.deinit();
+
+    try std.testing.expectError(error.InvalidPromptPayload, promptToText(allocator, parsed.value));
+}
+
+test "readProtocolVersion reads initialize params" {
+    const allocator = std.testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, "{\"protocolVersion\":1}", .{});
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(i64, 1), try readProtocolVersion(parsed.value));
+}
+
+test "readProtocolVersion rejects missing or invalid initialize params" {
+    const allocator = std.testing.allocator;
+    var missing = try std.json.parseFromSlice(std.json.Value, allocator, "{}", .{});
+    defer missing.deinit();
+    var invalid = try std.json.parseFromSlice(std.json.Value, allocator, "{\"protocolVersion\":\"1\"}", .{});
+    defer invalid.deinit();
+
+    try std.testing.expectError(error.MissingProtocolVersion, readProtocolVersion(missing.value));
+    try std.testing.expectError(error.InvalidProtocolVersion, readProtocolVersion(invalid.value));
+}
+
+test "readNewSessionCwd requires absolute cwd" {
+    const allocator = std.testing.allocator;
+    const cwd = if (builtin.os.tag == .windows) "C:\\tmp\\project" else "/tmp/project";
+    const valid_json = try std.json.Stringify.valueAlloc(allocator, .{ .cwd = cwd }, .{});
+    defer allocator.free(valid_json);
+
+    var valid = try std.json.parseFromSlice(std.json.Value, allocator, valid_json, .{});
+    defer valid.deinit();
+    var relative = try std.json.parseFromSlice(std.json.Value, allocator, "{\"cwd\":\".\"}", .{});
+    defer relative.deinit();
+    var missing = try std.json.parseFromSlice(std.json.Value, allocator, "{}", .{});
+    defer missing.deinit();
+
+    try std.testing.expectEqualStrings(cwd, try readNewSessionCwd(valid.value));
+    try std.testing.expectError(error.RelativeCwd, readNewSessionCwd(relative.value));
+    try std.testing.expectError(error.MissingCwd, readNewSessionCwd(missing.value));
+}
+
+test "promptToText rejects malformed content blocks" {
+    const allocator = std.testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, "[{\"type\":\"text\"}]", .{});
+    defer parsed.deinit();
+
+    try std.testing.expectError(error.InvalidPromptPayload, promptToText(allocator, parsed.value));
+}

--- a/src/acp.zig
+++ b/src/acp.zig
@@ -3,9 +3,9 @@ const std_compat = @import("compat");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 
-const protocol_version: i64 = 1;
-const max_line_bytes: usize = 1024 * 1024;
-const max_child_output: usize = 4 * 1024 * 1024;
+const PROTOCOL_VERSION: i64 = 1;
+const MAX_LINE_BYTES: usize = 1024 * 1024;
+const MAX_CHILD_OUTPUT: usize = 4 * 1024 * 1024;
 
 const Options = struct {
     provider: ?[]const u8 = null,
@@ -128,7 +128,7 @@ const Server = struct {
 
         self.initialized = true;
         const result = .{
-            .protocolVersion = protocol_version,
+            .protocolVersion = PROTOCOL_VERSION,
             .agentCapabilities = .{
                 .loadSession = false,
                 .promptCapabilities = .{
@@ -370,7 +370,7 @@ fn serveStdio(allocator: std.mem.Allocator, server: *Server) !void {
         const n = try stdin.read(&read_buffer);
         if (n == 0) break;
 
-        if (pending.items.len + n > max_line_bytes) return error.RequestTooLarge;
+        if (pending.items.len > MAX_LINE_BYTES or n > MAX_LINE_BYTES - pending.items.len) return error.RequestTooLarge;
         try pending.appendSlice(allocator, read_buffer[0..n]);
 
         var start: usize = 0;
@@ -513,7 +513,7 @@ fn invokeNullclaw(
         .allocator = allocator,
         .argv = argv.items,
         .cwd = session.cwd,
-        .max_output_bytes = max_child_output,
+        .max_output_bytes = MAX_CHILD_OUTPUT,
     });
     errdefer allocator.free(result.stdout);
     errdefer allocator.free(result.stderr);
@@ -711,6 +711,54 @@ test "parseOptions accepts ACP forwarding flags" {
     try std.testing.expectEqualStrings("review", options.skill_name.?);
 }
 
+test "handleLine rejects requests before initialize" {
+    const allocator = std.testing.allocator;
+    var server = Server.init(allocator, .{});
+    defer server.deinit();
+
+    const out = try handleLineForTest(
+        allocator,
+        &server,
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"session/prompt\",\"params\":{}}\n",
+    );
+    defer allocator.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"id\":1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"code\":-32002") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Connection not initialized") != null);
+}
+
+test "handleLine initializes and creates session with absolute cwd" {
+    const allocator = std.testing.allocator;
+    var server = Server.init(allocator, .{});
+    defer server.deinit();
+
+    const cwd = if (builtin.os.tag == .windows) "C:\\tmp\\project" else "/tmp/project";
+    const session_req = try std.json.Stringify.valueAlloc(allocator, .{
+        .jsonrpc = "2.0",
+        .id = 2,
+        .method = "session/new",
+        .params = .{ .cwd = cwd },
+    }, .{});
+    defer allocator.free(session_req);
+
+    const initialized = try handleLineForTest(
+        allocator,
+        &server,
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":1}}\n",
+    );
+    defer allocator.free(initialized);
+    const session_out = try handleLineForTest(allocator, &server, session_req);
+    defer allocator.free(session_out);
+
+    try std.testing.expect(server.initialized);
+    try std.testing.expectEqual(@as(usize, 1), server.sessions.count());
+    try std.testing.expect(std.mem.indexOf(u8, initialized, "\"protocolVersion\":1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, session_out, "\"sessionId\":\"acp-1\"") != null);
+    const stored = server.sessions.get("acp-1").?;
+    try std.testing.expectEqualStrings(cwd, stored.cwd);
+}
+
 test "promptToText extracts text and embedded resources" {
     const allocator = std.testing.allocator;
     const json =
@@ -730,6 +778,16 @@ test "promptToText extracts text and embedded resources" {
     try std.testing.expect(std.mem.indexOf(u8, text, "file:///tmp/a.zig") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "const x = 1;") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "file:///tmp/b.zig") != null);
+}
+
+fn handleLineForTest(allocator: std.mem.Allocator, server: *Server, line: []const u8) ![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    var out_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &out);
+    defer out_writer.deinit();
+
+    try server.handleLine(&out_writer.writer, line);
+    out = out_writer.toArrayList();
+    return out.toOwnedSlice(allocator);
 }
 
 test "parseNullclawResponse extracts response field" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -19,6 +19,7 @@ const log = std.log.scoped(.main);
 
 const Command = enum {
     agent,
+    acp,
     gateway,
     service,
     config,
@@ -64,6 +65,7 @@ const TOP_LEVEL_USAGE = std.fmt.comptimePrint(
     \\COMMANDS:
     \\  onboard      Initialize workspace and configuration
     \\  agent        Start the AI agent loop
+    \\  acp          Start Agent Client Protocol server (stdio JSON-RPC)
     \\  gateway      Start the gateway server (HTTP/WebSocket)
     \\  service      Manage OS service lifecycle
     \\  config       Inspect resolved config values
@@ -88,6 +90,7 @@ const TOP_LEVEL_USAGE = std.fmt.comptimePrint(
     \\OPTIONS:
     \\  onboard [--interactive] [--api-key KEY] [--provider PROV] [--model MODEL] [--memory MEM]
     \\  agent [-m MESSAGE] [-s SESSION] [--provider PROVIDER] [--model MODEL] [--temperature TEMP] [--workspace PATH] [--skill SKILL]
+    \\  acp [--provider PROVIDER] [--model MODEL] [--temperature TEMP] [--agent NAME] [--skill NAME]
     \\  gateway [--port PORT] [--host HOST] [--workspace PATH]
     \\  status [--json]
     \\  version | --version | -V
@@ -127,6 +130,7 @@ const TOP_LEVEL_USAGE = std.fmt.comptimePrint(
 fn parseCommand(arg: []const u8) ?Command {
     const command_map = std.StaticStringMap(Command).initComptime(.{
         .{ "agent", .agent },
+        .{ "acp", .acp },
         .{ "gateway", .gateway },
         .{ "service", .service },
         .{ "config", .config },
@@ -228,6 +232,7 @@ pub fn main(init: std.process.Init) !void {
         } else {
             try yc.agent.run(allocator, sub_args);
         },
+        .acp => try yc.acp.run(allocator, sub_args),
         .onboard => try runOnboard(allocator, sub_args),
         .doctor => try runDoctorCommand(allocator, sub_args),
         .help => printUsage(),
@@ -373,7 +378,7 @@ fn printAgentUsage() void {
         \\Start the AI agent loop.
         \\
         \\OPTIONS:
-        \\  invoke --message MESSAGE [--session SESSION] [--skill SKILL] [--json]
+        \\  invoke --message MESSAGE [--session SESSION] [--workspace PATH] [--skill SKILL] [--json]
         \\                               Run one machine-readable agent turn
         \\  sessions list [--json]       List persisted agent sessions
         \\  sessions get <session> [--json]
@@ -529,6 +534,7 @@ const AgentInvokeForwardOptions = struct {
     model: ?[]const u8 = null,
     temperature: ?[]const u8 = null,
     agent_name: ?[]const u8 = null,
+    workspace: ?[]const u8 = null,
     skill_name: ?[]const u8 = null,
 };
 
@@ -560,6 +566,10 @@ fn appendAgentInvokeForwardArgs(
         try argv.append(allocator, "--agent");
         try argv.append(allocator, value);
     }
+    if (options.workspace) |value| {
+        try argv.append(allocator, "--workspace");
+        try argv.append(allocator, value);
+    }
     if (options.skill_name) |value| {
         try argv.append(allocator, "--skill");
         try argv.append(allocator, value);
@@ -573,6 +583,7 @@ fn runAgentInvokeJson(allocator: std.mem.Allocator, sub_args: []const []const u8
     var model: ?[]const u8 = null;
     var temperature: ?[]const u8 = null;
     var agent_name: ?[]const u8 = null;
+    var workspace: ?[]const u8 = null;
     var skill_name: ?[]const u8 = null;
     var json_mode = false;
 
@@ -621,6 +632,13 @@ fn runAgentInvokeJson(allocator: std.mem.Allocator, sub_args: []const []const u8
             }
             i += 1;
             agent_name = sub_args[i];
+        } else if (std.mem.eql(u8, arg, "--workspace")) {
+            if (i + 1 >= sub_args.len) {
+                writeJsonError("bad_request", "Missing value for --workspace", null);
+                std_compat.process.exit(1);
+            }
+            i += 1;
+            workspace = sub_args[i];
         } else if (std.mem.eql(u8, arg, "--skill")) {
             if (i + 1 >= sub_args.len) {
                 writeJsonError("bad_request", "Missing value for --skill", null);
@@ -658,6 +676,7 @@ fn runAgentInvokeJson(allocator: std.mem.Allocator, sub_args: []const []const u8
         .model = model,
         .temperature = temperature,
         .agent_name = agent_name,
+        .workspace = workspace,
         .skill_name = skill_name,
     });
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -405,9 +405,10 @@ const HistoryStoreContext = struct {
     mem_rt: yc.memory.MemoryRuntime,
     session_store: yc.memory.SessionStore,
 
-    fn init(allocator: std.mem.Allocator) !HistoryStoreContext {
+    fn init(allocator: std.mem.Allocator, workspace_override: ?[]const u8) !HistoryStoreContext {
         var cfg = yc.config.Config.load(allocator) catch return error.ConfigNotFound;
         errdefer cfg.deinit();
+        applyHistoryWorkspaceOverride(&cfg, workspace_override);
 
         var history_memory_cfg = buildHistoryMemoryConfig(cfg.memory);
         var mem_rt = yc.memory.initRuntime(allocator, &history_memory_cfg, cfg.workspace_dir) orelse return error.MemoryRuntimeUnavailable;
@@ -427,6 +428,12 @@ const HistoryStoreContext = struct {
         self.* = undefined;
     }
 };
+
+fn applyHistoryWorkspaceOverride(cfg: *yc.config.Config, workspace_override: ?[]const u8) void {
+    if (workspace_override) |workspace| {
+        cfg.workspace_dir = workspace;
+    }
+}
 
 fn runDoctorCommand(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
     if (sub_args.len == 0) {
@@ -691,7 +698,7 @@ fn runAgentInvokeJson(allocator: std.mem.Allocator, sub_args: []const []const u8
         .exited => |code| code == 0,
         else => false,
     }) {
-        var ctx = HistoryStoreContext.init(allocator) catch |err| switch (err) {
+        var ctx = HistoryStoreContext.init(allocator, workspace) catch |err| switch (err) {
             error.ConfigNotFound => {
                 writeJsonError("config_not_found", "No config found -- run `nullclaw onboard` first", null);
                 std_compat.process.exit(1);
@@ -733,7 +740,7 @@ fn runAgentSessionsAdmin(allocator: std.mem.Allocator, sub_args: []const []const
     const subcmd = sub_args[0];
     const json_mode = hasJsonFlag(sub_args[1..]);
 
-    var ctx = HistoryStoreContext.init(allocator) catch |err| switch (err) {
+    var ctx = HistoryStoreContext.init(allocator, null) catch |err| switch (err) {
         error.ConfigNotFound => {
             if (json_mode) writeJsonError("config_not_found", "No config found -- run `nullclaw onboard` first", null);
             std.debug.print("No config found -- run `nullclaw onboard` first\n", .{});
@@ -5262,6 +5269,32 @@ test "appendAgentInvokeForwardArgs forwards skill option" {
     for (expected, argv.items) |want, got| {
         try std.testing.expectEqualStrings(want, got);
     }
+}
+
+test "appendAgentInvokeForwardArgs forwards workspace option" {
+    var argv = std.ArrayListUnmanaged([]const u8).empty;
+    defer argv.deinit(std.testing.allocator);
+
+    try appendAgentInvokeForwardArgs(std.testing.allocator, &argv, "hello", "api:default", .{
+        .workspace = "/tmp/acp-workspace",
+    });
+
+    const expected = [_][]const u8{ "agent", "-m", "hello", "-s", "api:default", "--workspace", "/tmp/acp-workspace" };
+    try std.testing.expectEqual(expected.len, argv.items.len);
+    for (expected, argv.items) |want, got| {
+        try std.testing.expectEqualStrings(want, got);
+    }
+}
+
+test "applyHistoryWorkspaceOverride uses ACP workspace for history reads" {
+    var cfg = yc.config.Config{
+        .workspace_dir = "/tmp/nullclaw-default",
+        .config_path = "/tmp/nullclaw-default/config.json",
+        .allocator = std.testing.allocator,
+    };
+
+    applyHistoryWorkspaceOverride(&cfg, "/tmp/nullclaw-acp");
+    try std.testing.expectEqualStrings("/tmp/nullclaw-acp", cfg.workspace_dir);
 }
 
 test "gatewayHelpRequested detects standalone help flag" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -56,6 +56,7 @@ pub const bootstrap = @import("bootstrap/root.zig");
 pub const gateway = @import("gateway.zig");
 pub const channels = @import("channels/root.zig");
 pub const a2a = @import("a2a.zig");
+pub const acp = @import("acp.zig");
 
 // Phase 4: Extensions
 pub const security = @import("security/root.zig");


### PR DESCRIPTION
## What changed

- Added `nullclaw acp`, a native Agent Client Protocol stdio JSON-RPC adapter inside the main `nullclaw` binary.
- Implemented ACP initialization, session creation, prompt handling, cancel acknowledgement, session update notifications, and prompt content translation for text/resource/resource_link blocks.
- Forwarded ACP session `cwd` into `agent invoke --workspace` so editor-created sessions run against the requested workspace.
- Documented the new command in README and English/Chinese command docs.

## Why

A2A remains the agent-to-agent/gateway protocol. ACP is the editor/client-to-agent bridge. Keeping ACP as a `nullclaw` command preserves the one-binary story while making nullclaw usable from ACP-compatible editors.

## Validation

- `zig fmt src/acp.zig src/root.zig src/main.zig`
- `zig build`
- `zig build test`
- `git diff --check`
- `./zig-out/bin/nullclaw acp --help`
- `./zig-out/bin/nullclaw acp --version`
- ACP stdin/stdout smoke test for `initialize` + `session/new`
- ACP error smoke tests for pre-initialize request and relative `cwd`

## Notes

This first native adapter intentionally uses the existing machine-readable `agent invoke --json` path as the stable execution boundary. A later follow-up can collapse this into a direct in-process `AgentSession` API once that boundary exists cleanly.