### PR TITLE
fix: make queue_mode configurable from config.json

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -150,6 +150,23 @@ Common per-provider fields:
 - Sets default model route, typically `provider/vendor/model`.
 - Example: `openrouter/anthropic/claude-sonnet-4`
 
+### `agent.default_queue_mode`
+
+- Sets the inbound queue mode for newly created sessions. Accepted values are `off`, `serial`, `latest`, and `debounce`; the default is `off`.
+- `off` drops messages that arrive while a turn is running, `serial` waits for the active turn, and `latest` keeps the newest pending injection. `debounce` selects the existing runtime debounce mode; this field does not configure its duration, cap, or drop policy.
+- `/queue` can override the mode for the current session. `/queue reset`, `/restart`, and `/debug reset` restore the configured default.
+- Changes require a restart so the session manager and newly created sessions use the same default.
+
+Example:
+
+```json
+{
+  "agent": {
+    "default_queue_mode": "latest"
+  }
+}
+```
+
 ### `workspace_audit.llm_triage`
 
 - Selects the provider/model used by `nullclaw workspace audit --llm-triage external`.

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -135,6 +135,23 @@ nullclaw onboard --interactive
 - 设置默认模型路由，通常是 `provider/vendor/model`。
 - 示例：`openrouter/anthropic/claude-sonnet-4`
 
+### `agent.default_queue_mode`
+
+- 设置新建会话的入站队列模式。可选值为 `off`、`serial`、`latest` 和 `debounce`，默认值为 `off`。
+- `off` 会丢弃正在执行回合时到达的消息，`serial` 会等待当前回合结束，`latest` 会保留最新的待注入消息。`debounce` 选择现有的运行时 debounce 模式；此字段不配置其时长、容量或丢弃策略。
+- `/queue` 可以覆盖当前会话的模式。`/queue reset`、`/restart` 和 `/debug reset` 会恢复这里配置的默认值。
+- 修改后需要重启，确保 session manager 与后续新建会话使用同一个默认值。
+
+示例：
+
+```json
+{
+  "agent": {
+    "default_queue_mode": "latest"
+  }
+}
+```
+
 ### `workspace_audit.llm_triage`
 
 - 选择 `nullclaw workspace audit --llm-triage external` 使用的 provider/model。

--- a/src/agent/commands.zig
+++ b/src/agent/commands.zig
@@ -3390,14 +3390,6 @@ fn parseExecAsk(comptime T: type, raw: []const u8) ?T {
     return null;
 }
 
-fn parseQueueMode(comptime T: type, raw: []const u8) ?T {
-    if (std.ascii.eqlIgnoreCase(raw, "off")) return .off;
-    if (std.ascii.eqlIgnoreCase(raw, "serial")) return .serial;
-    if (std.ascii.eqlIgnoreCase(raw, "latest")) return .latest;
-    if (std.ascii.eqlIgnoreCase(raw, "debounce")) return .debounce;
-    return null;
-}
-
 fn parseQueueDrop(comptime T: type, raw: []const u8) ?T {
     if (std.ascii.eqlIgnoreCase(raw, "summarize")) return .summarize;
     if (std.ascii.eqlIgnoreCase(raw, "oldest")) return .oldest;
@@ -3466,7 +3458,7 @@ fn resetRuntimeCommandState(self: anytype) void {
     if (self.exec_node_id_owned and self.exec_node_id != null) self.allocator.free(self.exec_node_id.?);
     self.exec_node_id = null;
     self.exec_node_id_owned = false;
-    self.queue_mode = .off;
+    self.queue_mode = self.default_queue_mode;
     self.queue_debounce_ms = 0;
     self.queue_cap = 0;
     self.queue_drop = .summarize;
@@ -3688,7 +3680,7 @@ fn handleQueueCommand(self: anytype, arg: []const u8) ![]const u8 {
     }
 
     if (std.ascii.eqlIgnoreCase(arg, "reset")) {
-        self.queue_mode = .off;
+        self.queue_mode = self.default_queue_mode;
         self.queue_debounce_ms = 0;
         self.queue_cap = 0;
         self.queue_drop = .summarize;
@@ -3697,7 +3689,7 @@ fn handleQueueCommand(self: anytype, arg: []const u8) ![]const u8 {
 
     var it = std.mem.tokenizeAny(u8, arg, " \t");
     while (it.next()) |tok| {
-        if (parseQueueMode(@TypeOf(self.queue_mode), tok)) |mode| {
+        if (@TypeOf(self.queue_mode).fromSlice(tok)) |mode| {
             self.queue_mode = mode;
             continue;
         }

--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -179,21 +179,7 @@ pub const Agent = struct {
         }
     };
 
-    pub const QueueMode = enum {
-        off,
-        serial,
-        latest,
-        debounce,
-
-        pub fn toSlice(self: QueueMode) []const u8 {
-            return switch (self) {
-                .off => "off",
-                .serial => "serial",
-                .latest => "latest",
-                .debounce => "debounce",
-            };
-        }
-    };
+    pub const QueueMode = config_types.QueueMode;
 
     const QueueDrop = enum {
         summarize,
@@ -312,7 +298,6 @@ pub const Agent = struct {
     max_tool_iterations: u32,
     max_history_messages: u32,
     auto_save: bool,
-    compact_context: bool = true,
     token_limit: u64 = 0,
     token_limit_override: ?u64 = null,
     max_tokens: u32 = max_tokens_resolver.DEFAULT_MODEL_MAX_TOKENS,
@@ -626,7 +611,6 @@ pub const Agent = struct {
             .max_tool_iterations = cfg.agent.max_tool_iterations,
             .max_history_messages = cfg.agent.max_history_messages,
             .auto_save = cfg.memory.auto_save,
-            .compact_context = cfg.agent.compact_context,
             .token_limit = resolved_token_limit,
             .token_limit_override = token_limit_override,
             .max_tokens = resolved_max_tokens,
@@ -639,6 +623,7 @@ pub const Agent = struct {
             .compaction_keep_recent = cfg.agent.compaction_keep_recent,
             .compaction_max_summary_chars = cfg.agent.compaction_max_summary_chars,
             .compaction_max_source_chars = cfg.agent.compaction_max_source_chars,
+            .queue_mode = cfg.agent.default_queue_mode,
             .tools_config = cfg.tools,
             .tool_filter_groups = cfg.agent.tool_filter_groups,
             .default_exec_security = resolved_exec_security,
@@ -866,15 +851,6 @@ pub const Agent = struct {
         const completion_budget_u32: u32 = @intCast(@min(completion_budget, @as(u64, std.math.maxInt(u32))));
         if (completion_budget_u32 == 0) return 1;
         return @max(@as(u32, 1), @min(max_tokens, completion_budget_u32));
-    }
-
-    /// Proactively auto-compact history, honoring `agent.compact_context`.
-    /// When the flag is disabled the LLM summarization pass is skipped. Hard
-    /// history trimming and emergency `forceCompressHistory` remain separate
-    /// safeguards and are intentionally not gated by this flag.
-    pub fn maybeAutoCompactHistory(self: *Agent) bool {
-        if (!self.compact_context) return false;
-        return self.autoCompactHistory() catch false;
     }
 
     /// Auto-compact history when it exceeds thresholds.
@@ -1849,37 +1825,6 @@ pub const Agent = struct {
         return prioritized;
     }
 
-    /// Build a subset of `self.tools` suitable for the text-based system prompt.
-    /// Only includes built-in tools and MCP tools from `always` filter groups.
-    /// Dynamic-group MCP tools are omitted — their schemas are still available
-    /// via native API tool-calling when the turn keywords match.
-    fn filterToolsForPromptText(self: *const Agent, arena: std.mem.Allocator) ![]const Tool {
-        if (self.tool_filter_groups.len == 0) return self.tools;
-
-        var result: std.ArrayListUnmanaged(Tool) = .empty;
-        errdefer result.deinit(arena);
-
-        for (self.tools) |t| {
-            if (!std.mem.startsWith(u8, t.name(), "mcp_")) {
-                try result.append(arena, t);
-                continue;
-            }
-
-            for (self.tool_filter_groups) |group| {
-                if (group.mode != .always) continue;
-                for (group.tools) |pattern| {
-                    if (globMatch(pattern, t.name())) {
-                        try result.append(arena, t);
-                        break;
-                    }
-                } else continue;
-                break;
-            }
-        }
-
-        return try result.toOwnedSlice(arena);
-    }
-
     /// Filter and prioritize `self.tool_specs` for the current turn.
     ///
     /// Returns a slice allocated from `arena` containing only the specs that should
@@ -2018,30 +1963,23 @@ pub const Agent = struct {
                 self.system_prompt_conversation_context_fingerprint != turn_conversation_context_fingerprint);
 
         if (!self.has_system_prompt or conversation_context_changed) {
-            var prompt_tools_arena = std.heap.ArenaAllocator.init(self.allocator);
-            defer prompt_tools_arena.deinit();
-            const prompt_tools = try self.filterToolsForPromptText(prompt_tools_arena.allocator());
-            const prompt_is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
-            const prompt_native_tools_enabled = !prompt_is_streaming and self.provider.supportsNativeTools();
-
             const capabilities_section = capabilities_mod.buildPromptSection(
                 self.allocator,
                 cfg_for_prompt_ptr,
-                prompt_tools,
+                self.tools,
             ) catch null;
             defer if (capabilities_section) |section| self.allocator.free(section);
 
             const full_system = try prompt.buildSystemPrompt(self.allocator, .{
                 .workspace_dir = self.workspace_dir,
                 .model_name = turn_model_name,
-                .tools = prompt_tools,
+                .tools = self.tools,
                 .timezone = if (cfg_for_prompt_ptr) |cfg_ptr| cfg_ptr.agent.timezone else "UTC",
                 .capabilities_section = capabilities_section,
                 .conversation_context = self.conversation_context,
                 .bootstrap_provider = self.bootstrap,
                 .identity_config = if (cfg_for_prompt_ptr) |cfg| cfg.identity else null,
                 .observer = self.observer,
-                .native_tools_enabled = prompt_native_tools_enabled,
             });
             const active_skill_section = try commands.buildActiveSkillPromptSection(self);
             defer if (active_skill_section) |section| self.allocator.free(section);
@@ -2629,8 +2567,8 @@ pub const Agent = struct {
                     .content = try self.dupeForHistory(display_text),
                 });
 
-                // Auto-compaction before hard trimming to preserve context.
-                self.last_turn_compacted = self.maybeAutoCompactHistory();
+                // Auto-compaction before hard trimming to preserve context
+                self.last_turn_compacted = self.autoCompactHistory() catch false;
                 self.trimHistory();
 
                 // Auto-save assistant response
@@ -2922,7 +2860,7 @@ pub const Agent = struct {
         });
 
         // Compact/trim history so the next turn doesn't start with bloated context
-        self.last_turn_compacted = self.maybeAutoCompactHistory();
+        self.last_turn_compacted = self.autoCompactHistory() catch false;
         self.trimHistory();
 
         const complete_event = ObserverEvent{ .turn_complete = {} };
@@ -4043,106 +3981,6 @@ test "compaction module reexport" {
     _ = compaction.forceCompressHistory;
     _ = compaction.trimHistory;
     _ = compaction.CompactionConfig;
-}
-
-// Minimal provider that returns a fixed summary and counts invocations,
-// used to observe whether maybeAutoCompactHistory reached the summarizer.
-const CompactionTestProvider = struct {
-    calls: usize = 0,
-
-    fn chatWithSystem(_: *anyopaque, allocator: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
-        return allocator.dupe(u8, "");
-    }
-    fn chat(ptr: *anyopaque, allocator: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
-        const self: *CompactionTestProvider = @ptrCast(@alignCast(ptr));
-        self.calls += 1;
-        return .{ .content = try allocator.dupe(u8, "auto summary") };
-    }
-    fn supportsNativeTools(_: *anyopaque) bool {
-        return false;
-    }
-    fn getName(_: *anyopaque) []const u8 {
-        return "compaction-test-provider";
-    }
-    fn deinit(_: *anyopaque) void {}
-
-    const vtable = Provider.VTable{
-        .chatWithSystem = chatWithSystem,
-        .chat = chat,
-        .supportsNativeTools = supportsNativeTools,
-        .getName = getName,
-        .deinit = deinit,
-    };
-};
-
-fn makeCompactionTestAgent(allocator: std.mem.Allocator, observer: anytype, provider: Provider, compact_context: bool) Agent {
-    return Agent{
-        .allocator = allocator,
-        .provider = provider,
-        .tools = &.{},
-        .tool_specs = &.{},
-        .mem = null,
-        .observer = observer,
-        .model_name = "test-model",
-        .temperature = 0.7,
-        .workspace_dir = "/tmp",
-        .max_tool_iterations = 10,
-        .max_history_messages = 4,
-        .auto_save = false,
-        .compact_context = compact_context,
-        .history = .empty,
-        .total_tokens = 0,
-        .has_system_prompt = false,
-        .token_limit = 0,
-    };
-}
-
-fn fillOverThreshold(allocator: std.mem.Allocator, agent: *Agent) !void {
-    try agent.history.append(allocator, .{ .role = .system, .content = try allocator.dupe(u8, "system prompt") });
-    for (0..12) |i| {
-        try agent.history.append(allocator, .{ .role = .user, .content = try std.fmt.allocPrint(allocator, "message {d}", .{i}) });
-        try agent.history.append(allocator, .{ .role = .assistant, .content = try std.fmt.allocPrint(allocator, "reply {d}", .{i}) });
-    }
-}
-
-test "maybeAutoCompactHistory skips compaction when compact_context is false (regression #937)" {
-    const allocator = std.testing.allocator;
-    var noop = observability.NoopObserver{};
-    var provider_state = CompactionTestProvider{};
-    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &CompactionTestProvider.vtable };
-
-    var agent = makeCompactionTestAgent(allocator, noop.observer(), provider, false);
-    defer agent.deinit();
-    try fillOverThreshold(allocator, &agent);
-
-    const len_before = agent.history.items.len;
-    const compacted = agent.maybeAutoCompactHistory();
-
-    // Flag is off: history is left untouched and the summarizer is never called,
-    // even though the message count is well over max_history_messages.
-    try std.testing.expect(!compacted);
-    try std.testing.expectEqual(len_before, agent.history.items.len);
-    try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
-}
-
-test "maybeAutoCompactHistory compacts when compact_context is true" {
-    const allocator = std.testing.allocator;
-    var noop = observability.NoopObserver{};
-    var provider_state = CompactionTestProvider{};
-    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &CompactionTestProvider.vtable };
-
-    var agent = makeCompactionTestAgent(allocator, noop.observer(), provider, true);
-    defer agent.deinit();
-    try fillOverThreshold(allocator, &agent);
-
-    const len_before = agent.history.items.len;
-    const compacted = agent.maybeAutoCompactHistory();
-
-    // Flag is on: the same over-threshold history is compacted and the
-    // summarizer is invoked, shrinking the message count.
-    try std.testing.expect(compacted);
-    try std.testing.expect(agent.history.items.len < len_before);
-    try std.testing.expect(provider_state.calls > 0);
 }
 
 test "cli module reexport" {
@@ -5314,26 +5152,6 @@ test "Agent.fromConfig applies status_show_emojis flag" {
     defer agent.deinit();
 
     try std.testing.expect(!agent.status_show_emojis);
-}
-
-test "Agent.fromConfig applies compact_context flag" {
-    // Regression: #937. Parsed `agent.compact_context = false` must reach the
-    // runtime Agent so proactive compaction can be skipped.
-    const allocator = std.testing.allocator;
-    var cfg = Config{
-        .workspace_dir = "/tmp/yc",
-        .config_path = "/tmp/yc/config.json",
-        .default_model = "openai/gpt-4.1-mini",
-        .allocator = allocator,
-    };
-    cfg.agent.compact_context = false;
-
-    var noop = observability.NoopObserver{};
-    var agent = try Agent.fromConfig(allocator, &cfg, undefined, &.{}, null, noop.observer());
-    defer agent.deinit();
-
-    try std.testing.expect(!agent.compact_context);
-    try std.testing.expect(!agent.maybeAutoCompactHistory());
 }
 
 test "slash /new clears history" {
@@ -10645,250 +10463,6 @@ test "priorityToolForSpecsMessage ignores tools excluded from turn specs" {
     try std.testing.expectEqualStrings("shell", turn_specs[0].name);
     try std.testing.expect(agent.priorityToolForSpecsMessage(turn_specs, "private") == null);
     agent.tool_specs = try allocator.alloc(ToolSpec, 0);
-}
-
-// ── filterToolsForPromptText tests ─────────────────────────────────
-
-const MockFilterTool = struct {
-    name_buf: []const u8,
-    desc_buf: []const u8,
-};
-
-fn mockFilterToolVTable() tools_mod.Tool.VTable {
-    return .{
-        .name = struct {
-            fn f(ptr: *anyopaque) []const u8 {
-                return @as(*const MockFilterTool, @ptrCast(@alignCast(ptr))).name_buf;
-            }
-        }.f,
-        .description = struct {
-            fn f(ptr: *anyopaque) []const u8 {
-                return @as(*const MockFilterTool, @ptrCast(@alignCast(ptr))).desc_buf;
-            }
-        }.f,
-        .parameters_json = struct {
-            fn f(_: *anyopaque) []const u8 {
-                return "{}";
-            }
-        }.f,
-        .execute = struct {
-            fn f(_: *anyopaque, _: std.mem.Allocator, _: tools_mod.JsonObjectMap) anyerror!tools_mod.ToolResult {
-                return tools_mod.ToolResult.ok("");
-            }
-        }.f,
-    };
-}
-
-fn makeMockFilterTool(allocator: std.mem.Allocator, name: []const u8) !Tool {
-    const m = try allocator.create(MockFilterTool);
-    m.* = .{ .name_buf = try allocator.dupe(u8, name), .desc_buf = try allocator.dupe(u8, name) };
-    const vt = try allocator.create(tools_mod.Tool.VTable);
-    vt.* = mockFilterToolVTable();
-    return .{ .ptr = @ptrCast(m), .vtable = vt };
-}
-
-fn freeMockFilterTool(tool: Tool, allocator: std.mem.Allocator) void {
-    const m: *MockFilterTool = @ptrCast(@alignCast(tool.ptr));
-    allocator.free(m.name_buf);
-    allocator.free(m.desc_buf);
-    allocator.destroy(m);
-    allocator.destroy(@constCast(tool.vtable));
-}
-
-test "filterToolsForPromptText no groups returns all tools" {
-    const allocator = std.testing.allocator;
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    var agent = try makeTestAgent(allocator);
-    defer agent.deinit();
-    allocator.free(agent.tools);
-
-    agent.tools = &.{
-        try makeMockFilterTool(allocator, "shell"),
-        try makeMockFilterTool(allocator, "mcp_webdav_read"),
-    };
-    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
-
-    const result = try agent.filterToolsForPromptText(arena.allocator());
-    try std.testing.expectEqual(@as(usize, 2), result.len);
-}
-
-test "filterToolsForPromptText always group includes matching MCP" {
-    const allocator = std.testing.allocator;
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    var agent = try makeTestAgent(allocator);
-    defer agent.deinit();
-    allocator.free(agent.tools);
-
-    agent.tools = &.{
-        try makeMockFilterTool(allocator, "shell"),
-        try makeMockFilterTool(allocator, "mcp_webdav_read"),
-        try makeMockFilterTool(allocator, "mcp_browser_open"),
-    };
-    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
-    agent.tool_filter_groups = &.{
-        .{ .mode = .always, .tools = &.{"mcp_webdav_*"} },
-    };
-
-    const result = try agent.filterToolsForPromptText(arena.allocator());
-    try std.testing.expectEqual(@as(usize, 2), result.len);
-}
-
-test "filterToolsForPromptText dynamic group excluded from text" {
-    const allocator = std.testing.allocator;
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    var agent = try makeTestAgent(allocator);
-    defer agent.deinit();
-    allocator.free(agent.tools);
-
-    agent.tools = &.{
-        try makeMockFilterTool(allocator, "shell"),
-        try makeMockFilterTool(allocator, "mcp_vikunja_create_task"),
-        try makeMockFilterTool(allocator, "mcp_webdav_read"),
-    };
-    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
-    agent.tool_filter_groups = &.{
-        .{ .mode = .dynamic, .tools = &.{"mcp_vikunja_*"}, .keywords = &.{"task"} },
-        .{ .mode = .always, .tools = &.{"mcp_webdav_*"} },
-    };
-
-    const result = try agent.filterToolsForPromptText(arena.allocator());
-    try std.testing.expectEqual(@as(usize, 2), result.len);
-    try std.testing.expectEqualStrings("shell", result[0].name());
-}
-
-test "filterToolsForPromptText empty group excludes MCP tools" {
-    const allocator = std.testing.allocator;
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    var agent = try makeTestAgent(allocator);
-    defer agent.deinit();
-    allocator.free(agent.tools);
-
-    agent.tools = &.{
-        try makeMockFilterTool(allocator, "shell"),
-        try makeMockFilterTool(allocator, "mcp_webdav_read"),
-    };
-    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
-    agent.tool_filter_groups = &.{
-        .{ .mode = .always, .tools = &.{} },
-    };
-
-    const result = try agent.filterToolsForPromptText(arena.allocator());
-    try std.testing.expectEqual(@as(usize, 1), result.len);
-    try std.testing.expectEqualStrings("shell", result[0].name());
-}
-
-test "Agent system prompt keeps parameters when streaming disables native tool schemas" {
-    // Regression: streaming turns send tools=null, so the text prompt must keep
-    // Parameters even if the provider supports native tools.
-    const StreamingPromptCapture = struct {
-        captured_system: ?[]u8 = null,
-        capture_alloc: std.mem.Allocator,
-
-        fn chatWithSystem(_: *anyopaque, allocator_: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
-            return allocator_.dupe(u8, "ok");
-        }
-
-        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
-            return error.ShouldNotUseBlockingChat;
-        }
-
-        fn supportsNativeTools(_: *anyopaque) bool {
-            return true;
-        }
-
-        fn supportsStreaming(_: *anyopaque) bool {
-            return true;
-        }
-
-        fn streamChat(
-            ptr: *anyopaque,
-            allocator_: std.mem.Allocator,
-            request: providers.ChatRequest,
-            model: []const u8,
-            _: f64,
-            callback: providers.StreamCallback,
-            callback_ctx: *anyopaque,
-        ) anyerror!providers.StreamChatResult {
-            try std.testing.expect(request.tools == null);
-            const self: *@This() = @ptrCast(@alignCast(ptr));
-            for (request.messages) |msg| {
-                if (msg.role == .system) {
-                    if (self.captured_system) |old| self.capture_alloc.free(old);
-                    self.captured_system = try self.capture_alloc.dupe(u8, msg.content);
-                    break;
-                }
-            }
-            callback(callback_ctx, providers.StreamChunk.textDelta("ok"));
-            callback(callback_ctx, providers.StreamChunk.finalChunk());
-            return .{
-                .content = try allocator_.dupe(u8, "ok"),
-                .model = try allocator_.dupe(u8, model),
-            };
-        }
-
-        fn getName(_: *anyopaque) []const u8 {
-            return "streaming-prompt-capture";
-        }
-
-        fn deinitFn(_: *anyopaque) void {}
-    };
-
-    const allocator = std.testing.allocator;
-    var provider_state = StreamingPromptCapture{ .capture_alloc = allocator };
-    defer if (provider_state.captured_system) |captured| allocator.free(captured);
-    const provider_vtable = Provider.VTable{
-        .chatWithSystem = StreamingPromptCapture.chatWithSystem,
-        .chat = StreamingPromptCapture.chat,
-        .supportsNativeTools = StreamingPromptCapture.supportsNativeTools,
-        .getName = StreamingPromptCapture.getName,
-        .deinit = StreamingPromptCapture.deinitFn,
-        .supports_streaming = StreamingPromptCapture.supportsStreaming,
-        .stream_chat = StreamingPromptCapture.streamChat,
-    };
-    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &provider_vtable };
-
-    const runtime_tools = [_]Tool{
-        try makeMockFilterTool(allocator, "shell"),
-        try makeMockFilterTool(allocator, "mcp_secret_lookup"),
-    };
-    defer for (runtime_tools) |t| freeMockFilterTool(t, allocator);
-
-    var cfg = Config{
-        .workspace_dir = "/tmp",
-        .config_path = "/tmp/config.json",
-        .default_model = "openai/gpt-4.1-mini",
-        .allocator = allocator,
-    };
-    var noop = observability.NoopObserver{};
-    var agent = try Agent.fromConfig(allocator, &cfg, provider, &runtime_tools, null, noop.observer());
-    defer agent.deinit();
-    agent.tool_filter_groups = &.{
-        .{ .mode = .dynamic, .tools = &.{"mcp_secret_*"}, .keywords = &.{"secret"} },
-    };
-
-    const StreamSink = struct {
-        fn onChunk(_: *anyopaque, _: providers.StreamChunk) void {}
-    };
-    var stream_ctx: u8 = 0;
-    agent.stream_callback = StreamSink.onChunk;
-    agent.stream_ctx = @ptrCast(&stream_ctx);
-
-    const response = try agent.turn("hello");
-    defer allocator.free(response);
-
-    try std.testing.expect(provider_state.captured_system != null);
-    const captured = provider_state.captured_system.?;
-    try std.testing.expect(std.mem.indexOf(u8, captured, "**shell**: shell") != null);
-    try std.testing.expect(std.mem.indexOf(u8, captured, "Parameters: `{}`") != null);
-    try std.testing.expect(std.mem.indexOf(u8, captured, "mcp_secret_lookup") == null);
 }
 
 test "buildProviderMessagesForTurn adds priority hint without mutating history" {

--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -298,6 +298,7 @@ pub const Agent = struct {
     max_tool_iterations: u32,
     max_history_messages: u32,
     auto_save: bool,
+    compact_context: bool = true,
     token_limit: u64 = 0,
     token_limit_override: ?u64 = null,
     max_tokens: u32 = max_tokens_resolver.DEFAULT_MODEL_MAX_TOKENS,
@@ -313,6 +314,7 @@ pub const Agent = struct {
     exec_ask: ExecAsk = .on_miss,
     exec_node_id: ?[]const u8 = null,
     exec_node_id_owned: bool = false,
+    default_queue_mode: QueueMode = .off,
     queue_mode: QueueMode = .off,
     queue_debounce_ms: u32 = 0,
     queue_cap: u32 = 0,
@@ -611,6 +613,7 @@ pub const Agent = struct {
             .max_tool_iterations = cfg.agent.max_tool_iterations,
             .max_history_messages = cfg.agent.max_history_messages,
             .auto_save = cfg.memory.auto_save,
+            .compact_context = cfg.agent.compact_context,
             .token_limit = resolved_token_limit,
             .token_limit_override = token_limit_override,
             .max_tokens = resolved_max_tokens,
@@ -623,6 +626,7 @@ pub const Agent = struct {
             .compaction_keep_recent = cfg.agent.compaction_keep_recent,
             .compaction_max_summary_chars = cfg.agent.compaction_max_summary_chars,
             .compaction_max_source_chars = cfg.agent.compaction_max_source_chars,
+            .default_queue_mode = cfg.agent.default_queue_mode,
             .queue_mode = cfg.agent.default_queue_mode,
             .tools_config = cfg.tools,
             .tool_filter_groups = cfg.agent.tool_filter_groups,
@@ -851,6 +855,15 @@ pub const Agent = struct {
         const completion_budget_u32: u32 = @intCast(@min(completion_budget, @as(u64, std.math.maxInt(u32))));
         if (completion_budget_u32 == 0) return 1;
         return @max(@as(u32, 1), @min(max_tokens, completion_budget_u32));
+    }
+
+    /// Proactively auto-compact history, honoring `agent.compact_context`.
+    /// When the flag is disabled the LLM summarization pass is skipped. Hard
+    /// history trimming and emergency `forceCompressHistory` remain separate
+    /// safeguards and are intentionally not gated by this flag.
+    pub fn maybeAutoCompactHistory(self: *Agent) bool {
+        if (!self.compact_context) return false;
+        return self.autoCompactHistory() catch false;
     }
 
     /// Auto-compact history when it exceeds thresholds.
@@ -1825,6 +1838,37 @@ pub const Agent = struct {
         return prioritized;
     }
 
+    /// Build a subset of `self.tools` suitable for the text-based system prompt.
+    /// Only includes built-in tools and MCP tools from `always` filter groups.
+    /// Dynamic-group MCP tools are omitted — their schemas are still available
+    /// via native API tool-calling when the turn keywords match.
+    fn filterToolsForPromptText(self: *const Agent, arena: std.mem.Allocator) ![]const Tool {
+        if (self.tool_filter_groups.len == 0) return self.tools;
+
+        var result: std.ArrayListUnmanaged(Tool) = .empty;
+        errdefer result.deinit(arena);
+
+        for (self.tools) |t| {
+            if (!std.mem.startsWith(u8, t.name(), "mcp_")) {
+                try result.append(arena, t);
+                continue;
+            }
+
+            for (self.tool_filter_groups) |group| {
+                if (group.mode != .always) continue;
+                for (group.tools) |pattern| {
+                    if (globMatch(pattern, t.name())) {
+                        try result.append(arena, t);
+                        break;
+                    }
+                } else continue;
+                break;
+            }
+        }
+
+        return try result.toOwnedSlice(arena);
+    }
+
     /// Filter and prioritize `self.tool_specs` for the current turn.
     ///
     /// Returns a slice allocated from `arena` containing only the specs that should
@@ -1963,23 +2007,30 @@ pub const Agent = struct {
                 self.system_prompt_conversation_context_fingerprint != turn_conversation_context_fingerprint);
 
         if (!self.has_system_prompt or conversation_context_changed) {
+            var prompt_tools_arena = std.heap.ArenaAllocator.init(self.allocator);
+            defer prompt_tools_arena.deinit();
+            const prompt_tools = try self.filterToolsForPromptText(prompt_tools_arena.allocator());
+            const prompt_is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
+            const prompt_native_tools_enabled = !prompt_is_streaming and self.provider.supportsNativeTools();
+
             const capabilities_section = capabilities_mod.buildPromptSection(
                 self.allocator,
                 cfg_for_prompt_ptr,
-                self.tools,
+                prompt_tools,
             ) catch null;
             defer if (capabilities_section) |section| self.allocator.free(section);
 
             const full_system = try prompt.buildSystemPrompt(self.allocator, .{
                 .workspace_dir = self.workspace_dir,
                 .model_name = turn_model_name,
-                .tools = self.tools,
+                .tools = prompt_tools,
                 .timezone = if (cfg_for_prompt_ptr) |cfg_ptr| cfg_ptr.agent.timezone else "UTC",
                 .capabilities_section = capabilities_section,
                 .conversation_context = self.conversation_context,
                 .bootstrap_provider = self.bootstrap,
                 .identity_config = if (cfg_for_prompt_ptr) |cfg| cfg.identity else null,
                 .observer = self.observer,
+                .native_tools_enabled = prompt_native_tools_enabled,
             });
             const active_skill_section = try commands.buildActiveSkillPromptSection(self);
             defer if (active_skill_section) |section| self.allocator.free(section);
@@ -2567,8 +2618,8 @@ pub const Agent = struct {
                     .content = try self.dupeForHistory(display_text),
                 });
 
-                // Auto-compaction before hard trimming to preserve context
-                self.last_turn_compacted = self.autoCompactHistory() catch false;
+                // Auto-compaction before hard trimming to preserve context.
+                self.last_turn_compacted = self.maybeAutoCompactHistory();
                 self.trimHistory();
 
                 // Auto-save assistant response
@@ -2860,7 +2911,7 @@ pub const Agent = struct {
         });
 
         // Compact/trim history so the next turn doesn't start with bloated context
-        self.last_turn_compacted = self.autoCompactHistory() catch false;
+        self.last_turn_compacted = self.maybeAutoCompactHistory();
         self.trimHistory();
 
         const complete_event = ObserverEvent{ .turn_complete = {} };
@@ -3981,6 +4032,106 @@ test "compaction module reexport" {
     _ = compaction.forceCompressHistory;
     _ = compaction.trimHistory;
     _ = compaction.CompactionConfig;
+}
+
+// Minimal provider that returns a fixed summary and counts invocations,
+// used to observe whether maybeAutoCompactHistory reached the summarizer.
+const CompactionTestProvider = struct {
+    calls: usize = 0,
+
+    fn chatWithSystem(_: *anyopaque, allocator: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+        return allocator.dupe(u8, "");
+    }
+    fn chat(ptr: *anyopaque, allocator: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+        const self: *CompactionTestProvider = @ptrCast(@alignCast(ptr));
+        self.calls += 1;
+        return .{ .content = try allocator.dupe(u8, "auto summary") };
+    }
+    fn supportsNativeTools(_: *anyopaque) bool {
+        return false;
+    }
+    fn getName(_: *anyopaque) []const u8 {
+        return "compaction-test-provider";
+    }
+    fn deinit(_: *anyopaque) void {}
+
+    const vtable = Provider.VTable{
+        .chatWithSystem = chatWithSystem,
+        .chat = chat,
+        .supportsNativeTools = supportsNativeTools,
+        .getName = getName,
+        .deinit = deinit,
+    };
+};
+
+fn makeCompactionTestAgent(allocator: std.mem.Allocator, observer: anytype, provider: Provider, compact_context: bool) Agent {
+    return Agent{
+        .allocator = allocator,
+        .provider = provider,
+        .tools = &.{},
+        .tool_specs = &.{},
+        .mem = null,
+        .observer = observer,
+        .model_name = "test-model",
+        .temperature = 0.7,
+        .workspace_dir = "/tmp",
+        .max_tool_iterations = 10,
+        .max_history_messages = 4,
+        .auto_save = false,
+        .compact_context = compact_context,
+        .history = .empty,
+        .total_tokens = 0,
+        .has_system_prompt = false,
+        .token_limit = 0,
+    };
+}
+
+fn fillOverThreshold(allocator: std.mem.Allocator, agent: *Agent) !void {
+    try agent.history.append(allocator, .{ .role = .system, .content = try allocator.dupe(u8, "system prompt") });
+    for (0..12) |i| {
+        try agent.history.append(allocator, .{ .role = .user, .content = try std.fmt.allocPrint(allocator, "message {d}", .{i}) });
+        try agent.history.append(allocator, .{ .role = .assistant, .content = try std.fmt.allocPrint(allocator, "reply {d}", .{i}) });
+    }
+}
+
+test "maybeAutoCompactHistory skips compaction when compact_context is false (regression #937)" {
+    const allocator = std.testing.allocator;
+    var noop = observability.NoopObserver{};
+    var provider_state = CompactionTestProvider{};
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &CompactionTestProvider.vtable };
+
+    var agent = makeCompactionTestAgent(allocator, noop.observer(), provider, false);
+    defer agent.deinit();
+    try fillOverThreshold(allocator, &agent);
+
+    const len_before = agent.history.items.len;
+    const compacted = agent.maybeAutoCompactHistory();
+
+    // Flag is off: history is left untouched and the summarizer is never called,
+    // even though the message count is well over max_history_messages.
+    try std.testing.expect(!compacted);
+    try std.testing.expectEqual(len_before, agent.history.items.len);
+    try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
+}
+
+test "maybeAutoCompactHistory compacts when compact_context is true" {
+    const allocator = std.testing.allocator;
+    var noop = observability.NoopObserver{};
+    var provider_state = CompactionTestProvider{};
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &CompactionTestProvider.vtable };
+
+    var agent = makeCompactionTestAgent(allocator, noop.observer(), provider, true);
+    defer agent.deinit();
+    try fillOverThreshold(allocator, &agent);
+
+    const len_before = agent.history.items.len;
+    const compacted = agent.maybeAutoCompactHistory();
+
+    // Flag is on: the same over-threshold history is compacted and the
+    // summarizer is invoked, shrinking the message count.
+    try std.testing.expect(compacted);
+    try std.testing.expect(agent.history.items.len < len_before);
+    try std.testing.expect(provider_state.calls > 0);
 }
 
 test "cli module reexport" {
@@ -5152,6 +5303,45 @@ test "Agent.fromConfig applies status_show_emojis flag" {
     defer agent.deinit();
 
     try std.testing.expect(!agent.status_show_emojis);
+}
+
+test "Agent.fromConfig applies compact_context flag" {
+    // Regression: #937. Parsed `agent.compact_context = false` must reach the
+    // runtime Agent so proactive compaction can be skipped.
+    const allocator = std.testing.allocator;
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .default_model = "openai/gpt-4.1-mini",
+        .allocator = allocator,
+    };
+    cfg.agent.compact_context = false;
+
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, undefined, &.{}, null, noop.observer());
+    defer agent.deinit();
+
+    try std.testing.expect(!agent.compact_context);
+    try std.testing.expect(!agent.maybeAutoCompactHistory());
+}
+
+test "Agent.fromConfig applies default_queue_mode" {
+    // Regression: parsing the default is insufficient unless both runtime fields receive it.
+    const allocator = std.testing.allocator;
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .default_model = "openai/gpt-4.1-mini",
+        .allocator = allocator,
+    };
+    cfg.agent.default_queue_mode = .latest;
+
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, undefined, &.{}, null, noop.observer());
+    defer agent.deinit();
+
+    try std.testing.expectEqual(Agent.QueueMode.latest, agent.default_queue_mode);
+    try std.testing.expectEqual(Agent.QueueMode.latest, agent.queue_mode);
 }
 
 test "slash /new clears history" {
@@ -6497,6 +6687,23 @@ test "slash /queue updates queue settings" {
     try std.testing.expect(agent.queue_drop == .newest);
 }
 
+test "slash /queue reset restores configured default" {
+    // Regression: reset must not hardcode off after a non-off config default.
+    const allocator = std.testing.allocator;
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    agent.default_queue_mode = .latest;
+    agent.queue_mode = .serial;
+
+    const response = (try agent.handleSlashCommand("/queue reset")).?;
+    defer allocator.free(response);
+
+    try std.testing.expectEqual(Agent.QueueMode.latest, agent.queue_mode);
+    try std.testing.expectEqual(@as(u32, 0), agent.queue_debounce_ms);
+    try std.testing.expectEqual(@as(u32, 0), agent.queue_cap);
+    try std.testing.expect(agent.queue_drop == .summarize);
+}
+
 test "slash /usage updates usage mode" {
     const allocator = std.testing.allocator;
     var agent = try makeTestAgent(allocator);
@@ -6768,6 +6975,8 @@ test "slash /restart clears runtime command settings" {
     defer allocator.free(usage_resp);
     const tts_resp = (try agent.handleSlashCommand("/tts always provider test-provider")).?;
     defer allocator.free(tts_resp);
+    agent.default_queue_mode = .latest;
+    agent.queue_mode = .serial;
     agent.total_tokens = 42;
     agent.last_turn_usage = .{ .prompt_tokens = 7, .completion_tokens = 5, .total_tokens = 12 };
 
@@ -6780,6 +6989,8 @@ test "slash /restart clears runtime command settings" {
     try std.testing.expect(agent.usage_mode == .off);
     try std.testing.expect(agent.tts_mode == .off);
     try std.testing.expect(agent.tts_provider == null);
+    // Regression: /restart clears overrides but keeps the configured queue default.
+    try std.testing.expectEqual(Agent.QueueMode.latest, agent.queue_mode);
     try std.testing.expectEqual(@as(u64, 0), agent.total_tokens);
     try std.testing.expectEqual(@as(u32, 0), agent.last_turn_usage.total_tokens);
 }
@@ -10463,6 +10674,250 @@ test "priorityToolForSpecsMessage ignores tools excluded from turn specs" {
     try std.testing.expectEqualStrings("shell", turn_specs[0].name);
     try std.testing.expect(agent.priorityToolForSpecsMessage(turn_specs, "private") == null);
     agent.tool_specs = try allocator.alloc(ToolSpec, 0);
+}
+
+// ── filterToolsForPromptText tests ─────────────────────────────────
+
+const MockFilterTool = struct {
+    name_buf: []const u8,
+    desc_buf: []const u8,
+};
+
+fn mockFilterToolVTable() tools_mod.Tool.VTable {
+    return .{
+        .name = struct {
+            fn f(ptr: *anyopaque) []const u8 {
+                return @as(*const MockFilterTool, @ptrCast(@alignCast(ptr))).name_buf;
+            }
+        }.f,
+        .description = struct {
+            fn f(ptr: *anyopaque) []const u8 {
+                return @as(*const MockFilterTool, @ptrCast(@alignCast(ptr))).desc_buf;
+            }
+        }.f,
+        .parameters_json = struct {
+            fn f(_: *anyopaque) []const u8 {
+                return "{}";
+            }
+        }.f,
+        .execute = struct {
+            fn f(_: *anyopaque, _: std.mem.Allocator, _: tools_mod.JsonObjectMap) anyerror!tools_mod.ToolResult {
+                return tools_mod.ToolResult.ok("");
+            }
+        }.f,
+    };
+}
+
+fn makeMockFilterTool(allocator: std.mem.Allocator, name: []const u8) !Tool {
+    const m = try allocator.create(MockFilterTool);
+    m.* = .{ .name_buf = try allocator.dupe(u8, name), .desc_buf = try allocator.dupe(u8, name) };
+    const vt = try allocator.create(tools_mod.Tool.VTable);
+    vt.* = mockFilterToolVTable();
+    return .{ .ptr = @ptrCast(m), .vtable = vt };
+}
+
+fn freeMockFilterTool(tool: Tool, allocator: std.mem.Allocator) void {
+    const m: *MockFilterTool = @ptrCast(@alignCast(tool.ptr));
+    allocator.free(m.name_buf);
+    allocator.free(m.desc_buf);
+    allocator.destroy(m);
+    allocator.destroy(@constCast(tool.vtable));
+}
+
+test "filterToolsForPromptText no groups returns all tools" {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    allocator.free(agent.tools);
+
+    agent.tools = &.{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_webdav_read"),
+    };
+    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+
+    const result = try agent.filterToolsForPromptText(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 2), result.len);
+}
+
+test "filterToolsForPromptText always group includes matching MCP" {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    allocator.free(agent.tools);
+
+    agent.tools = &.{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_webdav_read"),
+        try makeMockFilterTool(allocator, "mcp_browser_open"),
+    };
+    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+    agent.tool_filter_groups = &.{
+        .{ .mode = .always, .tools = &.{"mcp_webdav_*"} },
+    };
+
+    const result = try agent.filterToolsForPromptText(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 2), result.len);
+}
+
+test "filterToolsForPromptText dynamic group excluded from text" {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    allocator.free(agent.tools);
+
+    agent.tools = &.{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_vikunja_create_task"),
+        try makeMockFilterTool(allocator, "mcp_webdav_read"),
+    };
+    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+    agent.tool_filter_groups = &.{
+        .{ .mode = .dynamic, .tools = &.{"mcp_vikunja_*"}, .keywords = &.{"task"} },
+        .{ .mode = .always, .tools = &.{"mcp_webdav_*"} },
+    };
+
+    const result = try agent.filterToolsForPromptText(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 2), result.len);
+    try std.testing.expectEqualStrings("shell", result[0].name());
+}
+
+test "filterToolsForPromptText empty group excludes MCP tools" {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var agent = try makeTestAgent(allocator);
+    defer agent.deinit();
+    allocator.free(agent.tools);
+
+    agent.tools = &.{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_webdav_read"),
+    };
+    defer for (agent.tools) |t| freeMockFilterTool(t, allocator);
+    agent.tool_filter_groups = &.{
+        .{ .mode = .always, .tools = &.{} },
+    };
+
+    const result = try agent.filterToolsForPromptText(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+    try std.testing.expectEqualStrings("shell", result[0].name());
+}
+
+test "Agent system prompt keeps parameters when streaming disables native tool schemas" {
+    // Regression: streaming turns send tools=null, so the text prompt must keep
+    // Parameters even if the provider supports native tools.
+    const StreamingPromptCapture = struct {
+        captured_system: ?[]u8 = null,
+        capture_alloc: std.mem.Allocator,
+
+        fn chatWithSystem(_: *anyopaque, allocator_: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator_.dupe(u8, "ok");
+        }
+
+        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            return error.ShouldNotUseBlockingChat;
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn supportsStreaming(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn streamChat(
+            ptr: *anyopaque,
+            allocator_: std.mem.Allocator,
+            request: providers.ChatRequest,
+            model: []const u8,
+            _: f64,
+            callback: providers.StreamCallback,
+            callback_ctx: *anyopaque,
+        ) anyerror!providers.StreamChatResult {
+            try std.testing.expect(request.tools == null);
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            for (request.messages) |msg| {
+                if (msg.role == .system) {
+                    if (self.captured_system) |old| self.capture_alloc.free(old);
+                    self.captured_system = try self.capture_alloc.dupe(u8, msg.content);
+                    break;
+                }
+            }
+            callback(callback_ctx, providers.StreamChunk.textDelta("ok"));
+            callback(callback_ctx, providers.StreamChunk.finalChunk());
+            return .{
+                .content = try allocator_.dupe(u8, "ok"),
+                .model = try allocator_.dupe(u8, model),
+            };
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "streaming-prompt-capture";
+        }
+
+        fn deinitFn(_: *anyopaque) void {}
+    };
+
+    const allocator = std.testing.allocator;
+    var provider_state = StreamingPromptCapture{ .capture_alloc = allocator };
+    defer if (provider_state.captured_system) |captured| allocator.free(captured);
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = StreamingPromptCapture.chatWithSystem,
+        .chat = StreamingPromptCapture.chat,
+        .supportsNativeTools = StreamingPromptCapture.supportsNativeTools,
+        .getName = StreamingPromptCapture.getName,
+        .deinit = StreamingPromptCapture.deinitFn,
+        .supports_streaming = StreamingPromptCapture.supportsStreaming,
+        .stream_chat = StreamingPromptCapture.streamChat,
+    };
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &provider_vtable };
+
+    const runtime_tools = [_]Tool{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_secret_lookup"),
+    };
+    defer for (runtime_tools) |t| freeMockFilterTool(t, allocator);
+
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .default_model = "openai/gpt-4.1-mini",
+        .allocator = allocator,
+    };
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, provider, &runtime_tools, null, noop.observer());
+    defer agent.deinit();
+    agent.tool_filter_groups = &.{
+        .{ .mode = .dynamic, .tools = &.{"mcp_secret_*"}, .keywords = &.{"secret"} },
+    };
+
+    const StreamSink = struct {
+        fn onChunk(_: *anyopaque, _: providers.StreamChunk) void {}
+    };
+    var stream_ctx: u8 = 0;
+    agent.stream_callback = StreamSink.onChunk;
+    agent.stream_ctx = @ptrCast(&stream_ctx);
+
+    const response = try agent.turn("hello");
+    defer allocator.free(response);
+
+    try std.testing.expect(provider_state.captured_system != null);
+    const captured = provider_state.captured_system.?;
+    try std.testing.expect(std.mem.indexOf(u8, captured, "**shell**: shell") != null);
+    try std.testing.expect(std.mem.indexOf(u8, captured, "Parameters: `{}`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, captured, "mcp_secret_lookup") == null);
 }
 
 test "buildProviderMessagesForTurn adds priority hint without mutating history" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -6671,6 +6671,28 @@ test "parse agents.defaults.heartbeat dispatch settings" {
     try std.testing.expect(!cfg.heartbeat.delivery_best_effort);
 }
 
+test "parse agent.default_queue_mode" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const json =
+        \\{"agent":{"default_queue_mode":"latest"}}
+    ;
+    var cfg = Config{ .workspace_dir = "/tmp/yc", .config_path = "/tmp/yc/config.json", .allocator = allocator };
+    try cfg.parseJson(json);
+    try std.testing.expectEqual(config_types.QueueMode.latest, cfg.agent.default_queue_mode);
+}
+
+test "agent.default_queue_mode defaults to off" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const json = "{}";
+    var cfg = Config{ .workspace_dir = "/tmp/yc", .config_path = "/tmp/yc/config.json", .allocator = allocator };
+    try cfg.parseJson(json);
+    try std.testing.expectEqual(config_types.QueueMode.off, cfg.agent.default_queue_mode);
+}
+
 test "save roundtrip preserves heartbeat dispatch settings" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/config.zig
+++ b/src/config.zig
@@ -1354,6 +1354,7 @@ pub const Config = struct {
             .max_history_messages = self.agent.max_history_messages,
             .parallel_tools = self.agent.parallel_tools,
             .tool_dispatcher = self.agent.tool_dispatcher,
+            .default_queue_mode = self.agent.default_queue_mode,
             .session_idle_timeout_secs = self.agent.session_idle_timeout_secs,
             .compaction_keep_recent = self.agent.compaction_keep_recent,
             .compaction_max_summary_chars = self.agent.compaction_max_summary_chars,
@@ -2966,6 +2967,7 @@ test "save outputs pretty-printed nested sections" {
     cfg.security.audit.enabled = true;
     cfg.agent.compact_context = true;
     cfg.agent.max_tool_iterations = 42;
+    cfg.agent.default_queue_mode = .latest;
     try cfg.save();
 
     const file = try std_compat.fs.openFileAbsolute(config_path, .{});
@@ -2985,6 +2987,7 @@ test "save outputs pretty-printed nested sections" {
     try std.testing.expect(std.mem.indexOf(u8, content, "    \"sandbox\": {\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, content, "      \"enabled\": true") != null);
     try std.testing.expect(std.mem.indexOf(u8, content, "    \"max_tool_iterations\": 42") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "    \"default_queue_mode\": \"latest\"") != null);
 
     // Roundtrip: values must survive parse
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -2999,6 +3002,8 @@ test "save outputs pretty-printed nested sections" {
     try std.testing.expect(loaded.security.audit.enabled);
     try std.testing.expect(loaded.agent.compact_context);
     try std.testing.expectEqual(@as(u32, 42), loaded.agent.max_tool_iterations);
+    // Regression: Config.save must not silently erase a non-off queue default.
+    try std.testing.expectEqual(config_types.QueueMode.latest, loaded.agent.default_queue_mode);
 }
 
 test "save escapes string arrays safely" {
@@ -6672,6 +6677,7 @@ test "parse agents.defaults.heartbeat dispatch settings" {
 }
 
 test "parse agent.default_queue_mode" {
+    // Regression: configured queue policy must be parsed before Agent creation.
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -6691,6 +6697,20 @@ test "agent.default_queue_mode defaults to off" {
     var cfg = Config{ .workspace_dir = "/tmp/yc", .config_path = "/tmp/yc/config.json", .allocator = allocator };
     try cfg.parseJson(json);
     try std.testing.expectEqual(config_types.QueueMode.off, cfg.agent.default_queue_mode);
+}
+
+test "agent.default_queue_mode rejects invalid values" {
+    // Regression: a typo must not silently fall back to off and drop busy-session messages.
+    const allocator = std.testing.allocator;
+    var cfg = Config{ .workspace_dir = "/tmp/yc", .config_path = "/tmp/yc/config.json", .allocator = allocator };
+    try std.testing.expectError(
+        error.InvalidDefaultQueueMode,
+        cfg.parseJson("{\"agent\":{\"default_queue_mode\":\"lastest\"}}"),
+    );
+    try std.testing.expectError(
+        error.InvalidDefaultQueueMode,
+        cfg.parseJson("{\"agent\":{\"default_queue_mode\":42}}"),
+    );
 }
 
 test "save roundtrip preserves heartbeat dispatch settings" {

--- a/src/config_mutator.zig
+++ b/src/config_mutator.zig
@@ -123,6 +123,7 @@ pub fn pathRequiresRestart(path: []const u8) bool {
     if (std.mem.startsWith(u8, path, "channels.")) return true;
     if (std.mem.startsWith(u8, path, "runtime.")) return true;
     if (std.mem.eql(u8, path, "memory.backend") or std.mem.eql(u8, path, "memory.profile")) return true;
+    if (std.mem.eql(u8, path, "agent.default_queue_mode")) return true;
     return false;
 }
 
@@ -505,6 +506,8 @@ test "pathRequiresRestart detects structural paths" {
     try std.testing.expect(pathRequiresRestart("channels.telegram.accounts.default.bot_token"));
     try std.testing.expect(pathRequiresRestart("runtime.kind"));
     try std.testing.expect(pathRequiresRestart("memory.backend"));
+    // A running session may have a /queue override; only new sessions read the configured default.
+    try std.testing.expect(pathRequiresRestart("agent.default_queue_mode"));
     try std.testing.expect(!pathRequiresRestart("default_temperature"));
 }
 

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -1791,6 +1791,13 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
             if (ag.object.get("enable_pii_redaction")) |v| {
                 if (v == .bool) self.agent.enable_pii_redaction = v.bool;
             }
+            if (ag.object.get("default_queue_mode")) |v| {
+                if (v == .string) {
+                    if (types.QueueMode.fromSlice(v.string)) |mode| {
+                        self.agent.default_queue_mode = mode;
+                    }
+                }
+            }
             // tool_filter_groups: array of { mode, tools, keywords? }
             if (ag.object.get("tool_filter_groups")) |fg_val| {
                 if (fg_val == .array) {

--- a/src/config_parse.zig
+++ b/src/config_parse.zig
@@ -1792,11 +1792,9 @@ pub fn parseJson(self: *Config, content: []const u8) !void {
                 if (v == .bool) self.agent.enable_pii_redaction = v.bool;
             }
             if (ag.object.get("default_queue_mode")) |v| {
-                if (v == .string) {
-                    if (types.QueueMode.fromSlice(v.string)) |mode| {
-                        self.agent.default_queue_mode = mode;
-                    }
-                }
+                if (v != .string) return error.InvalidDefaultQueueMode;
+                self.agent.default_queue_mode = types.QueueMode.fromSlice(v.string) orelse
+                    return error.InvalidDefaultQueueMode;
             }
             // tool_filter_groups: array of { mode, tools, keywords? }
             if (ag.object.get("tool_filter_groups")) |fg_val| {

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -374,16 +374,42 @@ pub const ToolFilterGroup = struct {
     keywords: []const []const u8 = &.{},
 };
 
+pub const QueueMode = enum {
+    off,
+    serial,
+    latest,
+    debounce,
+
+    pub fn toSlice(self: QueueMode) []const u8 {
+        return switch (self) {
+            .off => "off",
+            .serial => "serial",
+            .latest => "latest",
+            .debounce => "debounce",
+        };
+    }
+
+    pub fn fromSlice(s: []const u8) ?QueueMode {
+        return if (std.mem.eql(u8, s, "off"))
+            .off
+        else if (std.mem.eql(u8, s, "serial"))
+            .serial
+        else if (std.mem.eql(u8, s, "latest"))
+            .latest
+        else if (std.mem.eql(u8, s, "debounce"))
+            .debounce
+        else
+            null;
+    }
+};
+
 pub const AgentConfig = struct {
-    /// When true (default), history is auto-compacted once it crosses the
-    /// token / message thresholds. Set to false to skip proactive LLM
-    /// summarization while retaining hard trimming and emergency compression.
-    /// Default is true to preserve the historical always-compact behavior.
-    compact_context: bool = true,
+    compact_context: bool = false,
     max_tool_iterations: u32 = 1000,
     max_history_messages: u32 = 100,
     parallel_tools: bool = false,
     tool_dispatcher: []const u8 = "auto",
+    default_queue_mode: QueueMode = .off,
     token_limit: u64 = DEFAULT_AGENT_TOKEN_LIMIT,
     /// Internal parse marker: true only when token_limit is explicitly set in config.
     /// Not serialized; used to distinguish override vs default fallback chain.

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -390,13 +390,13 @@ pub const QueueMode = enum {
     }
 
     pub fn fromSlice(s: []const u8) ?QueueMode {
-        return if (std.mem.eql(u8, s, "off"))
+        return if (std.ascii.eqlIgnoreCase(s, "off"))
             .off
-        else if (std.mem.eql(u8, s, "serial"))
+        else if (std.ascii.eqlIgnoreCase(s, "serial"))
             .serial
-        else if (std.mem.eql(u8, s, "latest"))
+        else if (std.ascii.eqlIgnoreCase(s, "latest"))
             .latest
-        else if (std.mem.eql(u8, s, "debounce"))
+        else if (std.ascii.eqlIgnoreCase(s, "debounce"))
             .debounce
         else
             null;
@@ -404,7 +404,11 @@ pub const QueueMode = enum {
 };
 
 pub const AgentConfig = struct {
-    compact_context: bool = false,
+    /// When true (default), history is auto-compacted once it crosses the
+    /// token / message thresholds. Set to false to skip proactive LLM
+    /// summarization while retaining hard trimming and emergency compression.
+    /// Default is true to preserve the historical always-compact behavior.
+    compact_context: bool = true,
     max_tool_iterations: u32 = 1000,
     max_history_messages: u32 = 100,
     parallel_tools: bool = false,
@@ -2284,4 +2288,24 @@ test "markdown_only profile preserves explicit half-life override" {
 
     // Regression: markdown_only should not clobber an explicit half-life override.
     try std.testing.expectEqual(@as(u32, 0), cfg.search.query.hybrid.temporal_decay.half_life_days);
+}
+
+test "QueueMode parser and serializer cover every mode" {
+    // Regression: config parsing and /queue must share one canonical mapping.
+    const cases = [_]struct {
+        mode: QueueMode,
+        text: []const u8,
+    }{
+        .{ .mode = .off, .text = "off" },
+        .{ .mode = .serial, .text = "serial" },
+        .{ .mode = .latest, .text = "latest" },
+        .{ .mode = .debounce, .text = "debounce" },
+    };
+
+    for (cases) |case| {
+        try std.testing.expectEqualStrings(case.text, case.mode.toSlice());
+        try std.testing.expectEqual(case.mode, QueueMode.fromSlice(case.text).?);
+    }
+    try std.testing.expectEqual(QueueMode.latest, QueueMode.fromSlice("LATEST").?);
+    try std.testing.expect(QueueMode.fromSlice("lastest") == null);
 }

--- a/src/inbound_router.zig
+++ b/src/inbound_router.zig
@@ -13,9 +13,9 @@
 //!       .drop              => {},
 //!   }
 
-const agent_mod = @import("agent/root.zig");
+const config_types = @import("config_types.zig");
 
-pub const QueueMode = agent_mod.Agent.QueueMode;
+pub const QueueMode = config_types.QueueMode;
 
 /// Snapshot of the state needed to make a routing decision.
 /// Obtained via SessionManager.routeInput().


### PR DESCRIPTION
## Summary

- Add `agent.default_queue_mode` config field to set the initial queue mode for new sessions
- Move `QueueMode` enum to `config_types.zig` as single source of truth, re-exported from `agent/root.zig`
- Parse `{"agent":{"default_queue_mode":"latest"}}` from `config.json` with fallback to `off` (existing default)
- No behavior change for existing deployments — default remains `off` unless explicitly configured

## Problem

When `queue_mode` is `off` (the default), the inbound router silently drops any message that arrives while a session turn is already in progress. LLM provider errors from external sources (e.g. `RemoteProtocolError`, stream drops) can keep a session turn running or retrying, creating a window where real user mentions and DMs are discarded without feedback. Bots appear unresponsive even though non-session processing continues normally. 

The `queue_mode` runtime feature already exists and ischangeable via the `/queue` command, but it could not be set from config and always reset to `off` on restart. There was no way to persist a different default without sending a `/queue` DM to each agent after every restart.

## Solution

- **Configurable default**: `config.json` now accepts `"agent": {"default_queue_mode": "latest"}`. Valid values: `off`, `serial`, `latest`, `debounce`.
- **Preserves existing behavior**: The hardcoded default remains `off`. Operators must opt in to a different queue mode via config.
- **Single source of truth**: `QueueMode` enum defined once in `config_types.zig`, re-exported from `agent/root.zig`.

## Files Changed

- `src/config_types.zig` — `QueueMode` enum + `default_queue_mode` field on `AgentConfig`
- `src/agent/root.zig` — re-export `QueueMode`, wire `default_queue_mode` through `fromConfigWithProfile`
- `src/config_parse.zig` — parse `"default_queue_mode"` from `"agent"` object
- `src/config.zig` — 2 test cases for queue_mode config parsing

## Validation

```
zig build test --summary all
Build Summary: 13/13 steps succeeded; 7322/7331 tests passed (9 skipped)
```

## Notes

- No user-facing behavior change — existing deployments get the same `off` default
- The `/queue` runtime command continues to work and overrides the config default per-session
- Recommended operator action: add `"default_queue_mode": "latest"` to agent configs where message loss during busy sessions is a concern