### PR TITLE
fix cron agent delivery attribution

### DIFF
--- a/docs/en/commands.md
+++ b/docs/en/commands.md
@@ -115,7 +115,7 @@ Notes:
 | `nullclaw cron add "0 * * * *" "command"` | Add a recurring shell task |
 | `nullclaw cron add-agent "0 * * * *" "prompt" --model <model> [--announce] [--channel <name>] [--account <id>] [--to <id>]` | Add a recurring agent task |
 | `nullclaw cron once 10m "command"` | Add a one-shot delayed shell task |
-| `nullclaw cron once-agent 10m "prompt" --model <model>` | Add a one-shot delayed agent task |
+| `nullclaw cron once-agent 10m "prompt" --model <model> [--announce] [--channel <name>] [--account <id>] [--to <id>]` | Add a one-shot delayed agent task |
 | `nullclaw cron run <id>` | Run a task immediately |
 | `nullclaw cron pause <id>` / `resume <id>` | Pause or resume a task |
 | `nullclaw cron remove <id>` | Delete a task |

--- a/docs/en/commands.md
+++ b/docs/en/commands.md
@@ -113,9 +113,9 @@ Notes:
 | `nullclaw cron list [--json]` | List scheduled tasks |
 | `nullclaw cron status [--json]` | Show scheduler-level status and job counters |
 | `nullclaw cron add "0 * * * *" "command"` | Add a recurring shell task |
-| `nullclaw cron add-agent "0 * * * *" "prompt" --model <model> [--announce] [--channel <name>] [--account <id>] [--to <id>]` | Add a recurring agent task |
+| `nullclaw cron add-agent "0 * * * *" "prompt" [--model <model>] [--session-target <isolated\|main>] [--announce] [--channel <name>] [--account <id>] [--to <id>]` | Add a recurring agent task |
 | `nullclaw cron once 10m "command"` | Add a one-shot delayed shell task |
-| `nullclaw cron once-agent 10m "prompt" --model <model> [--announce] [--channel <name>] [--account <id>] [--to <id>]` | Add a one-shot delayed agent task |
+| `nullclaw cron once-agent 10m "prompt" [--model <model>] [--session-target <isolated\|main>] [--announce] [--channel <name>] [--account <id>] [--to <id>]` | Add a one-shot delayed agent task |
 | `nullclaw cron run <id>` | Run a task immediately |
 | `nullclaw cron pause <id>` / `resume <id>` | Pause or resume a task |
 | `nullclaw cron remove <id>` | Delete a task |

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -101,7 +101,7 @@
 | `nullclaw cron add "0 * * * *" "command"` | 新增周期性 shell 任务 |
 | `nullclaw cron add-agent "0 * * * *" "prompt" --model <model> [--announce] [--channel <name>] [--account <id>] [--to <id>]` | 新增周期性 agent 任务 |
 | `nullclaw cron once 10m "command"` | 新增一次性延迟任务 |
-| `nullclaw cron once-agent 10m "prompt" --model <model>` | 新增一次性 agent 延迟任务 |
+| `nullclaw cron once-agent 10m "prompt" --model <model> [--announce] [--channel <name>] [--account <id>] [--to <id>]` | 新增一次性 agent 延迟任务 |
 | `nullclaw cron run <id>` | 立即执行指定任务 |
 | `nullclaw cron pause <id>` / `resume <id>` | 暂停 / 恢复任务 |
 | `nullclaw cron remove <id>` | 删除任务 |

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -99,9 +99,9 @@
 | `nullclaw cron list [--json]` | 查看所有计划任务 |
 | `nullclaw cron status [--json]` | 查看 scheduler 层状态与任务计数 |
 | `nullclaw cron add "0 * * * *" "command"` | 新增周期性 shell 任务 |
-| `nullclaw cron add-agent "0 * * * *" "prompt" --model <model> [--announce] [--channel <name>] [--account <id>] [--to <id>]` | 新增周期性 agent 任务 |
+| `nullclaw cron add-agent "0 * * * *" "prompt" [--model <model>] [--session-target <isolated\|main>] [--announce] [--channel <name>] [--account <id>] [--to <id>]` | 新增周期性 agent 任务 |
 | `nullclaw cron once 10m "command"` | 新增一次性延迟任务 |
-| `nullclaw cron once-agent 10m "prompt" --model <model> [--announce] [--channel <name>] [--account <id>] [--to <id>]` | 新增一次性 agent 延迟任务 |
+| `nullclaw cron once-agent 10m "prompt" [--model <model>] [--session-target <isolated\|main>] [--announce] [--channel <name>] [--account <id>] [--to <id>]` | 新增一次性 agent 延迟任务 |
 | `nullclaw cron run <id>` | 立即执行指定任务 |
 | `nullclaw cron pause <id>` / `resume <id>` | 暂停 / 恢复任务 |
 | `nullclaw cron remove <id>` | 删除任务 |

--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -268,6 +268,8 @@ const ParsedAgentArgs = struct {
     agent_name: ?[]const u8 = null,
     workspace_override: ?[]const u8 = null,
     skill_name: ?[]const u8 = null,
+    origin_channel: ?[]const u8 = null,
+    origin_account_id: ?[]const u8 = null,
     verbose: bool = false,
 };
 
@@ -315,6 +317,14 @@ fn parseAgentArgs(args: []const []const u8) AgentArgParseResult {
             if (i + 1 >= args.len) return .{ .missing_value = arg };
             i += 1;
             parsed.skill_name = args[i];
+        } else if (std.mem.eql(u8, arg, "--origin-channel")) {
+            if (i + 1 >= args.len) return .{ .missing_value = arg };
+            i += 1;
+            parsed.origin_channel = args[i];
+        } else if (std.mem.eql(u8, arg, "--origin-account-id")) {
+            if (i + 1 >= args.len) return .{ .missing_value = arg };
+            i += 1;
+            parsed.origin_account_id = args[i];
         } else if (std.mem.eql(u8, arg, "--verbose") or std.mem.eql(u8, arg, "-v")) {
             parsed.verbose = true;
         }
@@ -497,7 +507,8 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
     const start_event = ObserverEvent{ .agent_start = .{
         .provider = if (selected_profile_storage) |profile| profile.provider else cfg.default_provider,
         .model = if (selected_profile_storage) |profile| profile.model else (cfg.default_model orelse "(default)"),
-        .channel = "cli",
+        .channel = parsed_args.origin_channel orelse "cli",
+        .bot_account = parsed_args.origin_account_id,
     } };
     obs.recordEvent(&start_event);
 
@@ -1300,10 +1311,36 @@ test "parseAgentArgs parses --skill" {
     try std.testing.expectEqualStrings("go", parsed.message_arg.?);
 }
 
+test "parseAgentArgs parses cron origin attribution" {
+    const args = [_][]const u8{
+        "--origin-channel",
+        "telegram",
+        "--origin-account-id",
+        "main",
+        "-m",
+        "go",
+    };
+    const parsed = switch (parseAgentArgs(&args)) {
+        .ok => |value| value,
+        else => unreachable,
+    };
+    try std.testing.expectEqualStrings("telegram", parsed.origin_channel.?);
+    try std.testing.expectEqualStrings("main", parsed.origin_account_id.?);
+    try std.testing.expectEqualStrings("go", parsed.message_arg.?);
+}
+
 test "parseAgentArgs returns missing value for --skill" {
     const args = [_][]const u8{"--skill"};
     switch (parseAgentArgs(&args)) {
         .missing_value => |value| try std.testing.expectEqualStrings("--skill", value),
+        else => unreachable,
+    }
+}
+
+test "parseAgentArgs returns missing value for origin attribution" {
+    const args = [_][]const u8{"--origin-channel"};
+    switch (parseAgentArgs(&args)) {
+        .missing_value => |value| try std.testing.expectEqualStrings("--origin-channel", value),
         else => unreachable,
     }
 }

--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -1312,6 +1312,7 @@ test "parseAgentArgs parses --skill" {
 }
 
 test "parseAgentArgs parses cron origin attribution" {
+    // Regression: scheduled child agents must retain delivery origin observability fields.
     const args = [_][]const u8{
         "--origin-channel",
         "telegram",
@@ -1338,10 +1339,14 @@ test "parseAgentArgs returns missing value for --skill" {
 }
 
 test "parseAgentArgs returns missing value for origin attribution" {
-    const args = [_][]const u8{"--origin-channel"};
-    switch (parseAgentArgs(&args)) {
-        .missing_value => |value| try std.testing.expectEqualStrings("--origin-channel", value),
-        else => unreachable,
+    // Regression: incomplete internal origin flags must fail before agent startup.
+    const flags = [_][]const u8{ "--origin-channel", "--origin-account-id" };
+    for (flags) |flag| {
+        const args = [_][]const u8{flag};
+        switch (parseAgentArgs(&args)) {
+            .missing_value => |value| try std.testing.expectEqualStrings(flag, value),
+            else => unreachable,
+        }
     }
 }
 

--- a/src/agent_runner.zig
+++ b/src/agent_runner.zig
@@ -14,6 +14,11 @@ pub const AgentRunResult = struct {
     output: []const u8,
 };
 
+pub const AgentRunOptions = struct {
+    origin_channel: ?[]const u8 = null,
+    origin_account_id: ?[]const u8 = null,
+};
+
 pub const MAX_OUTPUT_BYTES: usize = 1_048_576;
 const POLL_STEP_NS: u64 = 200 * std.time.ns_per_ms;
 const LINUX_SELF_EXE_PATH = "/proc/self/exe";
@@ -173,12 +178,49 @@ fn preferExecPath(self_exe_path: []const u8) []const u8 {
     return self_exe_path;
 }
 
+fn appendAgentArgv(
+    allocator: std.mem.Allocator,
+    argv: *std.ArrayListUnmanaged([]const u8),
+    exec_path: []const u8,
+    prompt: []const u8,
+    model: ?[]const u8,
+    options: AgentRunOptions,
+) !void {
+    try argv.append(allocator, exec_path);
+    try argv.append(allocator, "agent");
+    if (model) |m| {
+        try argv.append(allocator, "--model");
+        try argv.append(allocator, m);
+    }
+    if (options.origin_channel) |channel| {
+        try argv.append(allocator, "--origin-channel");
+        try argv.append(allocator, channel);
+    }
+    if (options.origin_account_id) |account_id| {
+        try argv.append(allocator, "--origin-account-id");
+        try argv.append(allocator, account_id);
+    }
+    try argv.append(allocator, "-m");
+    try argv.append(allocator, prompt);
+}
+
 pub fn run(
     allocator: std.mem.Allocator,
     cwd: ?[]const u8,
     prompt: []const u8,
     model: ?[]const u8,
     timeout_secs: u64,
+) !AgentRunResult {
+    return runWithOptions(allocator, cwd, prompt, model, timeout_secs, .{});
+}
+
+pub fn runWithOptions(
+    allocator: std.mem.Allocator,
+    cwd: ?[]const u8,
+    prompt: []const u8,
+    model: ?[]const u8,
+    timeout_secs: u64,
+    options: AgentRunOptions,
 ) !AgentRunResult {
     const exe_path = try std_compat.fs.selfExePathAlloc(allocator);
     defer allocator.free(exe_path);
@@ -195,14 +237,7 @@ pub fn run(
     var child: std_compat.process.Child = undefined;
     spawn_loop: while (true) {
         argv.clearRetainingCapacity();
-        try argv.append(allocator, exec_path);
-        try argv.append(allocator, "agent");
-        if (model) |m| {
-            try argv.append(allocator, "--model");
-            try argv.append(allocator, m);
-        }
-        try argv.append(allocator, "-m");
-        try argv.append(allocator, prompt);
+        try appendAgentArgv(allocator, &argv, exec_path, prompt, model, options);
 
         child = std_compat.process.Child.init(argv.items, allocator);
         child.stdin_behavior = .Ignore;
@@ -367,4 +402,32 @@ test "preferExecPath uses proc self exe for deleted linux path" {
 test "pathAgentExecutableName returns platform command name" {
     const expected = if (comptime builtin.os.tag == .windows) "nullclaw.exe" else "nullclaw";
     try std.testing.expectEqualStrings(expected, pathAgentExecutableName());
+}
+
+test "appendAgentArgv includes cron origin attribution" {
+    const allocator = std.testing.allocator;
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer argv.deinit(allocator);
+
+    try appendAgentArgv(allocator, &argv, "/usr/bin/nullclaw", "say test", "glm-cn/glm-5-turbo", .{
+        .origin_channel = "telegram",
+        .origin_account_id = "main",
+    });
+
+    const expected = [_][]const u8{
+        "/usr/bin/nullclaw",
+        "agent",
+        "--model",
+        "glm-cn/glm-5-turbo",
+        "--origin-channel",
+        "telegram",
+        "--origin-account-id",
+        "main",
+        "-m",
+        "say test",
+    };
+    try std.testing.expectEqual(expected.len, argv.items.len);
+    for (expected, argv.items) |want, got| {
+        try std.testing.expectEqualStrings(want, got);
+    }
 }

--- a/src/agent_runner.zig
+++ b/src/agent_runner.zig
@@ -405,11 +405,12 @@ test "pathAgentExecutableName returns platform command name" {
 }
 
 test "appendAgentArgv includes cron origin attribution" {
+    // Regression: scheduled child agents must receive origin metadata in every spawn attempt.
     const allocator = std.testing.allocator;
     var argv: std.ArrayListUnmanaged([]const u8) = .empty;
     defer argv.deinit(allocator);
 
-    try appendAgentArgv(allocator, &argv, "/usr/bin/nullclaw", "say test", "glm-cn/glm-5-turbo", .{
+    try appendAgentArgv(allocator, &argv, "/usr/bin/nullclaw", "Summarize status", "test-model", .{
         .origin_channel = "telegram",
         .origin_account_id = "main",
     });
@@ -418,13 +419,13 @@ test "appendAgentArgv includes cron origin attribution" {
         "/usr/bin/nullclaw",
         "agent",
         "--model",
-        "glm-cn/glm-5-turbo",
+        "test-model",
         "--origin-channel",
         "telegram",
         "--origin-account-id",
         "main",
         "-m",
-        "say test",
+        "Summarize status",
     };
     try std.testing.expectEqual(expected.len, argv.items.len);
     for (expected, argv.items) |want, got| {

--- a/src/bus.zig
+++ b/src/bus.zig
@@ -17,7 +17,7 @@ const thread_stacks = @import("thread_stacks.zig");
 // ---------------------------------------------------------------------------
 
 pub const InboundMessage = struct {
-    channel: []const u8, // "telegram", "discord", "webhook", "system"
+    channel: []const u8, // owned channel name: "telegram", "discord", "webhook", "system"
     sender_id: []const u8, // sender identifier
     chat_id: []const u8, // chat/room identifier
     content: []const u8, // message text
@@ -29,7 +29,7 @@ pub const InboundMessage = struct {
         for (self.media) |m| allocator.free(m);
         if (self.media.len > 0) allocator.free(self.media);
         if (self.metadata_json) |md| allocator.free(md);
-        // channel is a string literal or long-lived config pointer — not owned, don't free
+        allocator.free(self.channel);
         allocator.free(self.sender_id);
         allocator.free(self.chat_id);
         allocator.free(self.content);
@@ -38,7 +38,7 @@ pub const InboundMessage = struct {
 };
 
 pub const OutboundMessage = struct {
-    channel: []const u8, // target channel
+    channel: []const u8, // owned target channel
     account_id: ?[]const u8 = null, // target account (multi-account channels)
     chat_id: []const u8, // target chat
     content: []const u8, // response text
@@ -52,7 +52,7 @@ pub const OutboundMessage = struct {
         if (self.media.len > 0) allocator.free(self.media);
         for (self.choices) |choice| choice.deinit(allocator);
         if (self.choices.len > 0) allocator.free(self.choices);
-        // channel is a string literal or long-lived config pointer — not owned, don't free
+        allocator.free(self.channel);
         if (self.account_id) |aid| allocator.free(aid);
         allocator.free(self.chat_id);
         allocator.free(self.content);
@@ -71,7 +71,8 @@ pub fn makeInbound(
     content: []const u8,
     session_key: []const u8,
 ) Allocator.Error!InboundMessage {
-    // channel is not duped — must be a literal or long-lived config pointer
+    const ch = try allocator.dupe(u8, channel);
+    errdefer allocator.free(ch);
     const sid = try allocator.dupe(u8, sender_id);
     errdefer allocator.free(sid);
     const cid = try allocator.dupe(u8, chat_id);
@@ -81,7 +82,7 @@ pub fn makeInbound(
     const sk = try allocator.dupe(u8, session_key);
 
     return .{
-        .channel = channel,
+        .channel = ch,
         .sender_id = sid,
         .chat_id = cid,
         .content = ct,
@@ -100,7 +101,8 @@ pub fn makeInboundFull(
     media_src: []const []const u8,
     metadata_json: ?[]const u8,
 ) Allocator.Error!InboundMessage {
-    // channel is not duped — must be a literal or long-lived config pointer
+    const ch = try allocator.dupe(u8, channel);
+    errdefer allocator.free(ch);
     const sid = try allocator.dupe(u8, sender_id);
     errdefer allocator.free(sid);
     const cid = try allocator.dupe(u8, chat_id);
@@ -134,7 +136,7 @@ pub fn makeInboundFull(
     const md = if (metadata_json) |mj| try allocator.dupe(u8, mj) else null;
 
     return .{
-        .channel = channel,
+        .channel = ch,
         .sender_id = sid,
         .chat_id = cid,
         .content = ct,
@@ -169,13 +171,14 @@ fn makeOutboundWithStage(
     content: []const u8,
     stage: streaming.OutboundStage,
 ) Allocator.Error!OutboundMessage {
-    // channel is not duped — must be a literal or long-lived config pointer
+    const ch = try allocator.dupe(u8, channel);
+    errdefer allocator.free(ch);
     const cid = try allocator.dupe(u8, chat_id);
     errdefer allocator.free(cid);
     const ct = try allocator.dupe(u8, content);
 
     return .{
-        .channel = channel,
+        .channel = ch,
         .chat_id = cid,
         .content = ct,
         .stage = stage,
@@ -210,6 +213,8 @@ fn makeOutboundWithAccountStage(
     content: []const u8,
     stage: streaming.OutboundStage,
 ) Allocator.Error!OutboundMessage {
+    const ch = try allocator.dupe(u8, channel);
+    errdefer allocator.free(ch);
     const cid = try allocator.dupe(u8, chat_id);
     errdefer allocator.free(cid);
     const ct = try allocator.dupe(u8, content);
@@ -217,7 +222,7 @@ fn makeOutboundWithAccountStage(
     const aid = try allocator.dupe(u8, account_id);
 
     return .{
-        .channel = channel,
+        .channel = ch,
         .account_id = aid,
         .chat_id = cid,
         .content = ct,
@@ -291,6 +296,8 @@ pub fn makeOutboundWithChoices(
     content: []const u8,
     choices_src: anytype,
 ) Allocator.Error!OutboundMessage {
+    const ch = try allocator.dupe(u8, channel);
+    errdefer allocator.free(ch);
     const cid = try allocator.dupe(u8, chat_id);
     errdefer allocator.free(cid);
     const ct = try allocator.dupe(u8, content);
@@ -302,7 +309,7 @@ pub fn makeOutboundWithChoices(
     };
 
     return .{
-        .channel = channel,
+        .channel = ch,
         .chat_id = cid,
         .content = ct,
         .choices = choices,
@@ -317,6 +324,8 @@ pub fn makeOutboundWithAccountChoices(
     content: []const u8,
     choices_src: anytype,
 ) Allocator.Error!OutboundMessage {
+    const ch = try allocator.dupe(u8, channel);
+    errdefer allocator.free(ch);
     const cid = try allocator.dupe(u8, chat_id);
     errdefer allocator.free(cid);
     const ct = try allocator.dupe(u8, content);
@@ -330,7 +339,7 @@ pub fn makeOutboundWithAccountChoices(
     };
 
     return .{
-        .channel = channel,
+        .channel = ch,
         .account_id = aid,
         .chat_id = cid,
         .content = ct,
@@ -346,7 +355,8 @@ fn makeOutboundWithMedia(
     content: []const u8,
     media_src: []const []const u8,
 ) Allocator.Error!OutboundMessage {
-    // channel is not duped — must be a literal or long-lived config pointer
+    const ch = try allocator.dupe(u8, channel);
+    errdefer allocator.free(ch);
     const cid = try allocator.dupe(u8, chat_id);
     errdefer allocator.free(cid);
     const ct = try allocator.dupe(u8, content);
@@ -366,7 +376,7 @@ fn makeOutboundWithMedia(
     } else &[_][]const u8{};
 
     return .{
-        .channel = channel,
+        .channel = ch,
         .chat_id = cid,
         .content = ct,
         .media = media,
@@ -579,15 +589,18 @@ test "OutboundMessage.deinit frees all fields" {
     msg.deinit(alloc);
 }
 
-test "makeInbound produces owned copies of non-channel fields" {
+test "makeInbound produces owned copies" {
     const alloc = testing.allocator;
+    var src_channel = try alloc.dupe(u8, "webhook");
+    defer alloc.free(src_channel);
     var src_content = try alloc.dupe(u8, "body");
     defer alloc.free(src_content);
 
-    const msg = try makeInbound(alloc, "webhook", "s", "c", src_content, "webhook:c");
+    const msg = try makeInbound(alloc, src_channel, "s", "c", src_content, "webhook:c");
     defer msg.deinit(alloc);
 
-    // Mutate source — message must be unaffected (channel is borrowed, not duped)
+    // Regression (#941): queued messages must outlive a one-shot cron job's routing storage.
+    src_channel[0] = 'X';
     src_content[0] = 'X';
     try testing.expectEqualStrings("body", msg.content);
     try testing.expectEqualStrings("webhook", msg.channel);
@@ -595,13 +608,18 @@ test "makeInbound produces owned copies of non-channel fields" {
 
 test "makeOutbound produces owned copies" {
     const alloc = testing.allocator;
+    var src_channel = try alloc.dupe(u8, "telegram");
+    defer alloc.free(src_channel);
     var src_content = try alloc.dupe(u8, "reply");
     defer alloc.free(src_content);
 
-    const msg = try makeOutbound(alloc, "telegram", "c1", src_content);
+    const msg = try makeOutbound(alloc, src_channel, "c1", src_content);
     defer msg.deinit(alloc);
 
+    // Regression (#941): queued messages must not borrow freed delivery routing.
+    src_channel[0] = 'X';
     src_content[0] = 'Z';
+    try testing.expectEqualStrings("telegram", msg.channel);
     try testing.expectEqualStrings("reply", msg.content);
     try testing.expect(msg.stage == .final);
     try testing.expectEqual(@as(u64, 0), msg.draft_id);

--- a/src/cron.zig
+++ b/src/cron.zig
@@ -981,7 +981,7 @@ pub const CronScheduler = struct {
                             }
                         }
                     } else {
-                        const exec_result = runAgentJob(self.allocator, self.shell_cwd, agent_output, job.model, self.agent_timeout_secs) catch |err| {
+                        const exec_result = runAgentJob(self.allocator, self.shell_cwd, agent_output, job.model, self.agent_timeout_secs, job.delivery) catch |err| {
                             log.err("cron agent job '{s}' execution failed: {s}", .{ job.id, @errorName(err) });
                             job.last_run_secs = now;
                             job.last_status = "error";
@@ -1086,8 +1086,12 @@ fn runAgentJob(
     prompt: []const u8,
     model: ?[]const u8,
     timeout_secs: u64,
+    delivery: DeliveryConfig,
 ) !AgentRunResult {
-    return agent_runner.run(allocator, cwd, prompt, model, timeout_secs);
+    return agent_runner.runWithOptions(allocator, cwd, prompt, model, timeout_secs, .{
+        .origin_channel = delivery.channel,
+        .origin_account_id = delivery.account_id,
+    });
 }
 
 const LoadPolicy = enum {
@@ -2246,8 +2250,9 @@ pub fn cliAddAgentOnce(
     prompt: []const u8,
     model: ?[]const u8,
     session_target: SessionTarget,
+    delivery: DeliveryConfig,
 ) !void {
-    const delivery = DeliveryConfig{};
+    const enriched_delivery = enrichDeliveryRouting(delivery);
     if (readGatewayUrl(allocator)) |url| {
         defer allocator.free(url);
         var body_buf: std.ArrayListUnmanaged(u8) = .empty;
@@ -2264,6 +2269,37 @@ pub fn cliAddAgentOnce(
             body_buf.appendSlice(allocator, ",") catch {};
             json_util.appendJsonKeyValue(&body_buf, allocator, "session_target", session_target.asStr()) catch {};
         }
+        if (enriched_delivery.mode != .none) {
+            body_buf.appendSlice(allocator, ",") catch {};
+            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_mode", enriched_delivery.mode.asStr()) catch {};
+        }
+        if (enriched_delivery.channel) |ch| {
+            body_buf.appendSlice(allocator, ",") catch {};
+            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_channel", ch) catch {};
+        }
+        if (enriched_delivery.account_id) |account_id| {
+            body_buf.appendSlice(allocator, ",") catch {};
+            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_account_id", account_id) catch {};
+        }
+        if (enriched_delivery.to) |t| {
+            body_buf.appendSlice(allocator, ",") catch {};
+            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_to", t) catch {};
+        }
+        if (enriched_delivery.peer_kind) |peer_kind| {
+            body_buf.appendSlice(allocator, ",") catch {};
+            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_peer_kind", chatTypeAsStr(peer_kind)) catch {};
+        }
+        if (enriched_delivery.peer_id) |peer_id| {
+            body_buf.appendSlice(allocator, ",") catch {};
+            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_peer_id", peer_id) catch {};
+        }
+        if (enriched_delivery.thread_id) |thread_id| {
+            body_buf.appendSlice(allocator, ",") catch {};
+            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_thread_id", thread_id) catch {};
+        }
+        if (!enriched_delivery.best_effort) {
+            body_buf.appendSlice(allocator, ",\"delivery_best_effort\":false") catch {};
+        }
         body_buf.appendSlice(allocator, "}") catch {};
         if (gatewayPost(allocator, url, "/cron/add", body_buf.items)) return;
     }
@@ -2272,7 +2308,7 @@ pub fn cliAddAgentOnce(
     defer scheduler.deinit();
     try loadJobs(&scheduler);
 
-    const job = try scheduler.addAgentOnce(delay, prompt, model, delivery);
+    const job = try scheduler.addAgentOnce(delay, prompt, model, enriched_delivery);
     job.session_target = session_target;
     try saveJobs(&scheduler);
 
@@ -2421,7 +2457,7 @@ pub fn cliRunJob(allocator: std.mem.Allocator, id: []const u8) !void {
             },
             .agent => {
                 const prompt = job.prompt orelse job.command;
-                const result = runAgentJob(allocator, run_cwd, prompt, job.model, scheduler.agent_timeout_secs) catch |err| {
+                const result = runAgentJob(allocator, run_cwd, prompt, job.model, scheduler.agent_timeout_secs, .{}) catch |err| {
                     job.last_run_secs = run_at;
                     job.last_status = "error";
                     try saveJobs(&scheduler);
@@ -3063,6 +3099,69 @@ test "save and load roundtrip keeps agent fields" {
     try std.testing.expect(job.delivery.thread_id != null);
     try std.testing.expectEqualStrings("77", job.delivery.thread_id.?);
     try std.testing.expectEqual(SessionTarget.main, job.session_target);
+}
+
+test "cliAddAgentOnce persists delivery routing" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    const c = @cImport({
+        @cInclude("stdlib.h");
+    });
+    const allocator = std.testing.allocator;
+
+    cron_store_test_mutex.lock();
+    defer cron_store_test_mutex.unlock();
+
+    const env_name = try allocator.dupeZ(u8, "NULLCLAW_HOME");
+    defer allocator.free(env_name);
+    const previous_home = std_compat.process.getEnvVarOwned(allocator, "NULLCLAW_HOME") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    defer {
+        if (previous_home) |value| {
+            defer allocator.free(value);
+            const value_z = allocator.dupeZ(u8, value) catch unreachable;
+            defer allocator.free(value_z);
+            _ = c.setenv(env_name.ptr, value_z.ptr, 1);
+        } else {
+            _ = c.unsetenv(env_name.ptr);
+        }
+    }
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try @import("compat").fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+    const test_home = try std_compat.fs.path.join(allocator, &.{ base, "nullclaw-home" });
+    defer allocator.free(test_home);
+    const test_home_z = try allocator.dupeZ(u8, test_home);
+    defer allocator.free(test_home_z);
+    try std.testing.expectEqual(@as(c_int, 0), c.setenv(env_name.ptr, test_home_z.ptr, 1));
+
+    try resetCronStoreForTest(allocator);
+    defer resetCronStoreForTest(allocator) catch {};
+
+    try cliAddAgentOnce(allocator, "30s", "say exactly one word: test", "glm-cn/glm-5-turbo", .isolated, .{
+        .mode = .always,
+        .channel = "telegram",
+        .account_id = "main",
+        .to = "7972814626",
+    });
+
+    var loaded = CronScheduler.init(allocator, 10, true);
+    defer loaded.deinit();
+    try loadJobsStrict(&loaded);
+
+    try std.testing.expectEqual(@as(usize, 1), loaded.listJobs().len);
+    const job = loaded.listJobs()[0];
+    try std.testing.expect(job.one_shot);
+    try std.testing.expectEqual(JobType.agent, job.job_type);
+    try std.testing.expectEqualStrings("say exactly one word: test", job.prompt.?);
+    try std.testing.expectEqualStrings("glm-cn/glm-5-turbo", job.model.?);
+    try std.testing.expectEqual(DeliveryMode.always, job.delivery.mode);
+    try std.testing.expectEqualStrings("telegram", job.delivery.channel.?);
+    try std.testing.expectEqualStrings("main", job.delivery.account_id.?);
+    try std.testing.expectEqualStrings("7972814626", job.delivery.to.?);
 }
 
 test "JobType parse and asStr" {

--- a/src/cron.zig
+++ b/src/cron.zig
@@ -1088,10 +1088,14 @@ fn runAgentJob(
     timeout_secs: u64,
     delivery: DeliveryConfig,
 ) !AgentRunResult {
-    return agent_runner.runWithOptions(allocator, cwd, prompt, model, timeout_secs, .{
+    return agent_runner.runWithOptions(allocator, cwd, prompt, model, timeout_secs, agentRunOptionsForDelivery(delivery));
+}
+
+fn agentRunOptionsForDelivery(delivery: DeliveryConfig) agent_runner.AgentRunOptions {
+    return .{
         .origin_channel = delivery.channel,
         .origin_account_id = delivery.account_id,
-    });
+    };
 }
 
 const LoadPolicy = enum {
@@ -1293,6 +1297,12 @@ fn loadJobsWithPolicy(scheduler: *CronScheduler, policy: LoadPolicy) !void {
             }
             break :blk null;
         };
+        const delivery_best_effort = blk: {
+            if (obj.get("delivery_best_effort")) |v| {
+                if (v == .bool) break :blk v.bool;
+            }
+            break :blk true;
+        };
         const session_target = blk: {
             if (obj.get("session_target")) |v| {
                 if (v == .string) {
@@ -1333,6 +1343,7 @@ fn loadJobsWithPolicy(scheduler: *CronScheduler, policy: LoadPolicy) !void {
                 .to_owned = delivery_to != null,
                 .peer_id_owned = delivery_peer_id != null,
                 .thread_id_owned = delivery_thread_id != null,
+                .best_effort = delivery_best_effort,
             },
         });
     }
@@ -1652,6 +1663,9 @@ fn appendCronJobJson(
     try buf.appendSlice(allocator, ",");
     try json_util.appendJsonKey(buf, allocator, "delivery_thread_id");
     try appendNullableString(buf, allocator, job.delivery.thread_id);
+    try buf.appendSlice(allocator, ",");
+    try json_util.appendJsonKey(buf, allocator, "delivery_best_effort");
+    try buf.appendSlice(allocator, if (job.delivery.best_effort) "true" else "false");
 
     try buf.appendSlice(allocator, "}");
 }
@@ -2112,18 +2126,79 @@ pub fn cliStatus(allocator: std.mem.Allocator, as_json: bool) !void {
     }
 }
 
+/// Build the shared `/cron/add` request body used by CLI and tool callers.
+pub fn buildGatewayAddBody(
+    allocator: std.mem.Allocator,
+    expression: ?[]const u8,
+    delay: ?[]const u8,
+    command: ?[]const u8,
+    prompt: ?[]const u8,
+    model: ?[]const u8,
+    delivery: ?DeliveryConfig,
+    session_target: ?SessionTarget,
+) ![]u8 {
+    var body_buf: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer body_buf.deinit(allocator);
+
+    try body_buf.appendSlice(allocator, "{");
+    var wrote_field = false;
+
+    if (expression) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "expression", value);
+    if (delay) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "delay", value);
+    if (command) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "command", value);
+    if (prompt) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "prompt", value);
+    if (model) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "model", value);
+    if (session_target) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "session_target", value.asStr());
+
+    if (delivery) |cfg| {
+        // Keep gateway and local fallback semantics identical even when routing
+        // fields are supplied without --announce.
+        try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "delivery_mode", cfg.mode.asStr());
+        if (cfg.channel) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "delivery_channel", value);
+        if (cfg.account_id) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "delivery_account_id", value);
+        if (cfg.to) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "delivery_to", value);
+        if (cfg.peer_kind) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "delivery_peer_kind", chatTypeAsStr(value));
+        if (cfg.peer_id) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "delivery_peer_id", value);
+        if (cfg.thread_id) |value| try appendGatewayBodyField(&body_buf, allocator, &wrote_field, "delivery_thread_id", value);
+        if (!cfg.best_effort) try appendGatewayBodyLiteral(&body_buf, allocator, &wrote_field, "\"delivery_best_effort\":false");
+    }
+
+    try body_buf.appendSlice(allocator, "}");
+    return try body_buf.toOwnedSlice(allocator);
+}
+
+fn appendGatewayBodyField(
+    body_buf: *std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+    wrote_field: *bool,
+    key: []const u8,
+    value: []const u8,
+) !void {
+    if (wrote_field.*) try body_buf.appendSlice(allocator, ",");
+    wrote_field.* = true;
+    try json_util.appendJsonKeyValue(body_buf, allocator, key, value);
+}
+
+fn appendGatewayBodyLiteral(
+    body_buf: *std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+    wrote_field: *bool,
+    literal: []const u8,
+) !void {
+    if (wrote_field.*) try body_buf.appendSlice(allocator, ",");
+    wrote_field.* = true;
+    try body_buf.appendSlice(allocator, literal);
+}
+
 /// CLI: add a recurring cron job.
 pub fn cliAddJob(allocator: std.mem.Allocator, expression: []const u8, command: []const u8) !void {
     if (readGatewayUrl(allocator)) |url| {
         defer allocator.free(url);
-        var body_buf: std.ArrayListUnmanaged(u8) = .empty;
-        defer body_buf.deinit(allocator);
-        body_buf.appendSlice(allocator, "{") catch {};
-        json_util.appendJsonKeyValue(&body_buf, allocator, "expression", expression) catch {};
-        body_buf.appendSlice(allocator, ",") catch {};
-        json_util.appendJsonKeyValue(&body_buf, allocator, "command", command) catch {};
-        body_buf.appendSlice(allocator, "}") catch {};
-        if (gatewayPost(allocator, url, "/cron/add", body_buf.items)) return;
+        const body = buildGatewayAddBody(allocator, expression, null, command, null, null, null, null) catch null;
+        if (body) |json_body| {
+            defer allocator.free(json_body);
+            if (gatewayPost(allocator, url, "/cron/add", json_body)) return;
+        }
     }
 
     var scheduler = CronScheduler.init(allocator, 1024, true);
@@ -2151,55 +2226,19 @@ pub fn cliAddAgentJob(
     const enriched_delivery = enrichDeliveryRouting(delivery);
     if (readGatewayUrl(allocator)) |url| {
         defer allocator.free(url);
-        // Build JSON body, escaping string values through json_util
-        var body_buf: std.ArrayListUnmanaged(u8) = .empty;
-        defer body_buf.deinit(allocator);
-        body_buf.appendSlice(allocator, "{") catch {};
-        json_util.appendJsonKeyValue(&body_buf, allocator, "expression", expression) catch {};
-        body_buf.appendSlice(allocator, ",") catch {};
-        json_util.appendJsonKeyValue(&body_buf, allocator, "prompt", prompt) catch {};
-        if (model) |m| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "model", m) catch {};
-        }
-        if (session_target != .isolated) {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "session_target", session_target.asStr()) catch {};
-        }
-        if (enriched_delivery.mode != .none) {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_mode", enriched_delivery.mode.asStr()) catch {};
-        }
-        if (enriched_delivery.channel) |ch| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_channel", ch) catch {};
-        }
-        if (enriched_delivery.account_id) |account_id| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_account_id", account_id) catch {};
-        }
-        if (enriched_delivery.to) |t| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_to", t) catch {};
-        }
-        if (enriched_delivery.peer_kind) |peer_kind| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_peer_kind", chatTypeAsStr(peer_kind)) catch {};
-        }
-        if (enriched_delivery.peer_id) |peer_id| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_peer_id", peer_id) catch {};
-        }
-        if (enriched_delivery.thread_id) |thread_id| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_thread_id", thread_id) catch {};
-        }
-        if (!enriched_delivery.best_effort) {
-            body_buf.appendSlice(allocator, ",\"delivery_best_effort\":false") catch {};
-        }
-        body_buf.appendSlice(allocator, "}") catch {};
-        if (body_buf.items.len > 2) {
-            if (gatewayPost(allocator, url, "/cron/add", body_buf.items)) return;
+        const body = buildGatewayAddBody(
+            allocator,
+            expression,
+            null,
+            null,
+            prompt,
+            model,
+            enriched_delivery,
+            if (session_target == .isolated) null else session_target,
+        ) catch null;
+        if (body) |json_body| {
+            defer allocator.free(json_body);
+            if (gatewayPost(allocator, url, "/cron/add", json_body)) return;
         }
     }
 
@@ -2221,14 +2260,11 @@ pub fn cliAddAgentJob(
 pub fn cliAddOnce(allocator: std.mem.Allocator, delay: []const u8, command: []const u8) !void {
     if (readGatewayUrl(allocator)) |url| {
         defer allocator.free(url);
-        var body_buf: std.ArrayListUnmanaged(u8) = .empty;
-        defer body_buf.deinit(allocator);
-        body_buf.appendSlice(allocator, "{") catch {};
-        json_util.appendJsonKeyValue(&body_buf, allocator, "delay", delay) catch {};
-        body_buf.appendSlice(allocator, ",") catch {};
-        json_util.appendJsonKeyValue(&body_buf, allocator, "command", command) catch {};
-        body_buf.appendSlice(allocator, "}") catch {};
-        if (gatewayPost(allocator, url, "/cron/add", body_buf.items)) return;
+        const body = buildGatewayAddBody(allocator, null, delay, command, null, null, null, null) catch null;
+        if (body) |json_body| {
+            defer allocator.free(json_body);
+            if (gatewayPost(allocator, url, "/cron/add", json_body)) return;
+        }
     }
 
     var scheduler = CronScheduler.init(allocator, 1024, true);
@@ -2255,53 +2291,20 @@ pub fn cliAddAgentOnce(
     const enriched_delivery = enrichDeliveryRouting(delivery);
     if (readGatewayUrl(allocator)) |url| {
         defer allocator.free(url);
-        var body_buf: std.ArrayListUnmanaged(u8) = .empty;
-        defer body_buf.deinit(allocator);
-        body_buf.appendSlice(allocator, "{") catch {};
-        json_util.appendJsonKeyValue(&body_buf, allocator, "delay", delay) catch {};
-        body_buf.appendSlice(allocator, ",") catch {};
-        json_util.appendJsonKeyValue(&body_buf, allocator, "prompt", prompt) catch {};
-        if (model) |m| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "model", m) catch {};
+        const body = buildGatewayAddBody(
+            allocator,
+            null,
+            delay,
+            null,
+            prompt,
+            model,
+            enriched_delivery,
+            if (session_target == .isolated) null else session_target,
+        ) catch null;
+        if (body) |json_body| {
+            defer allocator.free(json_body);
+            if (gatewayPost(allocator, url, "/cron/add", json_body)) return;
         }
-        if (session_target != .isolated) {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "session_target", session_target.asStr()) catch {};
-        }
-        if (enriched_delivery.mode != .none) {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_mode", enriched_delivery.mode.asStr()) catch {};
-        }
-        if (enriched_delivery.channel) |ch| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_channel", ch) catch {};
-        }
-        if (enriched_delivery.account_id) |account_id| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_account_id", account_id) catch {};
-        }
-        if (enriched_delivery.to) |t| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_to", t) catch {};
-        }
-        if (enriched_delivery.peer_kind) |peer_kind| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_peer_kind", chatTypeAsStr(peer_kind)) catch {};
-        }
-        if (enriched_delivery.peer_id) |peer_id| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_peer_id", peer_id) catch {};
-        }
-        if (enriched_delivery.thread_id) |thread_id| {
-            body_buf.appendSlice(allocator, ",") catch {};
-            json_util.appendJsonKeyValue(&body_buf, allocator, "delivery_thread_id", thread_id) catch {};
-        }
-        if (!enriched_delivery.best_effort) {
-            body_buf.appendSlice(allocator, ",\"delivery_best_effort\":false") catch {};
-        }
-        body_buf.appendSlice(allocator, "}") catch {};
-        if (gatewayPost(allocator, url, "/cron/add", body_buf.items)) return;
     }
 
     var scheduler = CronScheduler.init(allocator, 1024, true);
@@ -2457,7 +2460,7 @@ pub fn cliRunJob(allocator: std.mem.Allocator, id: []const u8) !void {
             },
             .agent => {
                 const prompt = job.prompt orelse job.command;
-                const result = runAgentJob(allocator, run_cwd, prompt, job.model, scheduler.agent_timeout_secs, .{}) catch |err| {
+                const result = runAgentJob(allocator, run_cwd, prompt, job.model, scheduler.agent_timeout_secs, job.delivery) catch |err| {
                     job.last_run_secs = run_at;
                     job.last_status = "error";
                     try saveJobs(&scheduler);
@@ -3071,6 +3074,7 @@ test "save and load roundtrip keeps agent fields" {
         .peer_kind = .group,
         .peer_id = "-100123",
         .thread_id = "77",
+        .best_effort = false,
     });
     recurring.session_target = .main;
     try saveJobs(&scheduler);
@@ -3098,10 +3102,12 @@ test "save and load roundtrip keeps agent fields" {
     try std.testing.expectEqualStrings("-100123", job.delivery.peer_id.?);
     try std.testing.expect(job.delivery.thread_id != null);
     try std.testing.expectEqualStrings("77", job.delivery.thread_id.?);
+    try std.testing.expect(!job.delivery.best_effort);
     try std.testing.expectEqual(SessionTarget.main, job.session_target);
 }
 
 test "cliAddAgentOnce persists delivery routing" {
+    // Regression: once-agent delivery fields must survive CLI storage and reload.
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
     const c = @cImport({
         @cInclude("stdlib.h");
@@ -3141,11 +3147,12 @@ test "cliAddAgentOnce persists delivery routing" {
     try resetCronStoreForTest(allocator);
     defer resetCronStoreForTest(allocator) catch {};
 
-    try cliAddAgentOnce(allocator, "30s", "say exactly one word: test", "glm-cn/glm-5-turbo", .isolated, .{
+    try cliAddAgentOnce(allocator, "30s", "Summarize status", "test-model", .isolated, .{
         .mode = .always,
         .channel = "telegram",
         .account_id = "main",
-        .to = "7972814626",
+        .to = "chat-42",
+        .best_effort = false,
     });
 
     var loaded = CronScheduler.init(allocator, 10, true);
@@ -3156,12 +3163,13 @@ test "cliAddAgentOnce persists delivery routing" {
     const job = loaded.listJobs()[0];
     try std.testing.expect(job.one_shot);
     try std.testing.expectEqual(JobType.agent, job.job_type);
-    try std.testing.expectEqualStrings("say exactly one word: test", job.prompt.?);
-    try std.testing.expectEqualStrings("glm-cn/glm-5-turbo", job.model.?);
+    try std.testing.expectEqualStrings("Summarize status", job.prompt.?);
+    try std.testing.expectEqualStrings("test-model", job.model.?);
     try std.testing.expectEqual(DeliveryMode.always, job.delivery.mode);
     try std.testing.expectEqualStrings("telegram", job.delivery.channel.?);
     try std.testing.expectEqualStrings("main", job.delivery.account_id.?);
-    try std.testing.expectEqualStrings("7972814626", job.delivery.to.?);
+    try std.testing.expectEqualStrings("chat-42", job.delivery.to.?);
+    try std.testing.expect(!job.delivery.best_effort);
 }
 
 test "JobType parse and asStr" {
@@ -3697,6 +3705,74 @@ test "agent job delivers result via bus" {
     try std.testing.expectEqualStrings("discord", msg.channel);
     try std.testing.expectEqualStrings("general", msg.chat_id);
     try std.testing.expectEqualStrings("Summarize today's news", msg.content);
+}
+
+test "one-shot isolated agent delivery outlives removed job" {
+    // Regression (#941): the outbound queue must not retain freed job delivery routing.
+    const allocator = std.testing.allocator;
+    var scheduler = CronScheduler.init(allocator, 10, true);
+    defer scheduler.deinit();
+
+    var test_bus = bus.Bus.init();
+    defer test_bus.close();
+
+    const job = try scheduler.addAgentOnce("1s", "Summarize status", null, .{
+        .mode = .always,
+        .channel = "telegram",
+        .account_id = "main",
+        .to = "chat-42",
+    });
+    job.next_run_secs = 0;
+
+    _ = scheduler.tick(std_compat.time.timestamp(), &test_bus);
+    try std.testing.expectEqual(@as(usize, 0), scheduler.listJobs().len);
+
+    var msg = test_bus.consumeOutbound().?;
+    defer msg.deinit(allocator);
+    try std.testing.expectEqualStrings("telegram", msg.channel);
+    try std.testing.expectEqualStrings("main", msg.account_id.?);
+    try std.testing.expectEqualStrings("chat-42", msg.chat_id);
+    try std.testing.expectEqualStrings("Summarize status", msg.content);
+}
+
+test "one-shot main agent delivery outlives removed job" {
+    // Regression (#941): the inbound queue has the same lifetime boundary as outbound delivery.
+    const allocator = std.testing.allocator;
+    var scheduler = CronScheduler.init(allocator, 10, true);
+    defer scheduler.deinit();
+
+    var test_bus = bus.Bus.init();
+    defer test_bus.close();
+
+    const job = try scheduler.addAgentOnce("1s", "Summarize status", null, .{
+        .mode = .always,
+        .channel = "telegram",
+        .account_id = "main",
+        .to = "chat-42",
+    });
+    job.session_target = .main;
+    job.next_run_secs = 0;
+
+    _ = scheduler.tick(std_compat.time.timestamp(), &test_bus);
+    try std.testing.expectEqual(@as(usize, 0), scheduler.listJobs().len);
+
+    var msg = test_bus.consumeInbound().?;
+    defer msg.deinit(allocator);
+    try std.testing.expectEqualStrings("telegram", msg.channel);
+    try std.testing.expectEqualStrings("system:cron", msg.sender_id);
+    try std.testing.expectEqualStrings("chat-42", msg.chat_id);
+    try std.testing.expectEqualStrings("telegram:main:chat-42", msg.session_key);
+    try std.testing.expect(std.mem.indexOf(u8, msg.content, "Summarize status") != null);
+}
+
+test "agent run options preserve cron delivery attribution" {
+    // Regression: every cron execution path must pass saved origin metadata to the child agent.
+    const options = agentRunOptionsForDelivery(.{
+        .channel = "telegram",
+        .account_id = "main",
+    });
+    try std.testing.expectEqualStrings("telegram", options.origin_channel.?);
+    try std.testing.expectEqualStrings("main", options.origin_account_id.?);
 }
 
 test "DeliveryMode parse and asStr" {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -214,6 +214,14 @@ fn heartbeatDeliveryConfig(config: *const Config) ?cron.DeliveryConfig {
     });
 }
 
+fn heartbeatAgentRunOptions(delivery: ?cron.DeliveryConfig) agent_runner.AgentRunOptions {
+    const config = delivery orelse return .{};
+    return .{
+        .origin_channel = config.channel,
+        .origin_account_id = config.account_id,
+    };
+}
+
 fn recordGatewayFailure(err: anyerror, state: *DaemonState) void {
     requestShutdown();
     state.markError("gateway", @errorName(err));
@@ -295,7 +303,14 @@ fn heartbeatThread(allocator: std.mem.Allocator, config: *const Config, state: *
                     } else {
                         const delivery = heartbeatDeliveryConfig(config);
                         const prompt = config.heartbeat.prompt orelse DEFAULT_HEARTBEAT_PROMPT;
-                        const result = agent_runner.run(allocator, config.workspace_dir, prompt, config.heartbeat.model, config.heartbeat.timeout_secs) catch |err| {
+                        const result = agent_runner.runWithOptions(
+                            allocator,
+                            config.workspace_dir,
+                            prompt,
+                            config.heartbeat.model,
+                            config.heartbeat.timeout_secs,
+                            heartbeatAgentRunOptions(delivery),
+                        ) catch |err| {
                             log.warn("heartbeat agent dispatch failed: {s}", .{@errorName(err)});
                             if (delivery) |cfg| {
                                 const failure_output = std.fmt.allocPrint(allocator, "heartbeat agent dispatch failed: {s}", .{@errorName(err)}) catch null;
@@ -3256,6 +3271,11 @@ test "heartbeatDeliveryConfig enriches routing" {
     try std.testing.expectEqualStrings("-100123", delivery.peer_id.?);
     try std.testing.expectEqualStrings("77", delivery.thread_id.?);
     try std.testing.expect(!delivery.best_effort);
+
+    // Regression: scheduled heartbeat agents must not be attributed to the CLI.
+    const options = heartbeatAgentRunOptions(delivery);
+    try std.testing.expectEqualStrings("telegram", options.origin_channel.?);
+    try std.testing.expectEqualStrings("backup", options.origin_account_id.?);
 }
 
 test "mergeSchedulerTickChangesAndSave preserves runtime agent fields" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -994,7 +994,7 @@ fn runCron(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
             \\  add-agent <expression> <prompt> [--model <model>] [--announce] [--channel <name>] [--account <id>] [--to <id>]
             \\                                Add a recurring agent cron job
             \\  once <delay> <command>        Add a one-shot delayed task
-            \\  once-agent <delay> <prompt> [--model <model>]
+            \\  once-agent <delay> <prompt> [--model <model>] [--session-target <isolated|main>] [--announce] [--channel <name>] [--account <id>] [--to <id>]
             \\                                Add a one-shot delayed agent task
             \\  remove <id>                   Remove a scheduled task
             \\  pause <id>                    Pause a scheduled task
@@ -1077,7 +1077,7 @@ fn runCron(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
         try yc.cron.cliAddOnce(allocator, sub_args[1], sub_args[2]);
     } else if (std.mem.eql(u8, subcmd, "once-agent")) {
         if (sub_args.len < 3) {
-            std.debug.print("Usage: nullclaw cron once-agent <delay> <prompt> [--model <model>] [--session-target <isolated|main>]\n", .{});
+            std.debug.print("Usage: nullclaw cron once-agent <delay> <prompt> [--model <model>] [--session-target <isolated|main>] [--announce] [--channel <name>] [--account <id>] [--to <id>]\n", .{});
             std_compat.process.exit(1);
         }
         const options = parseCronAgentOptions(sub_args, 3) catch |err| switch (err) {
@@ -1086,7 +1086,7 @@ fn runCron(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
                 std_compat.process.exit(1);
             },
         };
-        try yc.cron.cliAddAgentOnce(allocator, sub_args[1], sub_args[2], options.model, options.session_target);
+        try yc.cron.cliAddAgentOnce(allocator, sub_args[1], sub_args[2], options.model, options.session_target, options.delivery);
     } else if (std.mem.eql(u8, subcmd, "remove")) {
         if (sub_args.len < 2) {
             std.debug.print("Usage: nullclaw cron remove <id>\n", .{});
@@ -6534,6 +6534,34 @@ test "parseCronAddAgentOptions preserves delivery account flag" {
     const options = try parseCronAddAgentOptions(&args);
     try std.testing.expectEqualStrings("glm-cn/glm-5-turbo", options.model.?);
     try std.testing.expectEqual(yc.cron.SessionTarget.main, options.session_target);
+    try std.testing.expectEqual(yc.cron.DeliveryMode.always, options.delivery.mode);
+    try std.testing.expectEqualStrings("telegram", options.delivery.channel.?);
+    try std.testing.expectEqualStrings("main", options.delivery.account_id.?);
+    try std.testing.expectEqualStrings("7972814626", options.delivery.to.?);
+    try std.testing.expect(!options.delivery.channel_owned);
+    try std.testing.expect(!options.delivery.account_id_owned);
+    try std.testing.expect(!options.delivery.to_owned);
+}
+
+test "parseCronAgentOptions preserves once-agent delivery account flag" {
+    // Regression: cron once-agent parsed delivery flags but did not pass them to cron storage.
+    const args = [_][]const u8{
+        "once-agent",
+        "30s",
+        "say exactly one word: test",
+        "--model",
+        "glm-cn/glm-5-turbo",
+        "--announce",
+        "--channel",
+        "telegram",
+        "--account",
+        "main",
+        "--to",
+        "7972814626",
+    };
+
+    const options = try parseCronAgentOptions(&args, 3);
+    try std.testing.expectEqualStrings("glm-cn/glm-5-turbo", options.model.?);
     try std.testing.expectEqual(yc.cron.DeliveryMode.always, options.delivery.mode);
     try std.testing.expectEqualStrings("telegram", options.delivery.channel.?);
     try std.testing.expectEqualStrings("main", options.delivery.account_id.?);

--- a/src/main.zig
+++ b/src/main.zig
@@ -951,27 +951,36 @@ fn parseCronSessionTargetArg(raw: []const u8) !yc.cron.SessionTarget {
     return yc.cron.SessionTarget.parseStrict(raw);
 }
 
+fn cronAgentOptionValue(sub_args: []const []const u8, option_index: usize) ![]const u8 {
+    if (option_index + 1 >= sub_args.len or std.mem.startsWith(u8, sub_args[option_index + 1], "--")) {
+        return error.MissingCronOptionValue;
+    }
+    return sub_args[option_index + 1];
+}
+
 fn parseCronAgentOptions(sub_args: []const []const u8, start_index: usize) !CronAddAgentOptions {
     var options = CronAddAgentOptions{};
     var i: usize = start_index;
     while (i < sub_args.len) : (i += 1) {
-        if (i + 1 < sub_args.len and std.mem.eql(u8, sub_args[i], "--model")) {
-            options.model = sub_args[i + 1];
+        if (std.mem.eql(u8, sub_args[i], "--model")) {
+            options.model = try cronAgentOptionValue(sub_args, i);
             i += 1;
-        } else if (i + 1 < sub_args.len and std.mem.eql(u8, sub_args[i], "--session-target")) {
-            options.session_target = try parseCronSessionTargetArg(sub_args[i + 1]);
+        } else if (std.mem.eql(u8, sub_args[i], "--session-target")) {
+            options.session_target = try parseCronSessionTargetArg(try cronAgentOptionValue(sub_args, i));
             i += 1;
         } else if (std.mem.eql(u8, sub_args[i], "--announce")) {
             options.delivery.mode = .always;
-        } else if (i + 1 < sub_args.len and std.mem.eql(u8, sub_args[i], "--channel")) {
-            options.delivery.channel = sub_args[i + 1];
+        } else if (std.mem.eql(u8, sub_args[i], "--channel")) {
+            options.delivery.channel = try cronAgentOptionValue(sub_args, i);
             i += 1;
-        } else if (i + 1 < sub_args.len and std.mem.eql(u8, sub_args[i], "--account")) {
-            options.delivery.account_id = sub_args[i + 1];
+        } else if (std.mem.eql(u8, sub_args[i], "--account")) {
+            options.delivery.account_id = try cronAgentOptionValue(sub_args, i);
             i += 1;
-        } else if (i + 1 < sub_args.len and std.mem.eql(u8, sub_args[i], "--to")) {
-            options.delivery.to = sub_args[i + 1];
+        } else if (std.mem.eql(u8, sub_args[i], "--to")) {
+            options.delivery.to = try cronAgentOptionValue(sub_args, i);
             i += 1;
+        } else {
+            return error.UnknownCronOption;
         }
     }
     return options;
@@ -991,7 +1000,7 @@ fn runCron(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
             \\  get <id> [--json]             Show one scheduled task
             \\  status [--json]               Show scheduler daemon status
             \\  add <expression> <command>    Add a recurring cron job
-            \\  add-agent <expression> <prompt> [--model <model>] [--announce] [--channel <name>] [--account <id>] [--to <id>]
+            \\  add-agent <expression> <prompt> [--model <model>] [--session-target <isolated|main>] [--announce] [--channel <name>] [--account <id>] [--to <id>]
             \\                                Add a recurring agent cron job
             \\  once <delay> <command>        Add a one-shot delayed task
             \\  once-agent <delay> <prompt> [--model <model>] [--session-target <isolated|main>] [--announce] [--channel <name>] [--account <id>] [--to <id>]
@@ -1067,6 +1076,14 @@ fn runCron(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
                 std.debug.print("Invalid --session-target: expected 'isolated' or 'main'\n", .{});
                 std_compat.process.exit(1);
             },
+            error.MissingCronOptionValue => {
+                std.debug.print("Missing value for cron agent option\n", .{});
+                std_compat.process.exit(1);
+            },
+            error.UnknownCronOption => {
+                std.debug.print("Unknown cron agent option\n", .{});
+                std_compat.process.exit(1);
+            },
         };
         try yc.cron.cliAddAgentJob(allocator, sub_args[1], sub_args[2], options.model, options.session_target, options.delivery);
     } else if (std.mem.eql(u8, subcmd, "once")) {
@@ -1083,6 +1100,14 @@ fn runCron(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
         const options = parseCronAgentOptions(sub_args, 3) catch |err| switch (err) {
             error.InvalidSessionTarget => {
                 std.debug.print("Invalid --session-target: expected 'isolated' or 'main'\n", .{});
+                std_compat.process.exit(1);
+            },
+            error.MissingCronOptionValue => {
+                std.debug.print("Missing value for cron agent option\n", .{});
+                std_compat.process.exit(1);
+            },
+            error.UnknownCronOption => {
+                std.debug.print("Unknown cron agent option\n", .{});
                 std_compat.process.exit(1);
             },
         };
@@ -6528,7 +6553,7 @@ test "parseCronAddAgentOptions preserves delivery account flag" {
         "--account",
         "main",
         "--to",
-        "7972814626",
+        "chat-42",
     };
 
     const options = try parseCronAddAgentOptions(&args);
@@ -6537,38 +6562,28 @@ test "parseCronAddAgentOptions preserves delivery account flag" {
     try std.testing.expectEqual(yc.cron.DeliveryMode.always, options.delivery.mode);
     try std.testing.expectEqualStrings("telegram", options.delivery.channel.?);
     try std.testing.expectEqualStrings("main", options.delivery.account_id.?);
-    try std.testing.expectEqualStrings("7972814626", options.delivery.to.?);
+    try std.testing.expectEqualStrings("chat-42", options.delivery.to.?);
     try std.testing.expect(!options.delivery.channel_owned);
     try std.testing.expect(!options.delivery.account_id_owned);
     try std.testing.expect(!options.delivery.to_owned);
 }
 
-test "parseCronAgentOptions preserves once-agent delivery account flag" {
-    // Regression: cron once-agent parsed delivery flags but did not pass them to cron storage.
-    const args = [_][]const u8{
-        "once-agent",
-        "30s",
-        "say exactly one word: test",
-        "--model",
-        "glm-cn/glm-5-turbo",
-        "--announce",
-        "--channel",
-        "telegram",
-        "--account",
-        "main",
-        "--to",
-        "7972814626",
-    };
+test "parseCronAgentOptions rejects missing option values" {
+    // Regression: malformed cron agent flags must fail fast instead of being ignored.
+    const flags = [_][]const u8{ "--model", "--session-target", "--channel", "--account", "--to" };
+    for (flags) |flag| {
+        const args = [_][]const u8{ "once-agent", "30s", "Summarize status", flag };
+        try std.testing.expectError(error.MissingCronOptionValue, parseCronAgentOptions(&args, 3));
 
-    const options = try parseCronAgentOptions(&args, 3);
-    try std.testing.expectEqualStrings("glm-cn/glm-5-turbo", options.model.?);
-    try std.testing.expectEqual(yc.cron.DeliveryMode.always, options.delivery.mode);
-    try std.testing.expectEqualStrings("telegram", options.delivery.channel.?);
-    try std.testing.expectEqualStrings("main", options.delivery.account_id.?);
-    try std.testing.expectEqualStrings("7972814626", options.delivery.to.?);
-    try std.testing.expect(!options.delivery.channel_owned);
-    try std.testing.expect(!options.delivery.account_id_owned);
-    try std.testing.expect(!options.delivery.to_owned);
+        const followed_by_flag = [_][]const u8{ "once-agent", "30s", "Summarize status", flag, "--announce" };
+        try std.testing.expectError(error.MissingCronOptionValue, parseCronAgentOptions(&followed_by_flag, 3));
+    }
+}
+
+test "parseCronAgentOptions rejects unknown options" {
+    // Regression: cron agent CLI typos must not be silently ignored.
+    const args = [_][]const u8{ "once-agent", "30s", "Summarize status", "--unknown" };
+    try std.testing.expectError(error.UnknownCronOption, parseCronAgentOptions(&args, 3));
 }
 
 test "appendAgentInvokeResponseJson renders machine-readable turn payload" {

--- a/src/tools/cron_gateway.zig
+++ b/src/tools/cron_gateway.zig
@@ -22,63 +22,7 @@ pub fn buildAddBody(
     delivery: ?cron.DeliveryConfig,
     session_target: ?cron.SessionTarget,
 ) ![]u8 {
-    var body_buf: std.ArrayListUnmanaged(u8) = .empty;
-    errdefer body_buf.deinit(allocator);
-
-    try body_buf.appendSlice(allocator, "{");
-    var wrote_field = false;
-
-    if (expression) |value| {
-        try appendBodyField(&body_buf, allocator, &wrote_field, "expression", value);
-    }
-    if (delay) |value| {
-        try appendBodyField(&body_buf, allocator, &wrote_field, "delay", value);
-    }
-    if (command) |value| {
-        try appendBodyField(&body_buf, allocator, &wrote_field, "command", value);
-    }
-    if (prompt) |value| {
-        try appendBodyField(&body_buf, allocator, &wrote_field, "prompt", value);
-    }
-    if (model) |value| {
-        try appendBodyField(&body_buf, allocator, &wrote_field, "model", value);
-    }
-    if (session_target) |value| {
-        try appendBodyField(&body_buf, allocator, &wrote_field, "session_target", value.asStr());
-    }
-    if (delivery) |cfg| {
-        if (cfg.mode != .none) {
-            try appendBodyField(&body_buf, allocator, &wrote_field, "delivery_mode", cfg.mode.asStr());
-        }
-        if (cfg.channel) |value| {
-            try appendBodyField(&body_buf, allocator, &wrote_field, "delivery_channel", value);
-        }
-        if (cfg.account_id) |value| {
-            try appendBodyField(&body_buf, allocator, &wrote_field, "delivery_account_id", value);
-        }
-        if (cfg.to) |value| {
-            try appendBodyField(&body_buf, allocator, &wrote_field, "delivery_to", value);
-        }
-        if (cfg.peer_kind) |value| {
-            try appendBodyField(&body_buf, allocator, &wrote_field, "delivery_peer_kind", switch (value) {
-                .direct => "direct",
-                .group => "group",
-                .channel => "channel",
-            });
-        }
-        if (cfg.peer_id) |value| {
-            try appendBodyField(&body_buf, allocator, &wrote_field, "delivery_peer_id", value);
-        }
-        if (cfg.thread_id) |value| {
-            try appendBodyField(&body_buf, allocator, &wrote_field, "delivery_thread_id", value);
-        }
-        if (!cfg.best_effort) {
-            try appendBodyLiteral(&body_buf, allocator, &wrote_field, "\"delivery_best_effort\":false");
-        }
-    }
-
-    try body_buf.appendSlice(allocator, "}");
-    return try body_buf.toOwnedSlice(allocator);
+    return cron.buildGatewayAddBody(allocator, expression, delay, command, prompt, model, delivery, session_target);
 }
 
 pub fn buildUpdateBody(
@@ -196,6 +140,27 @@ test "buildAddBody includes delivery fields" {
     try std.testing.expectEqualStrings("-100123", parsed.value.object.get("delivery_peer_id").?.string);
     try std.testing.expectEqualStrings("77", parsed.value.object.get("delivery_thread_id").?.string);
     try std.testing.expect(!parsed.value.object.get("delivery_best_effort").?.bool);
+}
+
+test "buildAddBody preserves explicit disabled delivery" {
+    // Regression: gateway and local CLI fallbacks must agree without --announce.
+    const body = try buildAddBody(
+        std.testing.allocator,
+        null,
+        "5m",
+        null,
+        "Summarize status",
+        null,
+        .{ .mode = .none, .channel = "telegram", .to = "chat-42" },
+        null,
+    );
+    defer std.testing.allocator.free(body);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("none", parsed.value.object.get("delivery_mode").?.string);
+    try std.testing.expectEqualStrings("telegram", parsed.value.object.get("delivery_channel").?.string);
+    try std.testing.expectEqualStrings("chat-42", parsed.value.object.get("delivery_to").?.string);
 }
 
 test "buildUpdateBody includes enabled flag" {


### PR DESCRIPTION
## Summary

- Pass cron delivery origin metadata into spawned `nullclaw agent` subprocesses so `agent_start` is attributed to the delivery channel/account.
- Preserve delivery routing flags for `nullclaw cron once-agent` in both local storage and gateway `/cron/add` payloads.
- Update `once-agent` help/docs and add regression coverage for argv construction, agent arg parsing, and one-shot delivery persistence.

## Root Cause

Agent cron jobs spawned the child `agent` process without any origin metadata, so the child recorded `agent_start` as a plain CLI invocation instead of the Telegram account that created the scheduled task. Separately, the CLI `once-agent` path parsed delivery flags but dropped them before calling cron storage.

## Validation

- `zig build test --summary all` passed: 7346/7355 tests passed, 9 skipped.
- `zig fmt --check src/agent_runner.zig src/agent/cli.zig src/cron.zig src/main.zig`
- `git diff --check`