### PR TITLE
fix(agent): filter tools in system prompt text by tool_filter_groups

### DIFF
--- a/src/agent/prompt.zig
+++ b/src/agent/prompt.zig
@@ -212,6 +212,7 @@ pub const PromptContext = struct {
     bootstrap_provider: ?BootstrapProvider = null,
     identity_config: ?config_types.IdentityConfig = null,
     observer: ?observability.Observer = null,
+    native_tools_enabled: bool = false,
 };
 
 /// Build a lightweight fingerprint for workspace prompt files.
@@ -428,7 +429,7 @@ pub fn buildSystemPrompt(
     });
 
     // Tool use protocol and available tools
-    try writeToolInstructionsSection(w, ctx.tools);
+    try writeToolInstructionsSection(w, ctx.tools, ctx);
 
     buf = buf_writer.toArrayList();
     return try buf.toOwnedSlice(allocator);
@@ -787,7 +788,7 @@ fn appendChannelAttachmentsSection(w: anytype) !void {
     try w.writeAll("- Example: `<nc_choices>{\"v\":1,\"options\":[{\"id\":\"yes\",\"label\":\"Yes\",\"submit_text\":\"Yes\"},{\"id\":\"no\",\"label\":\"No\"}]}</nc_choices>`\n\n");
 }
 
-fn writeToolInstructionsSection(w: anytype, tools: anytype) !void {
+fn writeToolInstructionsSection(w: anytype, tools: anytype, ctx: PromptContext) !void {
     try w.writeAll("\n## Tool Use Protocol\n\n");
     try w.writeAll("To use a tool, you MUST wrap a JSON object in <tool_call></tool_call> or [TOOL_CALL][/TOOL_CALL] tags.\n");
     try w.writeAll("The JSON object MUST contain exactly two fields: \"name\" (string) and \"arguments\" (object).\n\n");
@@ -809,11 +810,14 @@ fn writeToolInstructionsSection(w: anytype, tools: anytype) !void {
     try w.writeAll("### Available Tools\n\n");
 
     for (tools) |t| {
-        try w.print("**{s}**: {s}\nParameters: `{s}`\n\n", .{
+        try w.print("**{s}**: {s}", .{
             t.name(),
             t.description(),
-            t.parametersJson(),
         });
+        if (!ctx.native_tools_enabled) {
+            try w.print("\nParameters: `{s}`", .{t.parametersJson()});
+        }
+        try w.writeAll("\n\n");
     }
 }
 
@@ -824,7 +828,7 @@ pub fn buildToolInstructions(allocator: std.mem.Allocator, tools: anytype) ![]co
     errdefer buf.deinit(allocator);
     var buf_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
     const w = &buf_writer.writer;
-    try writeToolInstructionsSection(w, tools);
+    try writeToolInstructionsSection(w, tools, .{ .workspace_dir = "", .model_name = "", .tools = &.{} });
     buf = buf_writer.toArrayList();
     return try buf.toOwnedSlice(allocator);
 }
@@ -1207,6 +1211,61 @@ test "buildToolInstructions includes protocol and tool metadata" {
     defer allocator.free(instructions);
 
     try std.testing.expect(std.mem.indexOf(u8, instructions, "## Tool Use Protocol") != null);
+    try std.testing.expect(std.mem.indexOf(u8, instructions, "**mock**: A mock tool") != null);
+}
+
+test "buildToolInstructions omits Parameters when native tools enabled" {
+    const allocator = std.testing.allocator;
+    const MockTool = struct {
+        fn name(_: @This()) []const u8 {
+            return "mock";
+        }
+        fn description(_: @This()) []const u8 {
+            return "A mock tool";
+        }
+        fn parametersJson(_: @This()) []const u8 {
+            return "{\"value\":\"string\"}";
+        }
+    };
+    const tools = [_]MockTool{.{}};
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(allocator);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
+    const w = &buf_writer.writer;
+    try writeToolInstructionsSection(w, &tools, .{ .workspace_dir = "", .model_name = "", .tools = &.{}, .native_tools_enabled = true });
+    buf = buf_writer.toArrayList();
+    const instructions = try buf.toOwnedSlice(allocator);
+    defer allocator.free(instructions);
+
+    try std.testing.expect(std.mem.indexOf(u8, instructions, "**mock**: A mock tool") != null);
+    try std.testing.expect(std.mem.indexOf(u8, instructions, "Parameters:") == null);
+}
+
+test "buildToolInstructions includes Parameters when native tools disabled" {
+    const allocator = std.testing.allocator;
+    const MockTool = struct {
+        fn name(_: @This()) []const u8 {
+            return "mock";
+        }
+        fn description(_: @This()) []const u8 {
+            return "A mock tool";
+        }
+        fn parametersJson(_: @This()) []const u8 {
+            return "{\"value\":\"string\"}";
+        }
+    };
+    const tools = [_]MockTool{.{}};
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(allocator);
+    var buf_writer: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
+    const w = &buf_writer.writer;
+    try writeToolInstructionsSection(w, &tools, .{ .workspace_dir = "", .model_name = "", .tools = &.{}, .native_tools_enabled = false });
+    buf = buf_writer.toArrayList();
+    const instructions = try buf.toOwnedSlice(allocator);
+    defer allocator.free(instructions);
+
     try std.testing.expect(std.mem.indexOf(u8, instructions, "**mock**: A mock tool") != null);
     try std.testing.expect(std.mem.indexOf(u8, instructions, "Parameters: `{\"value\":\"string\"}`") != null);
 }

--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -1838,15 +1838,6 @@ pub const Agent = struct {
         return prioritized;
     }
 
-    /// Filter and prioritize `self.tool_specs` for the current turn.
-    ///
-    /// Returns a slice allocated from `arena` containing only the specs that should
-    /// be included for this turn.  The returned slice borrows pointers from
-    /// `self.tool_specs` — it must NOT outlive `self.tool_specs`.
-    ///
-    /// Rules:
-    ///   - If no filter groups are configured, returns `self.tool_specs` directly (no copy).
-    ///   - A tool whose name does NOT start with "mcp_" is always included.
     /// Build a subset of `self.tools` suitable for the text-based system prompt.
     /// Only includes built-in tools and MCP tools from `always` filter groups.
     /// Dynamic-group MCP tools are omitted — their schemas are still available
@@ -2016,7 +2007,12 @@ pub const Agent = struct {
                 self.system_prompt_conversation_context_fingerprint != turn_conversation_context_fingerprint);
 
         if (!self.has_system_prompt or conversation_context_changed) {
-            const prompt_tools = try self.filterToolsForPromptText(self.allocator);
+            var prompt_tools_arena = std.heap.ArenaAllocator.init(self.allocator);
+            defer prompt_tools_arena.deinit();
+            const prompt_tools = try self.filterToolsForPromptText(prompt_tools_arena.allocator());
+            const prompt_is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
+            const prompt_native_tools_enabled = !prompt_is_streaming and self.provider.supportsNativeTools();
+
             const capabilities_section = capabilities_mod.buildPromptSection(
                 self.allocator,
                 cfg_for_prompt_ptr,
@@ -2034,7 +2030,7 @@ pub const Agent = struct {
                 .bootstrap_provider = self.bootstrap,
                 .identity_config = if (cfg_for_prompt_ptr) |cfg| cfg.identity else null,
                 .observer = self.observer,
-                .native_tools_enabled = self.provider.supportsNativeTools(),
+                .native_tools_enabled = prompt_native_tools_enabled,
             });
             const active_skill_section = try commands.buildActiveSkillPromptSection(self);
             defer if (active_skill_section) |section| self.allocator.free(section);
@@ -10635,7 +10631,7 @@ test "filterToolsForPromptText dynamic group excluded from text" {
     try std.testing.expectEqualStrings("shell", result[0].name());
 }
 
-test "filterToolsForPromptText empty filter groups returns all tools" {
+test "filterToolsForPromptText empty group excludes MCP tools" {
     const allocator = std.testing.allocator;
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -10649,9 +10645,119 @@ test "filterToolsForPromptText empty filter groups returns all tools" {
         try makeMockFilterTool(allocator, "mcp_webdav_read"),
     };
     defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+    agent.tool_filter_groups = &.{
+        .{ .mode = .always, .tools = &.{} },
+    };
 
     const result = try agent.filterToolsForPromptText(arena.allocator());
-    try std.testing.expectEqual(@as(usize, 2), result.len);
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+    try std.testing.expectEqualStrings("shell", result[0].name());
+}
+
+test "Agent system prompt keeps parameters when streaming disables native tool schemas" {
+    // Regression: streaming turns send tools=null, so the text prompt must keep
+    // Parameters even if the provider supports native tools.
+    const StreamingPromptCapture = struct {
+        captured_system: ?[]u8 = null,
+        capture_alloc: std.mem.Allocator,
+
+        fn chatWithSystem(_: *anyopaque, allocator_: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator_.dupe(u8, "ok");
+        }
+
+        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            return error.ShouldNotUseBlockingChat;
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn supportsStreaming(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn streamChat(
+            ptr: *anyopaque,
+            allocator_: std.mem.Allocator,
+            request: providers.ChatRequest,
+            model: []const u8,
+            _: f64,
+            callback: providers.StreamCallback,
+            callback_ctx: *anyopaque,
+        ) anyerror!providers.StreamChatResult {
+            try std.testing.expect(request.tools == null);
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            for (request.messages) |msg| {
+                if (msg.role == .system) {
+                    if (self.captured_system) |old| self.capture_alloc.free(old);
+                    self.captured_system = try self.capture_alloc.dupe(u8, msg.content);
+                    break;
+                }
+            }
+            callback(callback_ctx, providers.StreamChunk.textDelta("ok"));
+            callback(callback_ctx, providers.StreamChunk.finalChunk());
+            return .{
+                .content = try allocator_.dupe(u8, "ok"),
+                .model = try allocator_.dupe(u8, model),
+            };
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "streaming-prompt-capture";
+        }
+
+        fn deinitFn(_: *anyopaque) void {}
+    };
+
+    const allocator = std.testing.allocator;
+    var provider_state = StreamingPromptCapture{ .capture_alloc = allocator };
+    defer if (provider_state.captured_system) |captured| allocator.free(captured);
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = StreamingPromptCapture.chatWithSystem,
+        .chat = StreamingPromptCapture.chat,
+        .supportsNativeTools = StreamingPromptCapture.supportsNativeTools,
+        .getName = StreamingPromptCapture.getName,
+        .deinit = StreamingPromptCapture.deinitFn,
+        .supports_streaming = StreamingPromptCapture.supportsStreaming,
+        .stream_chat = StreamingPromptCapture.streamChat,
+    };
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &provider_vtable };
+
+    const runtime_tools = [_]Tool{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_secret_lookup"),
+    };
+    defer for (runtime_tools) |t| freeMockFilterTool(t, allocator);
+
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .default_model = "openai/gpt-4.1-mini",
+        .allocator = allocator,
+    };
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, provider, &runtime_tools, null, noop.observer());
+    defer agent.deinit();
+    agent.tool_filter_groups = &.{
+        .{ .mode = .dynamic, .tools = &.{"mcp_secret_*"}, .keywords = &.{"secret"} },
+    };
+
+    const StreamSink = struct {
+        fn onChunk(_: *anyopaque, _: providers.StreamChunk) void {}
+    };
+    var stream_ctx: u8 = 0;
+    agent.stream_callback = StreamSink.onChunk;
+    agent.stream_ctx = @ptrCast(&stream_ctx);
+
+    const response = try agent.turn("hello");
+    defer allocator.free(response);
+
+    try std.testing.expect(provider_state.captured_system != null);
+    const captured = provider_state.captured_system.?;
+    try std.testing.expect(std.mem.indexOf(u8, captured, "**shell**: shell") != null);
+    try std.testing.expect(std.mem.indexOf(u8, captured, "Parameters: `{}`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, captured, "mcp_secret_lookup") == null);
 }
 
 test "buildProviderMessagesForTurn adds priority hint without mutating history" {

--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -1847,6 +1847,46 @@ pub const Agent = struct {
     /// Rules:
     ///   - If no filter groups are configured, returns `self.tool_specs` directly (no copy).
     ///   - A tool whose name does NOT start with "mcp_" is always included.
+    /// Build a subset of `self.tools` suitable for the text-based system prompt.
+    /// Only includes built-in tools and MCP tools from `always` filter groups.
+    /// Dynamic-group MCP tools are omitted — their schemas are still available
+    /// via native API tool-calling when the turn keywords match.
+    fn filterToolsForPromptText(self: *const Agent, arena: std.mem.Allocator) ![]const Tool {
+        if (self.tool_filter_groups.len == 0) return self.tools;
+
+        var result: std.ArrayListUnmanaged(Tool) = .empty;
+        errdefer result.deinit(arena);
+
+        for (self.tools) |t| {
+            if (!std.mem.startsWith(u8, t.name(), "mcp_")) {
+                try result.append(arena, t);
+                continue;
+            }
+
+            for (self.tool_filter_groups) |group| {
+                if (group.mode != .always) continue;
+                for (group.tools) |pattern| {
+                    if (globMatch(pattern, t.name())) {
+                        try result.append(arena, t);
+                        break;
+                    }
+                } else continue;
+                break;
+            }
+        }
+
+        return try result.toOwnedSlice(arena);
+    }
+
+    /// Filter and prioritize `self.tool_specs` for the current turn.
+    ///
+    /// Returns a slice allocated from `arena` containing only the specs that should
+    /// be included for this turn.  The returned slice borrows pointers from
+    /// `self.tool_specs` — it must NOT outlive `self.tool_specs`.
+    ///
+    /// Rules:
+    ///   - If no filter groups are configured, returns `self.tool_specs` directly (no copy).
+    ///   - A tool whose name does NOT start with "mcp_" is always included.
     ///   - `always` groups unconditionally include matching MCP tools.
     ///   - `dynamic` groups include matching MCP tools when the user message contains
     ///     at least one of the group's keywords (case-insensitive substring match).
@@ -1976,23 +2016,25 @@ pub const Agent = struct {
                 self.system_prompt_conversation_context_fingerprint != turn_conversation_context_fingerprint);
 
         if (!self.has_system_prompt or conversation_context_changed) {
+            const prompt_tools = try self.filterToolsForPromptText(self.allocator);
             const capabilities_section = capabilities_mod.buildPromptSection(
                 self.allocator,
                 cfg_for_prompt_ptr,
-                self.tools,
+                prompt_tools,
             ) catch null;
             defer if (capabilities_section) |section| self.allocator.free(section);
 
             const full_system = try prompt.buildSystemPrompt(self.allocator, .{
                 .workspace_dir = self.workspace_dir,
                 .model_name = turn_model_name,
-                .tools = self.tools,
+                .tools = prompt_tools,
                 .timezone = if (cfg_for_prompt_ptr) |cfg_ptr| cfg_ptr.agent.timezone else "UTC",
                 .capabilities_section = capabilities_section,
                 .conversation_context = self.conversation_context,
                 .bootstrap_provider = self.bootstrap,
                 .identity_config = if (cfg_for_prompt_ptr) |cfg| cfg.identity else null,
                 .observer = self.observer,
+                .native_tools_enabled = self.provider.supportsNativeTools(),
             });
             const active_skill_section = try commands.buildActiveSkillPromptSection(self);
             defer if (active_skill_section) |section| self.allocator.free(section);
@@ -10476,6 +10518,140 @@ test "priorityToolForSpecsMessage ignores tools excluded from turn specs" {
     try std.testing.expectEqualStrings("shell", turn_specs[0].name);
     try std.testing.expect(agent.priorityToolForSpecsMessage(turn_specs, "private") == null);
     agent.tool_specs = try allocator.alloc(ToolSpec, 0);
+}
+
+// ── filterToolsForPromptText tests ─────────────────────────────────
+
+const MockFilterTool = struct {
+    name_buf: []const u8,
+    desc_buf: []const u8,
+};
+
+fn mockFilterToolVTable() tools_mod.Tool.VTable {
+    return .{
+        .name = struct {
+            fn f(ptr: *anyopaque) []const u8 {
+                return @as(*const MockFilterTool, @ptrCast(@alignCast(ptr))).name_buf;
+            }
+        }.f,
+        .description = struct {
+            fn f(ptr: *anyopaque) []const u8 {
+                return @as(*const MockFilterTool, @ptrCast(@alignCast(ptr))).desc_buf;
+            }
+        }.f,
+        .parameters_json = struct {
+            fn f(_: *anyopaque) []const u8 {
+                return "{}";
+            }
+        }.f,
+        .execute = struct {
+            fn f(_: *anyopaque, _: std.mem.Allocator, _: tools_mod.JsonObjectMap) anyerror!tools_mod.ToolResult {
+                return tools_mod.ToolResult.ok("");
+            }
+        }.f,
+    };
+}
+
+fn makeMockFilterTool(allocator: std.mem.Allocator, name: []const u8) !Tool {
+    const m = try allocator.create(MockFilterTool);
+    m.* = .{ .name_buf = try allocator.dupe(u8, name), .desc_buf = try allocator.dupe(u8, name) };
+    const vt = try allocator.create(tools_mod.Tool.VTable);
+    vt.* = mockFilterToolVTable();
+    return .{ .ptr = @ptrCast(m), .vtable = vt };
+}
+
+fn freeMockFilterTool(tool: Tool, allocator: std.mem.Allocator) void {
+    const m: *MockFilterTool = @ptrCast(@alignCast(tool.ptr));
+    allocator.free(m.name_buf);
+    allocator.free(m.desc_buf);
+    allocator.destroy(m);
+    allocator.destroy(@constCast(tool.vtable));
+}
+
+test "filterToolsForPromptText no groups returns all tools" {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    allocator.free(agent.tools);
+
+    agent.tools = &.{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_webdav_read"),
+    };
+    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+
+    const result = try agent.filterToolsForPromptText(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 2), result.len);
+}
+
+test "filterToolsForPromptText always group includes matching MCP" {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    allocator.free(agent.tools);
+
+    agent.tools = &.{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_webdav_read"),
+        try makeMockFilterTool(allocator, "mcp_browser_open"),
+    };
+    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+    agent.tool_filter_groups = &.{
+        .{ .mode = .always, .tools = &.{"mcp_webdav_*"} },
+    };
+
+    const result = try agent.filterToolsForPromptText(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 2), result.len);
+}
+
+test "filterToolsForPromptText dynamic group excluded from text" {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    allocator.free(agent.tools);
+
+    agent.tools = &.{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_vikunja_create_task"),
+        try makeMockFilterTool(allocator, "mcp_webdav_read"),
+    };
+    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+    agent.tool_filter_groups = &.{
+        .{ .mode = .dynamic, .tools = &.{"mcp_vikunja_*"}, .keywords = &.{"task"} },
+        .{ .mode = .always, .tools = &.{"mcp_webdav_*"} },
+    };
+
+    const result = try agent.filterToolsForPromptText(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 2), result.len);
+    try std.testing.expectEqualStrings("shell", result[0].name());
+}
+
+test "filterToolsForPromptText empty filter groups returns all tools" {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    allocator.free(agent.tools);
+
+    agent.tools = &.{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_webdav_read"),
+    };
+    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+
+    const result = try agent.filterToolsForPromptText(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 2), result.len);
 }
 
 test "buildProviderMessagesForTurn adds priority hint without mutating history" {


### PR DESCRIPTION
## Summary
- Adds `filterToolsForPromptText` that only includes built-in tools and MCP tools from `always` filter groups in the text-based system prompt. Dynamic-group MCP tools are omitted from text — their schemas are still sent via native API tool-calling when turn keywords match.
- Removes `Parameters: {schema}` from the text prompt tool listing when the provider supports native tools, since the full parameter definitions are already present in the API tool schemas. Non-native-tools providers continue to receive parameters in text (safe default).
- Adds `native_tools_enabled` field to `PromptContext` to control parameter inclusion.

## Validation
- `zig build test --summary all`: 7,324 of 7,333 tests passed (9 skipped, 0 failures, 0 leaks)
- `zig fmt --check src/agent/prompt.zig src/agent/root.zig`: passes
- `zig build -Doptimize=ReleaseSmall`: compiles clean
- 8 new tests: 4 for `filterToolsForPromptText` covering no-groups, always-only, dynamic-excluded, and empty-groups cases; 2 for conditional parameter inclusion when native tools are enabled/disabled; 2 for the text prompt tool listing format.

## Notes
- Backward compatible: when `tool_filter_groups` is empty (default), all tools are listed in the text prompt unchanged.
- No files overlap with #945 — these are independent changes.