### PR TITLE
fix(agent_runner): suppress stderr initialization logs on agent failure

### DIFF
--- a/src/agent_runner.zig
+++ b/src/agent_runner.zig
@@ -151,6 +151,7 @@ fn buildAgentOutput(
     stderr: []const u8,
     timeout_secs: u64,
     timed_out: bool,
+    success: bool,
 ) ![]const u8 {
     if (timed_out) {
         const source = if (stdout.len > 0) stdout else stderr;
@@ -160,8 +161,16 @@ fn buildAgentOutput(
         return std.fmt.allocPrint(allocator, "agent timed out after {d}s", .{timeout_secs});
     }
 
-    const output_source = if (stdout.len > 0) stdout else if (stderr.len > 0) stderr else "";
-    return allocator.dupe(u8, output_source);
+    // On success, prefer stdout; fall back to stderr only when stdout is empty
+    // (some LLM providers write diagnostic hints to stderr even on success).
+    // On failure, never use stderr - it contains initialization logs (memory
+    // plan, MCP server registration, channel startup) that are not meaningful
+    // output. Returning empty lets the caller surface a clean error message.
+    if (success) {
+        const output_source = if (stdout.len > 0) stdout else if (stderr.len > 0) stderr else "";
+        return allocator.dupe(u8, output_source);
+    }
+    return allocator.dupe(u8, if (stdout.len > 0) stdout else "");
 }
 
 fn preferExecPath(self_exe_path: []const u8) []const u8 {
@@ -274,7 +283,7 @@ pub fn run(
         .exited => |code| code == 0,
         else => false,
     };
-    const output = try buildAgentOutput(allocator, stdout.items, stderr.items, timeout_secs, timed_out);
+    const output = try buildAgentOutput(allocator, stdout.items, stderr.items, timeout_secs, timed_out, success);
     return .{ .success = success, .output = output };
 }
 
@@ -352,6 +361,52 @@ test "collectChildOutputWithTimeout kills process after deadline" {
         else => false,
     };
     try std.testing.expect(!completed_ok);
+}
+
+test "buildAgentOutput returns stdout on success" {
+    const allocator = std.testing.allocator;
+    const result = try buildAgentOutput(allocator, "hello", "", 0, false, true);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("hello", result);
+}
+
+test "buildAgentOutput falls back to stderr on success when stdout empty" {
+    const allocator = std.testing.allocator;
+    const result = try buildAgentOutput(allocator, "", "diagnostic hint", 0, false, true);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("diagnostic hint", result);
+}
+
+test "buildAgentOutput skips stderr on failure" {
+    // Regression: stderr contains initialization logs (memory plan, MCP server
+    // registration) that should not be posted to channels when the agent fails.
+    const allocator = std.testing.allocator;
+    const result = try buildAgentOutput(allocator, "", "info(memory): plan resolved\ninfo(mcp): 14 tools registered", 0, false, false);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("", result);
+}
+
+test "buildAgentOutput preserves stdout on failure" {
+    const allocator = std.testing.allocator;
+    const result = try buildAgentOutput(allocator, "partial output", "error details", 0, false, false);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("partial output", result);
+}
+
+test "buildAgentOutput appends timeout annotation" {
+    const allocator = std.testing.allocator;
+    const result = try buildAgentOutput(allocator, "working...", "", 30, true, false);
+    defer allocator.free(result);
+    try std.testing.expect(std.mem.indexOf(u8, result, "working...") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "timed out after 30s") != null);
+}
+
+test "buildAgentOutput timeout falls back to stderr when stdout empty" {
+    const allocator = std.testing.allocator;
+    const result = try buildAgentOutput(allocator, "", "stderr output", 60, true, false);
+    defer allocator.free(result);
+    try std.testing.expect(std.mem.indexOf(u8, result, "stderr output") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "timed out after 60s") != null);
 }
 
 test "preferExecPath keeps regular executable path" {

--- a/src/agent_runner.zig
+++ b/src/agent_runner.zig
@@ -148,29 +148,33 @@ fn terminateChildHard(child: *std_compat.process.Child) !void {
 fn buildAgentOutput(
     allocator: std.mem.Allocator,
     stdout: []const u8,
-    stderr: []const u8,
     timeout_secs: u64,
     timed_out: bool,
     success: bool,
 ) ![]const u8 {
     if (timed_out) {
-        const source = if (stdout.len > 0) stdout else stderr;
-        if (source.len > 0) {
-            return std.fmt.allocPrint(allocator, "{s}\n\n[agent timed out after {d}s]", .{ source, timeout_secs });
+        if (stdout.len > 0) {
+            return std.fmt.allocPrint(allocator, "{s}\n\n[agent timed out after {d}s]", .{ stdout, timeout_secs });
         }
         return std.fmt.allocPrint(allocator, "agent timed out after {d}s", .{timeout_secs});
     }
 
-    // On success, prefer stdout; fall back to stderr only when stdout is empty
-    // (some LLM providers write diagnostic hints to stderr even on success).
-    // On failure, never use stderr - it contains initialization logs (memory
-    // plan, MCP server registration, channel startup) that are not meaningful
-    // output. Returning empty lets the caller surface a clean error message.
-    if (success) {
-        const output_source = if (stdout.len > 0) stdout else if (stderr.len > 0) stderr else "";
-        return allocator.dupe(u8, output_source);
+    if (!success) {
+        if (stdout.len > 0) {
+            return std.fmt.allocPrint(allocator, "{s}\n\n[agent execution failed]", .{stdout});
+        }
+        return allocator.dupe(u8, "agent execution failed");
     }
-    return allocator.dupe(u8, if (stdout.len > 0) stdout else "");
+
+    // `nullclaw agent -m` writes responses to stdout. Stderr is drained by the
+    // runner to avoid pipe backpressure, but it only contains logs/diagnostics
+    // and must never become user-visible agent output.
+    return allocator.dupe(u8, stdout);
+}
+
+fn isSuccessfulAgentRun(timed_out: bool, exited_zero: bool, stdout: []const u8) bool {
+    if (timed_out or !exited_zero) return false;
+    return std.mem.trim(u8, stdout, " \t\r\n").len > 0;
 }
 
 fn preferExecPath(self_exe_path: []const u8) []const u8 {
@@ -279,11 +283,12 @@ pub fn run(
     );
 
     const term = try child.wait();
-    const success = !timed_out and switch (term) {
+    const exited_zero = switch (term) {
         .exited => |code| code == 0,
         else => false,
     };
-    const output = try buildAgentOutput(allocator, stdout.items, stderr.items, timeout_secs, timed_out, success);
+    const success = isSuccessfulAgentRun(timed_out, exited_zero, stdout.items);
+    const output = try buildAgentOutput(allocator, stdout.items, timeout_secs, timed_out, success);
     return .{ .success = success, .output = output };
 }
 
@@ -365,48 +370,51 @@ test "collectChildOutputWithTimeout kills process after deadline" {
 
 test "buildAgentOutput returns stdout on success" {
     const allocator = std.testing.allocator;
-    const result = try buildAgentOutput(allocator, "hello", "", 0, false, true);
+    const result = try buildAgentOutput(allocator, "hello", 0, false, true);
     defer allocator.free(result);
     try std.testing.expectEqualStrings("hello", result);
 }
 
-test "buildAgentOutput falls back to stderr on success when stdout empty" {
+test "buildAgentOutput returns generic message for empty failure" {
+    // Regression: stderr-only initialization logs must not replace the missing
+    // response, while on_error delivery still needs a non-sensitive message.
     const allocator = std.testing.allocator;
-    const result = try buildAgentOutput(allocator, "", "diagnostic hint", 0, false, true);
+    const result = try buildAgentOutput(allocator, "", 0, false, false);
     defer allocator.free(result);
-    try std.testing.expectEqualStrings("diagnostic hint", result);
+    try std.testing.expectEqualStrings("agent execution failed", result);
 }
 
-test "buildAgentOutput skips stderr on failure" {
-    // Regression: stderr contains initialization logs (memory plan, MCP server
-    // registration) that should not be posted to channels when the agent fails.
+test "buildAgentOutput marks partial stdout as failed" {
     const allocator = std.testing.allocator;
-    const result = try buildAgentOutput(allocator, "", "info(memory): plan resolved\ninfo(mcp): 14 tools registered", 0, false, false);
+    const result = try buildAgentOutput(allocator, "partial output", 0, false, false);
     defer allocator.free(result);
-    try std.testing.expectEqualStrings("", result);
-}
-
-test "buildAgentOutput preserves stdout on failure" {
-    const allocator = std.testing.allocator;
-    const result = try buildAgentOutput(allocator, "partial output", "error details", 0, false, false);
-    defer allocator.free(result);
-    try std.testing.expectEqualStrings("partial output", result);
+    try std.testing.expect(std.mem.indexOf(u8, result, "partial output") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "agent execution failed") != null);
 }
 
 test "buildAgentOutput appends timeout annotation" {
     const allocator = std.testing.allocator;
-    const result = try buildAgentOutput(allocator, "working...", "", 30, true, false);
+    const result = try buildAgentOutput(allocator, "working...", 30, true, false);
     defer allocator.free(result);
     try std.testing.expect(std.mem.indexOf(u8, result, "working...") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "timed out after 30s") != null);
 }
 
-test "buildAgentOutput timeout falls back to stderr when stdout empty" {
+test "buildAgentOutput timeout without stdout is generic" {
+    // Regression: timeout diagnostics from stderr must not be delivered as an
+    // agent response when the child produced no stdout.
     const allocator = std.testing.allocator;
-    const result = try buildAgentOutput(allocator, "", "stderr output", 60, true, false);
+    const result = try buildAgentOutput(allocator, "", 60, true, false);
     defer allocator.free(result);
-    try std.testing.expect(std.mem.indexOf(u8, result, "stderr output") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result, "timed out after 60s") != null);
+    try std.testing.expectEqualStrings("agent timed out after 60s", result);
+}
+
+test "isSuccessfulAgentRun rejects timeout exit failure and empty stdout" {
+    // Regression: CLI soft failures can exit zero after logging only to stderr.
+    try std.testing.expect(isSuccessfulAgentRun(false, true, "response\n"));
+    try std.testing.expect(!isSuccessfulAgentRun(true, true, "response\n"));
+    try std.testing.expect(!isSuccessfulAgentRun(false, false, "response\n"));
+    try std.testing.expect(!isSuccessfulAgentRun(false, true, "\n"));
 }
 
 test "preferExecPath keeps regular executable path" {

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -29,6 +29,7 @@ const memory_mod = @import("memory/root.zig");
 const bootstrap_mod = @import("bootstrap/root.zig");
 const subagent_mod = @import("subagent.zig");
 const subagent_runner = @import("subagent_runner.zig");
+const agent_runner = @import("agent_runner.zig");
 const observability = @import("observability.zig");
 const agent_routing = @import("agent_routing.zig");
 const security = @import("security/policy.zig");
@@ -2902,38 +2903,11 @@ fn writeJsonResponse(stream: *std_compat.net.Stream, status: []const u8, body: [
 /// Process an incoming message by spawning `nullclaw agent -m "..."`.
 /// Returns the agent's response text. Caller owns the returned memory.
 pub fn processIncomingMessage(allocator: std.mem.Allocator, message: []const u8) ![]u8 {
-    // Find our own executable path
-    var self_buf: [std_compat.fs.max_path_bytes]u8 = undefined;
-    const self_path = std_compat.fs.selfExePath(&self_buf) catch "nullclaw";
-
-    var child = std_compat.process.Child.init(
-        &[_][]const u8{ self_path, "agent", "-m", message },
-        allocator,
-    );
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    try child.spawn();
-
-    // Read stdout
-    var stdout_buf: std.ArrayList(u8) = .empty;
-    defer stdout_buf.deinit(allocator);
-
-    const stdout_reader = child.stdout.?;
-    var read_buf: [4096]u8 = undefined;
-    while (true) {
-        const n = stdout_reader.read(&read_buf) catch break;
-        if (n == 0) break;
-        try stdout_buf.appendSlice(allocator, read_buf[0..n]);
-    }
-
-    const term = try child.wait();
-    _ = term;
-
-    if (stdout_buf.items.len > 0) {
-        return try allocator.dupe(u8, stdout_buf.items);
-    }
-    return try allocator.dupe(u8, "No response from agent");
+    // Keep the legacy public helper on the canonical subprocess path so stderr
+    // is drained safely and never substituted for the agent response.
+    const result = try agent_runner.run(allocator, null, message, null, 0);
+    defer allocator.free(result.output);
+    return allocator.dupe(u8, result.output);
 }
 
 /// Send a reply to a Telegram chat using the Bot API.


### PR DESCRIPTION
## Summary

When the agent child process exits non-zero, `buildAgentOutput` previously fell back to stderr as output. This posted initialization logs (memory plan, MCP server registration, channel startup) to channels as if they were agent responses.

Now stderr is only used as fallback on success (where it may contain useful diagnostic hints). On failure, stdout-only is returned — which is empty when the LLM returned no content, resulting in a clean skip rather than noisy initialization log spam.

## Changes

- `buildAgentOutput` takes a new `success` parameter
- On success: prefer stdout, fall back to stderr (unchanged behavior for useful diagnostics)
- On failure: return stdout only (empty when LLM returned nothing), never stderr
- 6 new unit tests covering: success with stdout, success with stderr fallback, failure suppresses stderr, failure preserves stdout, timeout annotation, timeout stderr fallback

## Validation

```
zig build test --summary all
7258 pass, 9 skip (pre-existing failures in skills/cron tests unrelated to this change)
zig build -Doptimize=ReleaseSmall — clean
zig fmt --check src/agent_runner.zig — clean
```

## Notes

- Pre-existing test failures (9) are in `skills.zig` (git clone network tests) and `cron.zig` (expression parsing) — unrelated to this change
- Deployed and verified on all production hosts