### PR TITLE
ci: publish nightly prerelease

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,8 +23,11 @@ jobs:
     uses: nullclaw/nullbuilder/.github/workflows/zig-nightly.yml@v1
     permissions:
       actions: read
-      contents: read
+      contents: write
     with:
       binary_name: nullclaw
       artifact_prefix: nullclaw
+      publish_release: true
+      release_tag: nightly
+      release_title: NullClaw Nightly
       force: ${{ inputs.force || false }}


### PR DESCRIPTION
## What changed

Enables rolling nightly prerelease publishing for NullClaw's scheduled Nightly workflow.

The reusable `nullbuilder` workflow now supports `publish_release`; this caller opts in, grants `contents: write`, and publishes to the `nightly` prerelease with title prefix `NullClaw Nightly`.

## Expected result

After the next Nightly build that actually runs the matrix, GitHub Releases should contain/update a prerelease tagged `nightly` with title like `NullClaw Nightly 2026-05-08 02:23:00 UTC` and the nightly build assets attached.

## Validation

- `git diff --check`
- YAML parsed with Ruby `YAML.load_file`
- pre-push hook: `zig build test --summary all` passed (`6984/6993 tests passed`, `9 skipped`)
