### PR TITLE
ci: force scheduled nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,4 +27,4 @@ jobs:
     with:
       binary_name: nullclaw
       artifact_prefix: nullclaw
-      force: ${{ inputs.force || false }}
+      force: ${{ github.event_name == 'schedule' || inputs.force || false }}


### PR DESCRIPTION
## What changed

Scheduled Nightly runs now pass `force=true` into the reusable nullbuilder workflow. Manual `workflow_dispatch` keeps using its existing `force` input.

## Why

The reusable workflow dedupes successful runs by `head_sha`. That is useful for manual reruns, but it meant daily scheduled Nightly runs skipped the build whenever `main` had not changed since the last successful nightly.

## Validation

- `git diff --check`
- YAML parsed with Ruby `YAML.load_file`
- pre-push hook: `zig build test --summary all` passed (`6984/6993 tests passed`, `9 skipped`)
