### PR TITLE
v2026.5.29

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  packages: write
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,10 @@ jobs:
     with:
       binary_name: nullclaw
       artifact_prefix: nullclaw
+      source_archive: true
+      source_archive_name: nullclaw-source-${{ github.ref_name }}.tar.gz
+      source_archive_excludes: |
+        .git
+        .zig-cache
+        zig-out
       publish_docker: true

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .nullclaw,
-    .version = "2026.5.4",
+    .version = "2026.5.29",
     .fingerprint = 0xe73e13d1c95956c2,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{


### PR DESCRIPTION
Version bump for the v2026.5.29 release.

Changes:
- Update `build.zig.zon` to `2026.5.29`.

Validation:
- `zig fmt --check build.zig.zon`
- `git diff --check`