### PR TITLE
fix(agent): honor compact_context flag instead of always compacting

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -869,9 +869,9 @@ pub const Agent = struct {
     }
 
     /// Proactively auto-compact history, honoring `agent.compact_context`.
-    /// When the flag is disabled the history is left untouched (the user is
-    /// managing context themselves). Emergency `forceCompressHistory` used for
-    /// context-exhaustion recovery is intentionally not gated by this flag.
+    /// When the flag is disabled the LLM summarization pass is skipped. Hard
+    /// history trimming and emergency `forceCompressHistory` remain separate
+    /// safeguards and are intentionally not gated by this flag.
     pub fn maybeAutoCompactHistory(self: *Agent) bool {
         if (!self.compact_context) return false;
         return self.autoCompactHistory() catch false;
@@ -5276,6 +5276,26 @@ test "Agent.fromConfig applies status_show_emojis flag" {
     defer agent.deinit();
 
     try std.testing.expect(!agent.status_show_emojis);
+}
+
+test "Agent.fromConfig applies compact_context flag" {
+    // Regression: #937. Parsed `agent.compact_context = false` must reach the
+    // runtime Agent so proactive compaction can be skipped.
+    const allocator = std.testing.allocator;
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .default_model = "openai/gpt-4.1-mini",
+        .allocator = allocator,
+    };
+    cfg.agent.compact_context = false;
+
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, undefined, &.{}, null, noop.observer());
+    defer agent.deinit();
+
+    try std.testing.expect(!agent.compact_context);
+    try std.testing.expect(!agent.maybeAutoCompactHistory());
 }
 
 test "slash /new clears history" {

--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -312,6 +312,7 @@ pub const Agent = struct {
     max_tool_iterations: u32,
     max_history_messages: u32,
     auto_save: bool,
+    compact_context: bool = true,
     token_limit: u64 = 0,
     token_limit_override: ?u64 = null,
     max_tokens: u32 = max_tokens_resolver.DEFAULT_MODEL_MAX_TOKENS,
@@ -625,6 +626,7 @@ pub const Agent = struct {
             .max_tool_iterations = cfg.agent.max_tool_iterations,
             .max_history_messages = cfg.agent.max_history_messages,
             .auto_save = cfg.memory.auto_save,
+            .compact_context = cfg.agent.compact_context,
             .token_limit = resolved_token_limit,
             .token_limit_override = token_limit_override,
             .max_tokens = resolved_max_tokens,
@@ -864,6 +866,15 @@ pub const Agent = struct {
         const completion_budget_u32: u32 = @intCast(@min(completion_budget, @as(u64, std.math.maxInt(u32))));
         if (completion_budget_u32 == 0) return 1;
         return @max(@as(u32, 1), @min(max_tokens, completion_budget_u32));
+    }
+
+    /// Proactively auto-compact history, honoring `agent.compact_context`.
+    /// When the flag is disabled the history is left untouched (the user is
+    /// managing context themselves). Emergency `forceCompressHistory` used for
+    /// context-exhaustion recovery is intentionally not gated by this flag.
+    pub fn maybeAutoCompactHistory(self: *Agent) bool {
+        if (!self.compact_context) return false;
+        return self.autoCompactHistory() catch false;
     }
 
     /// Auto-compact history when it exceeds thresholds.
@@ -2580,8 +2591,8 @@ pub const Agent = struct {
                     .content = try self.dupeForHistory(display_text),
                 });
 
-                // Auto-compaction before hard trimming to preserve context
-                self.last_turn_compacted = self.autoCompactHistory() catch false;
+                // Auto-compaction before hard trimming to preserve context.
+                self.last_turn_compacted = self.maybeAutoCompactHistory();
                 self.trimHistory();
 
                 // Auto-save assistant response
@@ -2873,7 +2884,7 @@ pub const Agent = struct {
         });
 
         // Compact/trim history so the next turn doesn't start with bloated context
-        self.last_turn_compacted = self.autoCompactHistory() catch false;
+        self.last_turn_compacted = self.maybeAutoCompactHistory();
         self.trimHistory();
 
         const complete_event = ObserverEvent{ .turn_complete = {} };
@@ -3994,6 +4005,106 @@ test "compaction module reexport" {
     _ = compaction.forceCompressHistory;
     _ = compaction.trimHistory;
     _ = compaction.CompactionConfig;
+}
+
+// Minimal provider that returns a fixed summary and counts invocations,
+// used to observe whether maybeAutoCompactHistory reached the summarizer.
+const CompactionTestProvider = struct {
+    calls: usize = 0,
+
+    fn chatWithSystem(_: *anyopaque, allocator: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+        return allocator.dupe(u8, "");
+    }
+    fn chat(ptr: *anyopaque, allocator: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+        const self: *CompactionTestProvider = @ptrCast(@alignCast(ptr));
+        self.calls += 1;
+        return .{ .content = try allocator.dupe(u8, "auto summary") };
+    }
+    fn supportsNativeTools(_: *anyopaque) bool {
+        return false;
+    }
+    fn getName(_: *anyopaque) []const u8 {
+        return "compaction-test-provider";
+    }
+    fn deinit(_: *anyopaque) void {}
+
+    const vtable = Provider.VTable{
+        .chatWithSystem = chatWithSystem,
+        .chat = chat,
+        .supportsNativeTools = supportsNativeTools,
+        .getName = getName,
+        .deinit = deinit,
+    };
+};
+
+fn makeCompactionTestAgent(allocator: std.mem.Allocator, observer: anytype, provider: Provider, compact_context: bool) Agent {
+    return Agent{
+        .allocator = allocator,
+        .provider = provider,
+        .tools = &.{},
+        .tool_specs = &.{},
+        .mem = null,
+        .observer = observer,
+        .model_name = "test-model",
+        .temperature = 0.7,
+        .workspace_dir = "/tmp",
+        .max_tool_iterations = 10,
+        .max_history_messages = 4,
+        .auto_save = false,
+        .compact_context = compact_context,
+        .history = .empty,
+        .total_tokens = 0,
+        .has_system_prompt = false,
+        .token_limit = 0,
+    };
+}
+
+fn fillOverThreshold(allocator: std.mem.Allocator, agent: *Agent) !void {
+    try agent.history.append(allocator, .{ .role = .system, .content = try allocator.dupe(u8, "system prompt") });
+    for (0..12) |i| {
+        try agent.history.append(allocator, .{ .role = .user, .content = try std.fmt.allocPrint(allocator, "message {d}", .{i}) });
+        try agent.history.append(allocator, .{ .role = .assistant, .content = try std.fmt.allocPrint(allocator, "reply {d}", .{i}) });
+    }
+}
+
+test "maybeAutoCompactHistory skips compaction when compact_context is false (regression #937)" {
+    const allocator = std.testing.allocator;
+    var noop = observability.NoopObserver{};
+    var provider_state = CompactionTestProvider{};
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &CompactionTestProvider.vtable };
+
+    var agent = makeCompactionTestAgent(allocator, noop.observer(), provider, false);
+    defer agent.deinit();
+    try fillOverThreshold(allocator, &agent);
+
+    const len_before = agent.history.items.len;
+    const compacted = agent.maybeAutoCompactHistory();
+
+    // Flag is off: history is left untouched and the summarizer is never called,
+    // even though the message count is well over max_history_messages.
+    try std.testing.expect(!compacted);
+    try std.testing.expectEqual(len_before, agent.history.items.len);
+    try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
+}
+
+test "maybeAutoCompactHistory compacts when compact_context is true" {
+    const allocator = std.testing.allocator;
+    var noop = observability.NoopObserver{};
+    var provider_state = CompactionTestProvider{};
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &CompactionTestProvider.vtable };
+
+    var agent = makeCompactionTestAgent(allocator, noop.observer(), provider, true);
+    defer agent.deinit();
+    try fillOverThreshold(allocator, &agent);
+
+    const len_before = agent.history.items.len;
+    const compacted = agent.maybeAutoCompactHistory();
+
+    // Flag is on: the same over-threshold history is compacted and the
+    // summarizer is invoked, shrinking the message count.
+    try std.testing.expect(compacted);
+    try std.testing.expect(agent.history.items.len < len_before);
+    try std.testing.expect(provider_state.calls > 0);
 }
 
 test "cli module reexport" {

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -376,9 +376,9 @@ pub const ToolFilterGroup = struct {
 
 pub const AgentConfig = struct {
     /// When true (default), history is auto-compacted once it crosses the
-    /// token / message thresholds. Set to false to leave history untouched
-    /// and manage context yourself. Default is true to preserve the
-    /// historical always-compact behavior.
+    /// token / message thresholds. Set to false to skip proactive LLM
+    /// summarization while retaining hard trimming and emergency compression.
+    /// Default is true to preserve the historical always-compact behavior.
     compact_context: bool = true,
     max_tool_iterations: u32 = 1000,
     max_history_messages: u32 = 100,

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -375,7 +375,11 @@ pub const ToolFilterGroup = struct {
 };
 
 pub const AgentConfig = struct {
-    compact_context: bool = false,
+    /// When true (default), history is auto-compacted once it crosses the
+    /// token / message thresholds. Set to false to leave history untouched
+    /// and manage context yourself. Default is true to preserve the
+    /// historical always-compact behavior.
+    compact_context: bool = true,
     max_tool_iterations: u32 = 1000,
     max_history_messages: u32 = 100,
     parallel_tools: bool = false,


### PR DESCRIPTION
## Summary

Closes #937.

`AgentConfig.compact_context` is a dead flag. It is parsed from JSON
(`config_parse.zig`) and serialized back on config export (`config.zig`),
but **no runtime code ever reads it**. `autoCompactHistory()` runs on
every assistant turn — and again on the tool-iteration-limit path —
regardless of the flag's value.

Result: setting `"compact_context": false` has no effect. History is
compacted no matter what, even though the config schema clearly implies
the flag controls it.

## Fix

Introduce `Agent.maybeAutoCompactHistory()` which gates the proactive
compaction on the flag, and use it at both call sites in
`src/agent/root.zig`:

- the normal assistant-turn path (`turn()` loop)
- the tool-iteration-limit summary path

```zig
pub fn maybeAutoCompactHistory(self: *Agent) bool {
    if (!self.compact_context) return false;
    return self.autoCompactHistory() catch false;
}
```

`Agent` gains a `compact_context` field wired from `cfg.agent.compact_context`
at construction, mirroring how `auto_save`, `max_history_messages`, etc.
are already plumbed.

### Emergency recovery is intentionally NOT gated

`forceCompressHistory` (the context-exhaustion recovery path at
`root.zig` ~2389) is left untouched. A user disabling proactive
compaction should still not be able to wedge a session against the hard
context limit — the emergency fallback must always be available.

### Default flipped false → true

The field default changes from `false` to `true`. This is deliberate and
**preserves current behavior**:

- Today compaction effectively always runs (flag ignored). Honoring the
  flag with its old `false` default would silently disable compaction
  for every existing deployment — long conversations would grow
  unbounded until the lossier emergency `forceCompressHistory` kicks in.
  That is a real regression.
- With the default at `true`, existing users see no change; only users
  who explicitly set `"compact_context": false` see a difference — which
  is precisely the effect they were asking for.

No test asserted the old `false` default (all existing tests set the
flag explicitly), so the flip is safe.

## Tests

Two regression tests in `src/agent/root.zig`, using a minimal
invocation-counting provider mock:

- `maybeAutoCompactHistory skips compaction when compact_context is false (regression #937)`
  — history is filled well past `max_history_messages`; with the flag
  off, `maybeAutoCompactHistory()` returns false, history length is
  unchanged, and the summarizer provider is never called (`calls == 0`).
- `maybeAutoCompactHistory compacts when compact_context is true`
  — the same over-threshold history with the flag on is compacted:
  returns true, history shrinks, and the provider is invoked.

Sanity-checked by removing the `if (!self.compact_context) return false;`
guard and re-running: the first test fails (compaction runs despite the
flag); the second still passes. Guard restored: both pass.

## Verification

```
$ zig build test --summary all
... 7311 pass, 25 skip, 1 fail (7337 total)
```

The single failure (`tools.git.test.git add accepts string paths
parameter`) also fails on unmodified `main` in the same Docker test
environment — pre-existing flake, unrelated to this change.

## Scope

Out of scope:

- Making `recall_limit` / `max_context_bytes` / other compaction
  thresholds configurable — separate concern from the on/off flag.
- `/context` command display of the flag state (the issue noted it as
  optional) — left for a follow-up to keep this change focused.

## Environment

- Built and tested via `local/zig:0.16.0` Docker image
- Branch off current `main`
