### PR TITLE
fix(redaction): reject ISO date/time patterns as false-positive phone matches

### DIFF
--- a/src/redaction.zig
+++ b/src/redaction.zig
@@ -663,32 +663,66 @@ fn firstDigit(input: []const u8) ?u8 {
 }
 
 fn isDateLike(raw: []const u8) bool {
-    if (raw.len >= 5) {
-        if (std.ascii.isDigit(raw[0]) and
-            std.ascii.isDigit(raw[1]) and
-            std.ascii.isDigit(raw[2]) and
-            std.ascii.isDigit(raw[3]) and
-            raw[4] == '-')
-        {
-            return true;
-        }
+    return hasYmdDatePrefix(raw) or hasDmyDatePrefix(raw);
+}
+
+fn hasYmdDatePrefix(raw: []const u8) bool {
+    if (raw.len < 10) return false;
+    if (raw[4] != '-' or raw[7] != '-') return false;
+    if (!datePrefixTerminated(raw, 10)) return false;
+
+    const year = parseFourDigits(raw[0..4]) orelse return false;
+    const month = parseTwoDigits(raw[5], raw[6]) orelse return false;
+    const day = parseTwoDigits(raw[8], raw[9]) orelse return false;
+    return isPlausibleDate(year, month, day);
+}
+
+fn hasDmyDatePrefix(raw: []const u8) bool {
+    if (raw.len < 10) return false;
+    if (raw[2] != '-' or raw[5] != '-') return false;
+    if (!datePrefixTerminated(raw, 10)) return false;
+
+    const day = parseTwoDigits(raw[0], raw[1]) orelse return false;
+    const month = parseTwoDigits(raw[3], raw[4]) orelse return false;
+    const year = parseFourDigits(raw[6..10]) orelse return false;
+    return isPlausibleDate(year, month, day);
+}
+
+fn datePrefixTerminated(raw: []const u8, prefix_len: usize) bool {
+    return raw.len == prefix_len or raw[prefix_len] == ' ';
+}
+
+fn parseTwoDigits(a: u8, b: u8) ?u8 {
+    if (!std.ascii.isDigit(a) or !std.ascii.isDigit(b)) return null;
+    return (a - '0') * 10 + (b - '0');
+}
+
+fn parseFourDigits(raw: []const u8) ?u16 {
+    if (raw.len != 4) return null;
+    var value: u16 = 0;
+    for (raw) |c| {
+        if (!std.ascii.isDigit(c)) return null;
+        const digit: u16 = @intCast(c - '0');
+        value = value * 10 + digit;
     }
-    if (raw.len >= 11) {
-        if (std.ascii.isDigit(raw[0]) and
-            std.ascii.isDigit(raw[1]) and
-            raw[2] == '-' and
-            std.ascii.isDigit(raw[3]) and
-            std.ascii.isDigit(raw[4]) and
-            raw[5] == '-' and
-            std.ascii.isDigit(raw[6]) and
-            std.ascii.isDigit(raw[7]) and
-            std.ascii.isDigit(raw[8]) and
-            std.ascii.isDigit(raw[9]))
-        {
-            return true;
-        }
-    }
-    return false;
+    return value;
+}
+
+fn isPlausibleDate(year: u16, month: u8, day: u8) bool {
+    if (year < 1900 or year > 2199) return false;
+    if (month < 1 or month > 12 or day < 1) return false;
+
+    const max_day: u8 = switch (month) {
+        1, 3, 5, 7, 8, 10, 12 => 31,
+        4, 6, 9, 11 => 30,
+        2 => if (isLeapYear(year)) 29 else 28,
+        else => return false,
+    };
+    return day <= max_day;
+}
+
+fn isLeapYear(year: u16) bool {
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0);
 }
 
 const IdMatch = struct { value_start: usize, value_end: usize };
@@ -1209,7 +1243,8 @@ test "Redactor max_identity_entries bounds placeholder maps" {
     try std.testing.expectEqualStrings("known a@b.co capped [EMAIL_0]", restored);
 }
 
-test "Redactor ISO datetime preserved — regression for #944" {
+test "Redactor ISO datetime preserved - regression for #944" {
+    // Regression: #944. Prompt timestamps must not be replaced with [PHONE_N].
     const allocator = std.testing.allocator;
     var r = Redactor.init(allocator, .{});
     defer r.deinit();
@@ -1219,6 +1254,7 @@ test "Redactor ISO datetime preserved — regression for #944" {
 }
 
 test "Redactor ISO datetime DD-MM-YYYY preserved" {
+    // Regression: #944. Locale date/time strings can satisfy the phone heuristic.
     const allocator = std.testing.allocator;
     var r = Redactor.init(allocator, .{});
     defer r.deinit();
@@ -1228,6 +1264,7 @@ test "Redactor ISO datetime DD-MM-YYYY preserved" {
 }
 
 test "Redactor full system date string preserved" {
+    // Regression: #944. The full prompt date string must survive redaction.
     const allocator = std.testing.allocator;
     var r = Redactor.init(allocator, .{});
     defer r.deinit();
@@ -1238,6 +1275,7 @@ test "Redactor full system date string preserved" {
 }
 
 test "Redactor phone still redacted alongside dates" {
+    // Regression: #944 fix must not disable phone matches near date strings.
     const allocator = std.testing.allocator;
     var r = Redactor.init(allocator, .{});
     defer r.deinit();
@@ -1247,6 +1285,7 @@ test "Redactor phone still redacted alongside dates" {
 }
 
 test "Redactor cron heartbeat timestamp preserved" {
+    // Regression: #944. Heartbeat timestamps use the same false-positive shape.
     const allocator = std.testing.allocator;
     var r = Redactor.init(allocator, .{});
     defer r.deinit();
@@ -1255,6 +1294,17 @@ test "Redactor cron heartbeat timestamp preserved" {
     );
     defer allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "PHONE") == null);
+}
+
+test "Redactor non-date hyphenated phone heuristic still redacts" {
+    // Regression: date false-positive filtering must not treat every dddd- run
+    // as a date and silently weaken the existing phone heuristic.
+    const allocator = std.testing.allocator;
+    var r = Redactor.init(allocator, .{});
+    defer r.deinit();
+    const out = try r.redact(allocator, "call 1234-567-890 now");
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("call [PHONE_1] now", out);
 }
 
 test "matchPlaceholderEnd: covers all kinds and rejects look-alikes" {

--- a/src/redaction.zig
+++ b/src/redaction.zig
@@ -651,6 +651,7 @@ fn matchPhone(input: []const u8, pos: usize) ?PhoneMatch {
         }
     }
     if (last_digit_end < input.len and std.ascii.isAlphanumeric(input[last_digit_end])) return null;
+    if (isDateLike(input[pos..last_digit_end])) return null;
     return .{ .start = pos, .end = last_digit_end };
 }
 
@@ -659,6 +660,35 @@ fn firstDigit(input: []const u8) ?u8 {
         if (std.ascii.isDigit(c)) return c;
     }
     return null;
+}
+
+fn isDateLike(raw: []const u8) bool {
+    if (raw.len >= 5) {
+        if (std.ascii.isDigit(raw[0]) and
+            std.ascii.isDigit(raw[1]) and
+            std.ascii.isDigit(raw[2]) and
+            std.ascii.isDigit(raw[3]) and
+            raw[4] == '-')
+        {
+            return true;
+        }
+    }
+    if (raw.len >= 11) {
+        if (std.ascii.isDigit(raw[0]) and
+            std.ascii.isDigit(raw[1]) and
+            raw[2] == '-' and
+            std.ascii.isDigit(raw[3]) and
+            std.ascii.isDigit(raw[4]) and
+            raw[5] == '-' and
+            std.ascii.isDigit(raw[6]) and
+            std.ascii.isDigit(raw[7]) and
+            std.ascii.isDigit(raw[8]) and
+            std.ascii.isDigit(raw[9]))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 const IdMatch = struct { value_start: usize, value_end: usize };
@@ -1177,6 +1207,54 @@ test "Redactor max_identity_entries bounds placeholder maps" {
     const restored = try r.unredact(allocator, "known [EMAIL_1] capped [EMAIL_0]");
     defer allocator.free(restored);
     try std.testing.expectEqualStrings("known a@b.co capped [EMAIL_0]", restored);
+}
+
+test "Redactor ISO datetime preserved — regression for #944" {
+    const allocator = std.testing.allocator;
+    var r = Redactor.init(allocator, .{});
+    defer r.deinit();
+    const out = try r.redact(allocator, "Current time: 2026-06-02 20:17 UTC");
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("Current time: 2026-06-02 20:17 UTC", out);
+}
+
+test "Redactor ISO datetime DD-MM-YYYY preserved" {
+    const allocator = std.testing.allocator;
+    var r = Redactor.init(allocator, .{});
+    defer r.deinit();
+    const out = try r.redact(allocator, "02-06-2026 20:17 UTC");
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("02-06-2026 20:17 UTC", out);
+}
+
+test "Redactor full system date string preserved" {
+    const allocator = std.testing.allocator;
+    var r = Redactor.init(allocator, .{});
+    defer r.deinit();
+    const out = try r.redact(allocator, "Tue Jun 02 2026-06-02 20:17:00 CST 2026");
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "PHONE") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "2026-06-02") != null);
+}
+
+test "Redactor phone still redacted alongside dates" {
+    const allocator = std.testing.allocator;
+    var r = Redactor.init(allocator, .{});
+    defer r.deinit();
+    const out = try r.redact(allocator, "at 2026-06-02 20:17 UTC call (202) 555-1234");
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("at 2026-06-02 20:17 UTC call [PHONE_1]", out);
+}
+
+test "Redactor cron heartbeat timestamp preserved" {
+    const allocator = std.testing.allocator;
+    var r = Redactor.init(allocator, .{});
+    defer r.deinit();
+    const out = try r.redact(allocator,
+        \\ Heartbeat from bot at 2026-06-02 20:17 UTC
+    );
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "PHONE") == null);
 }
 
 test "matchPlaceholderEnd: covers all kinds and rejects look-alikes" {


### PR DESCRIPTION
## Summary
- Adds `isDateLike()` guard to `matchPhone` in `src/redaction.zig` that rejects matches where the raw text matches ISO date/time patterns (YYYY-MM-DD hh and DD-MM-YYYY hh).
- The system prompt `appendDateTimeSection` emits `{d}-{d:0>2}-{d:0>2} {d:0>2}` (e.g. `2026-06-02 20:17`), which contains 10 digits and 3 separators — exactly matching the non-plus-prefixed phone heuristic, causing `[PHONE_N]` placeholders in date output.
- Adds 5 regression tests covering both date formats, mixed date+phone strings, and realistic system prompt output.

## Why
The PII redactor (`enable_pii_redaction`, default `true` since May 2026) was aggressively replacing date/time digit sequences with `[PHONE_N]` placeholders, corrupting system date output, heartbeat timestamps, and anything that passed through the system prompt datetime section.

## Validation
- `zig build test --summary all`: **7,323 of 7,332 tests passed (9 skipped, 0 failures, 0 leaks)** — full test suite on macOS arm64
- `zig fmt --check src/redaction.zig`: passes
- `zig build -Doptimize=ReleaseSmall`: compiles clean
- **Live deployment verified**: Built and deployed to all 3 active NullClaw hosts (macOS arm64, riscv64-linux, aarch64-linux), confirmed `date` output shows clean timestamps with no `[PHONE_X]` placeholders on all hosts.

## Notes
- `isDateLike` only rejects the two unambiguous ISO date patterns — does not affect actual phone number matching.
- Existing phone redaction tests continue to pass unchanged.
- Closes #944