### PR TITLE
fix(models): query base_url for custom OpenAI-compatible providers

### DIFF
--- a/docs/en/commands.md
+++ b/docs/en/commands.md
@@ -215,7 +215,7 @@ These are more useful for automation, probing, or integrations than for normal d
 | Command | Purpose |
 |---|---|
 | `nullclaw --export-manifest` | Export the runtime manifest |
-| `nullclaw --list-models` | Print model information |
+| `nullclaw --list-models --provider <name> [--api-key <key>] [--base-url <url>]` | Print model information, including custom OpenAI-compatible endpoints |
 | `nullclaw --probe-provider-health` | Probe provider health |
 | `nullclaw --probe-channel-health` | Probe channel health |
 | `nullclaw --from-json` | Run a JSON-driven entry path |

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -186,7 +186,7 @@
 | 命令 | 说明 |
 |---|---|
 | `nullclaw --export-manifest` | 导出 manifest |
-| `nullclaw --list-models` | 列出模型信息 |
+| `nullclaw --list-models --provider <name> [--api-key <key>] [--base-url <url>]` | 列出模型信息，也支持自定义 OpenAI 兼容端点 |
 | `nullclaw --probe-provider-health` | 探测 provider 健康状态 |
 | `nullclaw --probe-channel-health` | 探测 channel 健康状态 |
 | `nullclaw --from-json` | 从 JSON 输入执行特定流程 |

--- a/src/agent/commands.zig
+++ b/src/agent/commands.zig
@@ -498,7 +498,8 @@ fn renderInteractiveModelMenu(self: anytype, provider_name: []const u8, page_num
     defer if (cfg_opt) |*cfg| cfg.deinit();
 
     const api_key = if (cfg_opt) |*cfg| cfg.getProviderKey(provider_name) else null;
-    const models = onboard.fetchModels(self.allocator, provider_name, api_key) catch return null;
+    const base_url = if (cfg_opt) |*cfg| cfg.getProviderBaseUrl(provider_name) else null;
+    const models = onboard.fetchModels(self.allocator, provider_name, api_key, base_url) catch return null;
     defer freeOwnedStringSlice(self.allocator, models);
 
     return renderInteractiveModelMenuFromModels(

--- a/src/list_models.zig
+++ b/src/list_models.zig
@@ -18,6 +18,7 @@ fn writeModelsJson(out: *std.Io.Writer, models: []const []const u8) !void {
 pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var provider: ?[]const u8 = null;
     var api_key: ?[]const u8 = null;
+    var base_url: ?[]const u8 = null;
 
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -26,6 +27,9 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
             i += 1;
         } else if (std.mem.eql(u8, args[i], "--api-key") and i + 1 < args.len) {
             api_key = args[i + 1];
+            i += 1;
+        } else if (std.mem.eql(u8, args[i], "--base-url") and i + 1 < args.len) {
+            base_url = args[i + 1];
             i += 1;
         }
     }
@@ -41,7 +45,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
 
     // Use onboard's fetchModels (handles caching, fallbacks, API calls)
-    const models = onboard.fetchModels(allocator, provider_info.key, api_key) catch |err| {
+    const models = onboard.fetchModels(allocator, provider_info.key, api_key, base_url) catch |err| {
         std.debug.print("error fetching models: {}\n", .{err});
         std_compat.process.exit(1);
     };

--- a/src/list_models.zig
+++ b/src/list_models.zig
@@ -5,6 +5,18 @@
 const std = @import("std");
 const std_compat = @import("compat");
 const onboard = @import("onboard.zig");
+const config_types = @import("config_types.zig");
+
+fn resolveProviderKey(provider: []const u8, base_url: ?[]const u8) ?[]const u8 {
+    if (onboard.resolveProviderForQuickSetup(provider)) |info| return info.key;
+    if (base_url != null) return provider;
+    return null;
+}
+
+fn isValidBaseUrlArg(base_url: ?[]const u8) bool {
+    if (base_url) |url| return config_types.ProviderEntry.isValidBaseUrl(url);
+    return true;
+}
 
 fn writeModelsJson(out: *std.Io.Writer, models: []const []const u8) !void {
     try out.writeByte('[');
@@ -39,13 +51,18 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         std_compat.process.exit(1);
     }
 
-    const provider_info = onboard.resolveProviderForQuickSetup(provider.?) orelse {
+    if (!isValidBaseUrlArg(base_url)) {
+        std.debug.print("error: --base-url must be an absolute http(s) URL with no query/fragment; http is only allowed for local/private hosts\n", .{});
+        std_compat.process.exit(1);
+    }
+
+    const provider_key = resolveProviderKey(provider.?, base_url) orelse {
         std.debug.print("error: unknown provider '{s}'\n", .{provider.?});
         std_compat.process.exit(1);
     };
 
     // Use onboard's fetchModels (handles caching, fallbacks, API calls)
-    const models = onboard.fetchModels(allocator, provider_info.key, api_key, base_url) catch |err| {
+    const models = onboard.fetchModels(allocator, provider_key, api_key, base_url) catch |err| {
         std.debug.print("error fetching models: {}\n", .{err});
         std_compat.process.exit(1);
     };
@@ -65,6 +82,20 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
 test "run requires --provider flag" {
     // Cannot easily test process.exit in-process; just verify the function signature compiles.
     // The real integration test is: nullclaw --list-models --provider anthropic
+}
+
+test "resolveProviderKey accepts unknown provider only with base_url" {
+    try std.testing.expect(resolveProviderKey("my-gateway", null) == null);
+    try std.testing.expectEqualStrings("my-gateway", resolveProviderKey("my-gateway", "https://gateway.example.com/v1").?);
+    try std.testing.expectEqualStrings("openai", resolveProviderKey("openai", null).?);
+}
+
+test "isValidBaseUrlArg matches provider base_url validation" {
+    try std.testing.expect(isValidBaseUrlArg(null));
+    try std.testing.expect(isValidBaseUrlArg("https://gateway.example.com/v1"));
+    try std.testing.expect(isValidBaseUrlArg("http://127.0.0.1:8080/v1"));
+    try std.testing.expect(!isValidBaseUrlArg("http://api.example.com/v1"));
+    try std.testing.expect(!isValidBaseUrlArg("https://gateway.example.com/v1?token=test"));
 }
 
 test "writeModelsJson escapes model identifiers" {

--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -511,7 +511,7 @@ fn dupeFallbackModels(allocator: std.mem.Allocator, provider: []const u8) ![][]c
 /// Uses file-based cache at `state/models_cache.json` inside the config directory with 12h TTL.
 /// Returns at most 20 model IDs. Caller ALWAYS owns the returned slice and strings.
 /// Free with: for (models) |m| allocator.free(m); allocator.free(models);
-pub fn fetchModels(allocator: std.mem.Allocator, provider: []const u8, api_key: ?[]const u8) ![][]const u8 {
+pub fn fetchModels(allocator: std.mem.Allocator, provider: []const u8, api_key: ?[]const u8, base_url: ?[]const u8) ![][]const u8 {
     const canonical = canonicalProviderName(provider);
     if (std.mem.eql(u8, canonical, "codex-cli") or std.mem.eql(u8, canonical, "openai-codex")) {
         return codex_support.loadCodexModels(allocator);
@@ -520,7 +520,7 @@ pub fn fetchModels(allocator: std.mem.Allocator, provider: []const u8, api_key: 
     // Tests must stay deterministic and must not depend on a developer's
     // real ~/.nullclaw cache state.
     if (builtin.is_test) {
-        return fetchModelsFromApi(allocator, canonical, api_key) catch
+        return fetchModelsFromApi(allocator, canonical, api_key, base_url) catch
             dupeFallbackModels(allocator, canonical);
     }
 
@@ -537,14 +537,14 @@ pub fn fetchModels(allocator: std.mem.Allocator, provider: []const u8, api_key: 
         else => return dupeFallbackModels(allocator, provider),
     };
 
-    return loadModelsWithCache(allocator, state_dir, provider, api_key);
+    return loadModelsWithCache(allocator, state_dir, provider, api_key, base_url);
 }
 
 /// Fetch model IDs from a provider's API. Returns owned slice of owned strings.
 /// Native list endpoints are preferred when available. For providers without a
 /// native listing API, or when setup lacks credentials, production builds fall
 /// back to the public models.dev catalog before using hardcoded defaults.
-pub fn fetchModelsFromApi(allocator: std.mem.Allocator, provider: []const u8, api_key: ?[]const u8) ![][]const u8 {
+pub fn fetchModelsFromApi(allocator: std.mem.Allocator, provider: []const u8, api_key: ?[]const u8, base_url: ?[]const u8) ![][]const u8 {
     const canonical = canonicalProviderName(provider);
 
     if (std.mem.eql(u8, canonical, "codex-cli") or std.mem.eql(u8, canonical, "openai-codex")) {
@@ -558,7 +558,7 @@ pub fn fetchModelsFromApi(allocator: std.mem.Allocator, provider: []const u8, ap
         if (dynamic.len > 0) return dynamic;
     }
 
-    if (fetchModelsFromNativeApi(allocator, canonical, api_key)) |maybe_models| {
+    if (fetchModelsFromNativeApi(allocator, canonical, api_key, base_url)) |maybe_models| {
         if (maybe_models) |models| return models;
     } else |err| {
         logModelCatalogFailureErr("native", canonical, err);
@@ -590,36 +590,77 @@ pub fn fetchModelsFromApi(allocator: std.mem.Allocator, provider: []const u8, ap
     return error.FetchFailed;
 }
 
-fn fetchModelsFromNativeApi(allocator: std.mem.Allocator, canonical: []const u8, api_key: ?[]const u8) !?[][]const u8 {
-    var url: []const u8 = undefined;
-    var url_to_free: ?[]const u8 = null;
-    var needs_auth = false;
-    var parse_options: ModelIdParseOptions = .{};
-    defer if (url_to_free) |u| allocator.free(u);
+/// Resolved /models request for a provider: where to GET and how to auth.
+/// `url_owned` indicates the caller must free `url`.
+const NativeModelsRequest = struct {
+    url: []const u8,
+    url_owned: bool,
+    needs_auth: bool,
+    auth_optional: bool,
+    parse_options: ModelIdParseOptions = .{},
+};
 
+/// Decide the /models endpoint and auth policy for a provider, without doing
+/// any I/O. Returns null when the provider has no resolvable listing endpoint
+/// (the caller then falls back to models.dev / static lists).
+fn resolveNativeModelsRequest(
+    allocator: std.mem.Allocator,
+    canonical: []const u8,
+    base_url: ?[]const u8,
+) !?NativeModelsRequest {
     if (staticNativeModelCatalogForProvider(canonical)) |catalog| {
-        url = catalog.url;
-        needs_auth = catalog.needs_auth;
-        parse_options = catalog.parse_options;
-    } else if (std.mem.startsWith(u8, canonical, "http://") or std.mem.startsWith(u8, canonical, "https://")) {
-        url_to_free = try buildModelsUrl(allocator, canonical);
-        url = url_to_free.?;
-        needs_auth = true;
-    } else {
-        return null;
+        return .{
+            .url = catalog.url,
+            .url_owned = false,
+            .needs_auth = catalog.needs_auth,
+            .auth_optional = false,
+            .parse_options = catalog.parse_options,
+        };
     }
+    if (std.mem.startsWith(u8, canonical, "http://") or std.mem.startsWith(u8, canonical, "https://")) {
+        return .{
+            .url = try buildModelsUrl(allocator, canonical),
+            .url_owned = true,
+            .needs_auth = true,
+            .auth_optional = false,
+        };
+    }
+    if (base_url) |configured| {
+        // Custom OpenAI-compatible provider with an arbitrary name and a
+        // `base_url` in config. Query <base_url>/models like any other
+        // OpenAI-style endpoint. Auth is optional: local routers
+        // (LM Studio, llama.cpp, vLLM) commonly serve models without a key,
+        // but we still attach one when configured.
+        return .{
+            .url = try buildModelsUrl(allocator, configured),
+            .url_owned = true,
+            .needs_auth = false,
+            .auth_optional = true,
+        };
+    }
+    return null;
+}
+
+fn fetchModelsFromNativeApi(allocator: std.mem.Allocator, canonical: []const u8, api_key: ?[]const u8, base_url: ?[]const u8) !?[][]const u8 {
+    const request = (try resolveNativeModelsRequest(allocator, canonical, base_url)) orelse return null;
+    defer if (request.url_owned) allocator.free(request.url);
 
     var headers_buf: [1][]const u8 = undefined;
     var headers: []const []const u8 = &.{};
-    if (needs_auth) {
-        const key = api_key orelse return null;
-        const auth_hdr = try std.fmt.allocPrint(allocator, "Authorization: Bearer {s}", .{key});
-        defer allocator.free(auth_hdr);
-        headers_buf[0] = auth_hdr;
-        headers = &headers_buf;
+    var auth_hdr: ?[]const u8 = null;
+    defer if (auth_hdr) |h| allocator.free(h);
+    if (request.needs_auth or request.auth_optional) {
+        if (api_key) |key| {
+            auth_hdr = try std.fmt.allocPrint(allocator, "Authorization: Bearer {s}", .{key});
+            headers_buf[0] = auth_hdr.?;
+            headers = &headers_buf;
+        } else if (request.needs_auth) {
+            // Hard requirement unmet — let the caller fall back.
+            return null;
+        }
     }
 
-    return try fetchAndParseModels(allocator, canonical, url, headers, parse_options);
+    return try fetchAndParseModels(allocator, canonical, request.url, headers, request.parse_options);
 }
 
 fn staticNativeModelCatalogForProvider(canonical: []const u8) ?NativeModelCatalog {
@@ -920,13 +961,13 @@ fn buildModelsUrl(allocator: std.mem.Allocator, base_url: []const u8) ![]const u
 
 /// Load models with file-based cache. Cache expires after 12 hours.
 /// Falls back to hardcoded list on any error. Caller ALWAYS owns the result.
-pub fn loadModelsWithCache(allocator: std.mem.Allocator, cache_dir: []const u8, provider: []const u8, api_key: ?[]const u8) ![][]const u8 {
-    return loadModelsWithCacheInner(allocator, cache_dir, provider, api_key) catch {
+pub fn loadModelsWithCache(allocator: std.mem.Allocator, cache_dir: []const u8, provider: []const u8, api_key: ?[]const u8, base_url: ?[]const u8) ![][]const u8 {
+    return loadModelsWithCacheInner(allocator, cache_dir, provider, api_key, base_url) catch {
         return dupeFallbackModels(allocator, provider);
     };
 }
 
-fn loadModelsWithCacheInner(allocator: std.mem.Allocator, cache_dir: []const u8, provider: []const u8, api_key: ?[]const u8) ![][]const u8 {
+fn loadModelsWithCacheInner(allocator: std.mem.Allocator, cache_dir: []const u8, provider: []const u8, api_key: ?[]const u8, base_url: ?[]const u8) ![][]const u8 {
     const canonical = canonicalProviderName(provider);
     const cache_path = try std.fmt.allocPrint(allocator, "{s}/models_cache.json", .{cache_dir});
     defer allocator.free(cache_path);
@@ -939,7 +980,7 @@ fn loadModelsWithCacheInner(allocator: std.mem.Allocator, cache_dir: []const u8,
     } else |_| {}
 
     // Cache miss or expired — fetch from API
-    const models = try fetchModelsFromApi(allocator, canonical, api_key);
+    const models = try fetchModelsFromApi(allocator, canonical, api_key, base_url);
 
     // Best-effort: save to cache (coerce [][]const u8 -> []const []const u8)
     const models_const: []const []const u8 = models;
@@ -2358,7 +2399,7 @@ pub fn runWizard(allocator: std.mem.Allocator) !void {
     else
         cfg.default_provider;
 
-    if (fetchModels(allocator, provider_for_fetch, cfg.defaultProviderKey())) |models| {
+    if (fetchModels(allocator, provider_for_fetch, cfg.defaultProviderKey(), cfg.getProviderBaseUrl(cfg.default_provider))) |models| {
         models_fetched = true;
         live_models = models;
         models_to_use = live_models;
@@ -5083,7 +5124,7 @@ test "loadModelsWithCache keeps public and native cache entries separate" {
     defer file.close();
     try file.writeAll(cache_json);
 
-    const public_models = try loadModelsWithCache(std.testing.allocator, base, "openai", null);
+    const public_models = try loadModelsWithCache(std.testing.allocator, base, "openai", null, null);
     defer {
         for (public_models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(public_models);
@@ -5091,7 +5132,7 @@ test "loadModelsWithCache keeps public and native cache entries separate" {
     try std.testing.expectEqual(@as(usize, 1), public_models.len);
     try std.testing.expectEqualStrings("gpt-public", public_models[0]);
 
-    const native_models = try loadModelsWithCache(std.testing.allocator, base, "openai", "test-key");
+    const native_models = try loadModelsWithCache(std.testing.allocator, base, "openai", "test-key", null);
     defer {
         for (native_models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(native_models);
@@ -5110,7 +5151,7 @@ test "loadModelsWithCache falls back on fetch failure" {
     defer std.testing.allocator.free(nonexistent);
 
     // openai without api key will fail fetch, falling back to hardcoded list
-    const models = try loadModelsWithCache(std.testing.allocator, nonexistent, "openai", null);
+    const models = try loadModelsWithCache(std.testing.allocator, nonexistent, "openai", null, null);
     defer {
         for (models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(models);
@@ -5126,7 +5167,7 @@ test "loadModelsWithCache returns models for anthropic" {
     const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(std.testing.allocator, ".");
     defer std.testing.allocator.free(base);
 
-    const models = try loadModelsWithCache(std.testing.allocator, base, "anthropic", null);
+    const models = try loadModelsWithCache(std.testing.allocator, base, "anthropic", null, null);
     // Anthropic returns hardcoded models (allocated copies)
     defer {
         for (models) |m| std.testing.allocator.free(m);
@@ -5137,7 +5178,7 @@ test "loadModelsWithCache returns models for anthropic" {
 }
 
 test "fetchModelsFromApi returns hardcoded for anthropic" {
-    const models = try fetchModelsFromApi(std.testing.allocator, "anthropic", null);
+    const models = try fetchModelsFromApi(std.testing.allocator, "anthropic", null, null);
     defer {
         for (models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(models);
@@ -5149,7 +5190,7 @@ test "fetchModelsFromApi returns hardcoded for anthropic" {
 }
 
 test "fetchModelsFromApi returns hardcoded for ollama" {
-    const models = try fetchModelsFromApi(std.testing.allocator, "ollama", null);
+    const models = try fetchModelsFromApi(std.testing.allocator, "ollama", null, null);
     defer {
         for (models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(models);
@@ -5159,13 +5200,53 @@ test "fetchModelsFromApi returns hardcoded for ollama" {
 }
 
 test "fetchModelsFromApi returns error for openai without key" {
-    const result = fetchModelsFromApi(std.testing.allocator, "openai", null);
+    const result = fetchModelsFromApi(std.testing.allocator, "openai", null, null);
     try std.testing.expectError(error.FetchFailed, result);
 }
 
 test "fetchModelsFromApi returns error for groq without key" {
-    const result = fetchModelsFromApi(std.testing.allocator, "groq", null);
+    const result = fetchModelsFromApi(std.testing.allocator, "groq", null, null);
     try std.testing.expectError(error.FetchFailed, result);
+}
+
+test "resolveNativeModelsRequest uses base_url for custom provider (regression #936)" {
+    const allocator = std.testing.allocator;
+    // A provider with an arbitrary name and a configured base_url must resolve
+    // to <base_url>/models with optional auth — not fall through to null
+    // (which previously caused the hardcoded Claude fallback).
+    const req = (try resolveNativeModelsRequest(allocator, "my-gateway", "http://192.168.1.100:8080/v1")) orelse
+        return error.TestExpectedEqual;
+    defer if (req.url_owned) allocator.free(req.url);
+    try std.testing.expectEqualStrings("http://192.168.1.100:8080/v1/models", req.url);
+    try std.testing.expect(!req.needs_auth);
+    try std.testing.expect(req.auth_optional);
+}
+
+test "resolveNativeModelsRequest returns null for unknown provider without base_url (regression #936)" {
+    const allocator = std.testing.allocator;
+    // Without a base_url and without being a known/url provider, there is no
+    // resolvable endpoint — caller must fall back rather than guess.
+    const req = try resolveNativeModelsRequest(allocator, "my-gateway", null);
+    try std.testing.expect(req == null);
+}
+
+test "resolveNativeModelsRequest keeps known providers and url providers intact" {
+    const allocator = std.testing.allocator;
+
+    // Known static provider: fixed catalog URL, not owned.
+    const known = (try resolveNativeModelsRequest(allocator, "openrouter", null)) orelse
+        return error.TestExpectedEqual;
+    defer if (known.url_owned) allocator.free(known.url);
+    try std.testing.expectEqualStrings("https://openrouter.ai/api/v1/models", known.url);
+    try std.testing.expect(!known.url_owned);
+
+    // Bare http(s) provider (custom: path): built URL, hard auth required.
+    const url_provider = (try resolveNativeModelsRequest(allocator, "https://api.example.com/v1", null)) orelse
+        return error.TestExpectedEqual;
+    defer if (url_provider.url_owned) allocator.free(url_provider.url);
+    try std.testing.expectEqualStrings("https://api.example.com/v1/models", url_provider.url);
+    try std.testing.expect(url_provider.needs_auth);
+    try std.testing.expect(!url_provider.auth_optional);
 }
 
 test "ModelsCacheEntry struct has expected fields" {
@@ -5216,7 +5297,7 @@ test "fetchModels returns models for anthropic (no network)" {
     defer std.testing.allocator.free(test_home_z);
     try std.testing.expectEqual(@as(c_int, 0), c.setenv(env_name.ptr, test_home_z.ptr, 1));
 
-    const models = try fetchModels(std.testing.allocator, "anthropic", null);
+    const models = try fetchModels(std.testing.allocator, "anthropic", null, null);
     // Anthropic uses hardcoded fallback (allocated copies via fetchModelsFromApi)
     defer {
         for (models) |m| std.testing.allocator.free(m);
@@ -5227,7 +5308,7 @@ test "fetchModels returns models for anthropic (no network)" {
 }
 
 test "fetchModels returns models for gemini (no network)" {
-    const models = try fetchModels(std.testing.allocator, "gemini", null);
+    const models = try fetchModels(std.testing.allocator, "gemini", null, null);
     defer {
         for (models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(models);
@@ -5237,7 +5318,7 @@ test "fetchModels returns models for gemini (no network)" {
 }
 
 test "fetchModels returns models for deepseek (no network)" {
-    const models = try fetchModels(std.testing.allocator, "deepseek", null);
+    const models = try fetchModels(std.testing.allocator, "deepseek", null, null);
     defer {
         for (models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(models);
@@ -5248,7 +5329,7 @@ test "fetchModels returns models for deepseek (no network)" {
 
 test "fetchModels returns fallback for openai without key" {
     // OpenAI needs auth — without key, should gracefully fall back
-    const models = try fetchModels(std.testing.allocator, "openai", null);
+    const models = try fetchModels(std.testing.allocator, "openai", null, null);
     defer {
         for (models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(models);
@@ -5258,7 +5339,7 @@ test "fetchModels returns fallback for openai without key" {
 }
 
 test "fetchModels returns fallback for unknown provider" {
-    const models = try fetchModels(std.testing.allocator, "some-random-provider", null);
+    const models = try fetchModels(std.testing.allocator, "some-random-provider", null, null);
     defer {
         for (models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(models);
@@ -5268,7 +5349,7 @@ test "fetchModels returns fallback for unknown provider" {
 }
 
 test "fetchModels handles google alias" {
-    const models = try fetchModels(std.testing.allocator, "google", null);
+    const models = try fetchModels(std.testing.allocator, "google", null, null);
     defer {
         for (models) |m| std.testing.allocator.free(m);
         std.testing.allocator.free(models);

--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -566,7 +566,7 @@ pub fn fetchModelsFromApi(allocator: std.mem.Allocator, provider: []const u8, ap
 
     // Tests must stay deterministic and offline; production can consult the
     // public models.dev catalog as a secondary source.
-    if (!builtin.is_test and shouldUseModelsDevCatalog(canonical, api_key)) {
+    if (!builtin.is_test and shouldUseModelsDevCatalog(canonical, api_key, base_url)) {
         if (fetchModelsFromModelsDev(allocator, canonical)) |maybe_models| {
             if (maybe_models) |models| return models;
         } else |err| {
@@ -608,6 +608,16 @@ fn resolveNativeModelsRequest(
     canonical: []const u8,
     base_url: ?[]const u8,
 ) !?NativeModelsRequest {
+    if (base_url) |configured| {
+        // Config base_url overrides built-in URL tables, matching provider
+        // factory behavior for OpenAI-compatible providers.
+        return .{
+            .url = try buildModelsUrl(allocator, configured),
+            .url_owned = true,
+            .needs_auth = false,
+            .auth_optional = true,
+        };
+    }
     if (staticNativeModelCatalogForProvider(canonical)) |catalog| {
         return .{
             .url = catalog.url,
@@ -617,25 +627,23 @@ fn resolveNativeModelsRequest(
             .parse_options = catalog.parse_options,
         };
     }
+    if (std.mem.startsWith(u8, canonical, "custom:")) {
+        const custom_url = canonical["custom:".len..];
+        if (std.mem.startsWith(u8, custom_url, "http://") or std.mem.startsWith(u8, custom_url, "https://")) {
+            return .{
+                .url = try buildModelsUrl(allocator, custom_url),
+                .url_owned = true,
+                .needs_auth = false,
+                .auth_optional = true,
+            };
+        }
+    }
     if (std.mem.startsWith(u8, canonical, "http://") or std.mem.startsWith(u8, canonical, "https://")) {
         return .{
             .url = try buildModelsUrl(allocator, canonical),
             .url_owned = true,
             .needs_auth = true,
             .auth_optional = false,
-        };
-    }
-    if (base_url) |configured| {
-        // Custom OpenAI-compatible provider with an arbitrary name and a
-        // `base_url` in config. Query <base_url>/models like any other
-        // OpenAI-style endpoint. Auth is optional: local routers
-        // (LM Studio, llama.cpp, vLLM) commonly serve models without a key,
-        // but we still attach one when configured.
-        return .{
-            .url = try buildModelsUrl(allocator, configured),
-            .url_owned = true,
-            .needs_auth = false,
-            .auth_optional = true,
         };
     }
     return null;
@@ -698,7 +706,8 @@ fn modelsDevProviderKey(provider: []const u8) ?[]const u8 {
     return null;
 }
 
-fn shouldUseModelsDevCatalog(provider: []const u8, api_key: ?[]const u8) bool {
+fn shouldUseModelsDevCatalog(provider: []const u8, api_key: ?[]const u8, base_url: ?[]const u8) bool {
+    if (base_url != null) return false;
     if (modelsDevProviderKey(provider) == null) return false;
     if (std.mem.eql(u8, provider, "openai") or std.mem.eql(u8, provider, "groq")) {
         return api_key == null;
@@ -706,8 +715,12 @@ fn shouldUseModelsDevCatalog(provider: []const u8, api_key: ?[]const u8) bool {
     return true;
 }
 
-fn modelsCacheProviderKey(allocator: std.mem.Allocator, provider: []const u8, api_key: ?[]const u8) ![]const u8 {
-    if (!shouldUseModelsDevCatalog(provider, api_key)) {
+fn modelsCacheProviderKey(allocator: std.mem.Allocator, provider: []const u8, api_key: ?[]const u8, base_url: ?[]const u8) ![]const u8 {
+    if (base_url) |configured| {
+        const endpoint_hash = std.hash.Wyhash.hash(0, configured);
+        return try std.fmt.allocPrint(allocator, "{s}@base-url:{x}", .{ provider, endpoint_hash });
+    }
+    if (!shouldUseModelsDevCatalog(provider, api_key, null)) {
         return try allocator.dupe(u8, provider);
     }
     return try std.fmt.allocPrint(allocator, "{s}@models.dev", .{provider});
@@ -971,7 +984,7 @@ fn loadModelsWithCacheInner(allocator: std.mem.Allocator, cache_dir: []const u8,
     const canonical = canonicalProviderName(provider);
     const cache_path = try std.fmt.allocPrint(allocator, "{s}/models_cache.json", .{cache_dir});
     defer allocator.free(cache_path);
-    const cache_provider = try modelsCacheProviderKey(allocator, canonical, api_key);
+    const cache_provider = try modelsCacheProviderKey(allocator, canonical, api_key, base_url);
     defer allocator.free(cache_provider);
 
     // Try reading cache file
@@ -1044,15 +1057,13 @@ fn saveCachedModels(allocator: std.mem.Allocator, cache_path: []const u8, provid
     var ts_buf: [24]u8 = undefined;
     const ts_str = std.fmt.bufPrint(&ts_buf, "{d}", .{std_compat.time.timestamp()}) catch return;
     try buf.appendSlice(allocator, ts_str);
-    try buf.appendSlice(allocator, ",\n  \"");
-    try buf.appendSlice(allocator, provider);
-    try buf.appendSlice(allocator, "\": [");
+    try buf.appendSlice(allocator, ",\n  ");
+    try json_util.appendJsonString(&buf, allocator, provider);
+    try buf.appendSlice(allocator, ": [");
 
     for (models, 0..) |m, i| {
         if (i > 0) try buf.appendSlice(allocator, ", ");
-        try buf.append(allocator, '"');
-        try buf.appendSlice(allocator, m);
-        try buf.append(allocator, '"');
+        try json_util.appendJsonString(&buf, allocator, m);
     }
 
     try buf.appendSlice(allocator, "]\n}\n");
@@ -5091,17 +5102,55 @@ test "cache read returns error for expired cache" {
 }
 
 test "modelsCacheProviderKey keeps public catalog separate from native listings" {
-    const public_key = try modelsCacheProviderKey(std.testing.allocator, "openai", null);
+    const public_key = try modelsCacheProviderKey(std.testing.allocator, "openai", null, null);
     defer std.testing.allocator.free(public_key);
     try std.testing.expectEqualStrings("openai@models.dev", public_key);
 
-    const native_key = try modelsCacheProviderKey(std.testing.allocator, "openai", "test-key");
+    const native_key = try modelsCacheProviderKey(std.testing.allocator, "openai", "test-key", null);
     defer std.testing.allocator.free(native_key);
     try std.testing.expectEqualStrings("openai", native_key);
 
-    const anthropic_key = try modelsCacheProviderKey(std.testing.allocator, "anthropic", null);
+    const anthropic_key = try modelsCacheProviderKey(std.testing.allocator, "anthropic", null, null);
     defer std.testing.allocator.free(anthropic_key);
     try std.testing.expectEqualStrings("anthropic@models.dev", anthropic_key);
+
+    const base_url_key = try modelsCacheProviderKey(std.testing.allocator, "my-gateway", null, "http://127.0.0.1:8080/v1");
+    defer std.testing.allocator.free(base_url_key);
+    try std.testing.expect(std.mem.startsWith(u8, base_url_key, "my-gateway@base-url:"));
+}
+
+test "modelsCacheProviderKey separates configured base_url endpoints" {
+    // Regression: custom provider names can point at different gateways over
+    // time; their cached model lists must not alias only by provider name.
+    const first = try modelsCacheProviderKey(std.testing.allocator, "my-gateway", null, "http://127.0.0.1:8080/v1");
+    defer std.testing.allocator.free(first);
+    const second = try modelsCacheProviderKey(std.testing.allocator, "my-gateway", null, "http://127.0.0.1:9090/v1");
+    defer std.testing.allocator.free(second);
+
+    try std.testing.expect(!std.mem.eql(u8, first, second));
+}
+
+test "cache round-trip escapes provider keys and model ids" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(base);
+    const cache_path = try std_compat.fs.path.join(std.testing.allocator, &.{ base, "models_cache.json" });
+    defer std.testing.allocator.free(cache_path);
+
+    const models = [_][]const u8{ "model\"quote", "path\\model" };
+    try saveCachedModels(std.testing.allocator, cache_path, "provider\"quote", &models);
+
+    const loaded = try readCachedModels(std.testing.allocator, cache_path, "provider\"quote");
+    defer {
+        for (loaded) |m| std.testing.allocator.free(m);
+        std.testing.allocator.free(loaded);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), loaded.len);
+    try std.testing.expectEqualStrings("model\"quote", loaded[0]);
+    try std.testing.expectEqualStrings("path\\model", loaded[1]);
 }
 
 test "loadModelsWithCache keeps public and native cache entries separate" {
@@ -5218,6 +5267,30 @@ test "resolveNativeModelsRequest uses base_url for custom provider (regression #
         return error.TestExpectedEqual;
     defer if (req.url_owned) allocator.free(req.url);
     try std.testing.expectEqualStrings("http://192.168.1.100:8080/v1/models", req.url);
+    try std.testing.expect(!req.needs_auth);
+    try std.testing.expect(req.auth_optional);
+}
+
+test "resolveNativeModelsRequest lets base_url override known provider catalog (regression #936)" {
+    const allocator = std.testing.allocator;
+    // Runtime config lets OpenAI-compatible providers override their base_url;
+    // model listing must query the same endpoint instead of a built-in catalog.
+    const req = (try resolveNativeModelsRequest(allocator, "groq", "http://127.0.0.1:8080/v1")) orelse
+        return error.TestExpectedEqual;
+    defer if (req.url_owned) allocator.free(req.url);
+    try std.testing.expectEqualStrings("http://127.0.0.1:8080/v1/models", req.url);
+    try std.testing.expect(!req.needs_auth);
+    try std.testing.expect(req.auth_optional);
+}
+
+test "resolveNativeModelsRequest supports custom prefix without separate base_url (regression #936)" {
+    const allocator = std.testing.allocator;
+    // Interactive paths often carry an explicit providers entry with base_url,
+    // but direct custom: providers should still resolve by their embedded URL.
+    const req = (try resolveNativeModelsRequest(allocator, "custom:http://127.0.0.1:8080/v1", null)) orelse
+        return error.TestExpectedEqual;
+    defer if (req.url_owned) allocator.free(req.url);
+    try std.testing.expectEqualStrings("http://127.0.0.1:8080/v1/models", req.url);
     try std.testing.expect(!req.needs_auth);
     try std.testing.expect(req.auth_optional);
 }


### PR DESCRIPTION
## Summary

Closes #936.

Selecting a custom OpenAI-compatible provider — an arbitrary name plus a
`base_url` in config — through the interactive `/models` menu (e.g. on
Telegram) lists **three hardcoded Claude models** instead of the
provider's real catalog. The provider is never queried.

```json
"my-gateway": {
    "api_key": "sk-...",
    "base_url": "http://192.168.1.100:8080/v1"
}
```

`/models` → select `my-gateway` → shows `anthropic_fallback`, unrelated
to the configured endpoint.

## Root cause

`fetchModelsFromNativeApi` (`src/onboard.zig`) resolves a `/models`
endpoint only for:

- hardcoded names (`openrouter`, `openai`, `groq`, ...), and
- providers whose **name itself is a URL** (the `custom:` path,
  `startsWith("http://")`).

A named provider with a separate `base_url` matches neither, so the
function returns `null` → `fetchModelsFromApi` fails → the static
`anthropic_fallback` list is returned.

The deeper issue: `base_url` was never threaded down to the resolver.
`fetchModels` / `fetchModelsFromApi` / `fetchModelsFromNativeApi` only
received the provider name and api_key, even though the `/models` call
site already loads the config (and therefore has `base_url`) right there.

## Fix

1. Thread `base_url: ?[]const u8` from the caller down the chain:
   `fetchModels` → `loadModelsWithCache` → `loadModelsWithCacheInner`
   → `fetchModelsFromApi` → `fetchModelsFromNativeApi`.
2. Add a resolution branch: when a `base_url` is configured, GET
   `<base_url>/models` (reusing the existing `buildModelsUrl`). Auth is
   **optional** there — local routers (LM Studio, llama.cpp, vLLM) serve
   the list without a key — but a configured key is still attached when
   present.
3. Factor the endpoint/auth decision into a pure
   `resolveNativeModelsRequest(canonical, base_url)` helper that does no
   I/O, so the routing logic is unit-testable offline.
4. Wire `base_url` at the two real call sites:
   - `agent/commands.zig` `/models` menu — from
     `cfg.getProviderBaseUrl(provider_name)`.
   - `onboard.zig` interactive setup — from
     `cfg.getProviderBaseUrl(default_provider)`.
5. `nullclaw --list-models` gains a matching `--base-url` flag so NullHub
   can enumerate custom endpoints the same way.

Auth handling was tightened into needs_auth (hard) vs auth_optional
(attach-if-present); existing known/url providers keep their exact prior
behavior (hard auth requirement, fall back to null when no key).

## Tests

Three offline unit tests on `resolveNativeModelsRequest` in
`src/onboard.zig`:

- `resolveNativeModelsRequest uses base_url for custom provider (regression #936)`
  — `my-gateway` + base_url resolves to `<base_url>/models` with
  `auth_optional` and not `needs_auth`.
- `resolveNativeModelsRequest returns null for unknown provider without base_url (regression #936)`
  — the pre-fix path: no base_url, unknown name → null (caller falls
  back), proving we did not change behavior for that case.
- `resolveNativeModelsRequest keeps known providers and url providers intact`
  — `openrouter` keeps its static (non-owned) catalog URL; a bare
  `https://...` provider keeps `needs_auth = true`. Guards against
  regressing the existing two branches.

Sanity-checked by stubbing the base_url branch to `return null` and
re-running: the first regression test fails; the other two still pass.
Restored: all three pass.

## Verification

```
$ zig build test --summary all
... 7312 pass, 25 skip, 1 fail (7338 total)
```

The single failure (`tools.git.test.git add accepts string paths
parameter`) also fails on unmodified `main` in the same Docker test
environment — pre-existing flake, unrelated to this change.

## Scope

Out of scope:

- Probing/validating the endpoint before saving in the onboarding wizard
  (a separate UX flow).
- The model list parse format is the generic OpenAI `{ "data": [...] }`
  shape via the existing `fetchAndParseModels` path; provider-specific
  parse quirks are not addressed here.

## Environment

- Built and tested via `local/zig:0.16.0` Docker image
- Branch off current `main`
