### PR TITLE
fix(discord): recover closed gateway sockets

### DIFF
--- a/src/channels/dingtalk.zig
+++ b/src/channels/dingtalk.zig
@@ -626,6 +626,8 @@ pub const DingTalkChannel = struct {
     running: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     connected: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     ws_thread: ?std.Thread = null,
+    lifecycle_mu: std_compat.sync.Mutex = .{},
+    ws_mu: std_compat.sync.Mutex = .{},
     ws_fd: std.atomic.Value(SocketFd) = std.atomic.Value(SocketFd).init(invalid_socket),
     token_mu: std_compat.sync.Mutex = .{},
     access_token: ?[]u8 = null,
@@ -831,6 +833,35 @@ pub const DingTalkChannel = struct {
 
     pub fn healthCheck(self: *DingTalkChannel) bool {
         return self.running.load(.acquire) and self.connected.load(.acquire);
+    }
+
+    fn shutdownActiveWebsocket(self: *DingTalkChannel) void {
+        self.ws_mu.lock();
+        defer self.ws_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+    }
+
+    fn closeOwnedWebsocket(self: *DingTalkChannel, ws: *websocket.WsClient) void {
+        self.ws_mu.lock();
+        defer self.ws_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        ws.deinit();
+    }
+
+    fn closeOwnedWebsocketStream(self: *DingTalkChannel, stream: std_compat.net.Stream) void {
+        self.ws_mu.lock();
+        defer self.ws_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        stream.close();
+    }
+
+    fn publishWebsocket(self: *DingTalkChannel, fd: SocketFd) bool {
+        self.ws_mu.lock();
+        defer self.ws_mu.unlock();
+        self.ws_fd.store(fd, .release);
+        if (self.running.load(.acquire)) return true;
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        return false;
     }
 
     fn clearEphemeralState(self: *DingTalkChannel) void {
@@ -1537,14 +1568,26 @@ pub const DingTalkChannel = struct {
         var path_buf: [2048]u8 = undefined;
         const endpoint = try parse_endpoint_url(connection.endpoint, connection.ticket, &host_buf, &path_buf);
 
-        var ws = try websocket.WsClient.connect(self.allocator, endpoint.host, endpoint.port, endpoint.path, &.{});
-        self.ws_fd.store(ws.stream.handle, .release);
+        const ws_stream = try websocket.WsClient.connectTcp(self.allocator, endpoint.host, endpoint.port);
+        if (!self.publishWebsocket(ws_stream.handle)) {
+            self.closeOwnedWebsocketStream(ws_stream);
+            return error.ConnectionClosed;
+        }
+        var ws = websocket.WsClient.connectFromStream(
+            self.allocator,
+            ws_stream,
+            endpoint.host,
+            endpoint.path,
+            &.{},
+        ) catch |err| {
+            self.closeOwnedWebsocketStream(ws_stream);
+            return err;
+        };
         self.connected.store(true, .release);
         log.info("dingtalk websocket connected to {s}", .{endpoint.host});
         defer {
             self.connected.store(false, .release);
-            self.ws_fd.store(invalid_socket, .release);
-            ws.deinit();
+            self.closeOwnedWebsocket(&ws);
         }
 
         while (self.running.load(.acquire)) {
@@ -1612,6 +1655,8 @@ pub const DingTalkChannel = struct {
 
     fn vtableStart(ptr: *anyopaque) anyerror!void {
         const self: *DingTalkChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
         if (self.running.load(.acquire)) return;
 
         self.running.store(true, .release);
@@ -1628,13 +1673,14 @@ pub const DingTalkChannel = struct {
 
     fn vtableStop(ptr: *anyopaque) void {
         const self: *DingTalkChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
         self.running.store(false, .release);
         self.connected.store(false, .release);
 
-        const fd = self.ws_fd.swap(invalid_socket, .acq_rel);
-        if (fd != invalid_socket) {
-            (std_compat.net.Stream{ .handle = fd }).close();
-        }
+        // shutdown() wakes the websocket reader while runWebsocketOnce retains final
+        // close ownership through WsClient.deinit().
+        self.shutdownActiveWebsocket();
 
         if (self.ws_thread) |t| {
             t.join();
@@ -1701,6 +1747,29 @@ pub const DingTalkChannel = struct {
 // ============================================================================
 // Tests
 // ============================================================================
+
+test "dingtalk websocket published after stop is shut down safely" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
+        @TypeOf(std.posix.system.socketpair) == void)
+    {
+        return error.SkipZigTest;
+    } else {
+        const sockets = try websocket.createTestSocketPair();
+        defer std.Io.Threaded.closeFd(sockets[0]);
+        defer std.Io.Threaded.closeFd(sockets[1]);
+
+        var ch = DingTalkChannel.init(std.testing.allocator, "cid", "secret", &.{});
+        ch.running.store(false, .release);
+
+        // Regression: stop must wake the reader without taking final close ownership
+        // away from WsClient.deinit in the websocket thread.
+        try std.testing.expect(!ch.publishWebsocket(sockets[0]));
+        try std.testing.expectEqual(invalid_socket, ch.ws_fd.load(.acquire));
+
+        var byte: [1]u8 = undefined;
+        try std.testing.expectEqual(@as(usize, 0), try std.posix.read(sockets[1], &byte));
+    }
+}
 
 test "build_open_connection_body subscribes to bot callback topic" {
     const body = try build_open_connection_body(std.testing.allocator, "cid", "secret");

--- a/src/channels/discord.zig
+++ b/src/channels/discord.zig
@@ -84,6 +84,10 @@ pub const DiscordChannel = struct {
     pub const GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json";
     const TYPING_INTERVAL_NS: u64 = 8 * std.time.ns_per_s;
     const TYPING_SLEEP_STEP_NS: u64 = 100 * std.time.ns_per_ms;
+    /// Initial connect/resume attempts should deliver HELLO quickly. If the gateway
+    /// thread gets stuck before HELLO/READY, treat it as unhealthy instead of letting
+    /// heartbeat_interval_ms==0 mask the dead socket forever.
+    const GATEWAY_CONNECT_GRACE_MS: i64 = 30 * std.time.ms_per_s;
     /// Minimum stale-gateway grace window. The channel_manager checks health every 10s;
     /// allow at least 3 heartbeat intervals OR 90s before declaring the gateway dead.
     const GATEWAY_STALE_GRACE_MS: i64 = 90 * std.time.ms_per_s;
@@ -188,15 +192,24 @@ pub const DiscordChannel = struct {
     fn gatewayHealthyAt(self: *DiscordChannel, now_ms: i64) bool {
         if (!self.running.load(.acquire)) return true;
 
-        const interval_ms = self.heartbeat_interval_ms.load(.acquire);
-        if (interval_ms == 0) return true;
-
         const last_activity_ms = self.last_gateway_activity_ms.load(.acquire);
         if (last_activity_ms == 0 or now_ms <= last_activity_ms) return true;
+
+        const interval_ms = self.heartbeat_interval_ms.load(.acquire);
+        if (interval_ms == 0) {
+            return (now_ms - last_activity_ms) <= GATEWAY_CONNECT_GRACE_MS;
+        }
 
         const heartbeat_window_ms: i64 = @as(i64, @intCast(interval_ms)) * 3;
         const stale_after_ms = @max(heartbeat_window_ms, GATEWAY_STALE_GRACE_MS);
         return (now_ms - last_activity_ms) <= stale_after_ms;
+    }
+
+    fn shutdownActiveGatewaySocket(self: *DiscordChannel) void {
+        const fd = self.ws_fd.swap(invalid_socket, .acq_rel);
+        if (fd != invalid_socket) {
+            (std_compat.net.Stream{ .handle = fd }).shutdown(.both) catch {};
+        }
     }
 
     const ReconnectDecision = struct {
@@ -761,10 +774,7 @@ pub const DiscordChannel = struct {
         // blocked reader, causing it to return 0 (EndOfStream → ConnectionClosed).
         // NOTE: No unit test for this path — requires a live remote TCP connection and
         // concurrent thread; covered by manual integration testing against a live gateway.
-        const fd = self.ws_fd.load(.acquire);
-        if (fd != invalid_socket) {
-            (std_compat.net.Stream{ .handle = fd }).shutdown(.both) catch {};
-        }
+        self.shutdownActiveGatewaySocket();
         if (self.gateway_thread) |t| {
             t.join();
             self.gateway_thread = null;
@@ -921,8 +931,11 @@ pub const DiscordChannel = struct {
         };
         defer {
             self.heartbeat_stop.store(true, .release);
+            // Shutdown before join: the heartbeat thread may be blocked in a TLS
+            // write/flush after Discord has closed the socket. Waiting first can
+            // strand the gateway loop with the fd in CLOSE_WAIT.
+            self.shutdownActiveGatewaySocket();
             hbt.join();
-            self.ws_fd.store(invalid_socket, .release);
             ws.deinit();
         }
 
@@ -934,7 +947,8 @@ pub const DiscordChannel = struct {
         self.markGatewayActivityNow();
 
         // IDENTIFY or RESUME
-        if (self.session_id != null) {
+        const attempting_resume = self.session_id != null;
+        if (attempting_resume) {
             try self.sendResumePayload(&ws);
         } else {
             self.sequence.store(0, .release);
@@ -947,7 +961,10 @@ pub const DiscordChannel = struct {
                 log.warn("Discord gateway read failed: {}", .{err});
                 break;
             };
-            const text = maybe_text orelse break;
+            const text = maybe_text orelse {
+                if (attempting_resume) return error.ShouldReconnect;
+                break;
+            };
             defer self.allocator.free(text);
             self.markGatewayActivityNow();
             self.handleGatewayMessage(&ws, text) catch |err| {
@@ -2188,6 +2205,29 @@ test "discord gateway restart refreshes stale activity baseline" {
     try std.testing.expect(!ch.gatewayHealthyAt(1_240_002));
 }
 
+test "discord health check fails stalled pre-hello reconnect after grace window" {
+    var ch = DiscordChannel.init(std.testing.allocator, "token", null, false);
+    ch.running.store(true, .release);
+
+    // Regression: reconnect wedges could leave the Discord socket stuck in CLOSE_WAIT
+    // before HELLO, which kept heartbeat_interval_ms at 0 and fooled healthCheck.
+    ch.last_gateway_activity_ms.store(2_000_000, .release);
+
+    try std.testing.expect(ch.gatewayHealthyAt(2_029_999));
+    try std.testing.expect(!ch.gatewayHealthyAt(2_030_001));
+}
+
+test "discord shutdown active gateway socket clears tracked fd" {
+    var ch = DiscordChannel.init(std.testing.allocator, "token", null, false);
+    ch.ws_fd.store(DiscordChannel.invalid_socket, .release);
+
+    // Regression: reconnect cleanup must clear ws_fd before waiting on heartbeat
+    // shutdown so health/restart paths don't keep seeing the stale descriptor.
+    ch.shutdownActiveGatewaySocket();
+
+    try std.testing.expectEqual(DiscordChannel.invalid_socket, ch.ws_fd.load(.acquire));
+}
+
 test "discord handleReady resets consecutive_reconnects to zero" {
     // Regression: rapid op-7 reconnect storms; READY must reset the backoff counter.
     const alloc = std.testing.allocator;
@@ -2227,4 +2267,25 @@ test "discord reconnect backoff clears session on exhaustion" {
     try std.testing.expect(ch.resume_gateway_url == null);
     try std.testing.expectEqual(@as(i64, 0), ch.sequence.load(.acquire));
     try std.testing.expectEqual(@as(u32, 0), ch.consecutive_reconnects);
+}
+
+test "discord reconnect request keeps session until exhaustion" {
+    const alloc = std.testing.allocator;
+    var ch = DiscordChannel.init(alloc, "token", null, false);
+    defer {
+        if (ch.session_id) |s| alloc.free(s);
+        if (ch.resume_gateway_url) |u| alloc.free(u);
+    }
+    ch.session_id = try alloc.dupe(u8, "resume-sess");
+    ch.resume_gateway_url = try alloc.dupe(u8, "wss://gateway.discord.gg/?v=10&encoding=json");
+    ch.sequence.store(77, .release);
+
+    const reconnect = ch.recordReconnectRequest();
+
+    try std.testing.expectEqual(@as(u32, 1), reconnect.attempt);
+    try std.testing.expectEqual(@as(u64, 1_000), reconnect.backoff_ms);
+    try std.testing.expect(!reconnect.cleared_session);
+    try std.testing.expect(ch.session_id != null);
+    try std.testing.expect(ch.resume_gateway_url != null);
+    try std.testing.expectEqual(@as(i64, 77), ch.sequence.load(.acquire));
 }

--- a/src/channels/discord.zig
+++ b/src/channels/discord.zig
@@ -68,8 +68,10 @@ pub const DiscordChannel = struct {
     resume_gateway_url: ?[]u8 = null,
     bot_user_id: ?[]u8 = null,
     gateway_thread: ?std.Thread = null,
+    lifecycle_mu: std_compat.sync.Mutex = .{},
+    gateway_socket_mu: std_compat.sync.Mutex = .{},
     ws_fd: Atomic(SocketFd) = Atomic(SocketFd).init(invalid_socket),
-    /// Count of consecutive op-7 RECONNECT events without an intervening READY.
+    /// Count of consecutive reconnect attempts without an intervening READY/RESUMED.
     /// Used to implement exponential backoff and RESUME→IDENTIFY fallback.
     /// Only accessed from gatewayLoop (single-threaded write path); no atomic needed.
     consecutive_reconnects: u32 = 0,
@@ -186,9 +188,14 @@ pub const DiscordChannel = struct {
         self.last_gateway_activity_ms.store(std_compat.time.milliTimestamp(), .release);
     }
 
+    fn prepareGatewayAttemptAt(self: *DiscordChannel, now_ms: i64) void {
+        self.heartbeat_interval_ms.store(0, .release);
+        self.last_gateway_activity_ms.store(now_ms, .release);
+    }
+
     /// Returns true if the gateway appears healthy at the given wall-clock ms.
-    /// Healthy conditions: not running, interval not yet received, or last activity
-    /// within max(3×heartbeat_interval, GATEWAY_STALE_GRACE_MS).
+    /// Before HELLO, allow GATEWAY_CONNECT_GRACE_MS. After HELLO, allow the larger
+    /// of 3×heartbeat_interval and GATEWAY_STALE_GRACE_MS since last activity.
     fn gatewayHealthyAt(self: *DiscordChannel, now_ms: i64) bool {
         if (!self.running.load(.acquire)) return true;
 
@@ -206,10 +213,40 @@ pub const DiscordChannel = struct {
     }
 
     fn shutdownActiveGatewaySocket(self: *DiscordChannel) void {
-        const fd = self.ws_fd.swap(invalid_socket, .acq_rel);
-        if (fd != invalid_socket) {
-            (std_compat.net.Stream{ .handle = fd }).shutdown(.both) catch {};
-        }
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+    }
+
+    fn closeOwnedGatewaySocket(self: *DiscordChannel, ws: *websocket.WsClient) void {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        ws.deinit();
+    }
+
+    fn closeOwnedGatewayStream(self: *DiscordChannel, stream: std_compat.net.Stream) void {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        stream.close();
+    }
+
+    fn publishGatewaySocket(self: *DiscordChannel, fd: SocketFd) bool {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        self.ws_fd.store(fd, .release);
+        if (self.running.load(.acquire)) return true;
+
+        // Stop may race with connectTcp before there is an fd to interrupt. Recheck
+        // after publishing so vtableStop cannot join a gateway thread that later
+        // enters TLS with an untracked socket.
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        return false;
+    }
+
+    fn shouldBackoffAfterGatewayClose(attempting_resume: bool, running: bool) bool {
+        return attempting_resume and running;
     }
 
     const ReconnectDecision = struct {
@@ -756,13 +793,19 @@ pub const DiscordChannel = struct {
 
     fn vtableStart(ptr: *anyopaque) anyerror!void {
         const self: *DiscordChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
+        if (self.running.load(.acquire)) return;
         self.markGatewayActivityNow();
         self.running.store(true, .release);
+        errdefer self.running.store(false, .release);
         self.gateway_thread = try std.Thread.spawn(.{ .stack_size = thread_stacks.HEAVY_RUNTIME_STACK_SIZE }, gatewayLoop, .{self});
     }
 
     fn vtableStop(ptr: *anyopaque) void {
         const self: *DiscordChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
         self.running.store(false, .release);
         self.heartbeat_stop.store(true, .release);
         self.stopAllTyping();
@@ -852,14 +895,14 @@ pub const DiscordChannel = struct {
             var backoff_ms: u64 = 5000;
             self.runGatewayOnce() catch |err| switch (err) {
                 error.ShouldReconnect => {
-                    // OP7 RECONNECT is a normal control signal from Discord.
-                    // Use exponential backoff to avoid rate-limiting reconnect storms:
+                    // Server reconnects and failed RESUME attempts use exponential
+                    // backoff to avoid rate-limiting reconnect storms:
                     // attempt 1→1s, 2→2s, 3→4s, 4→8s, 5→16s, 6→32s, 7+→60s.
                     const reconnect = self.recordReconnectRequest();
                     backoff_ms = reconnect.backoff_ms;
-                    log.info("Discord gateway reconnect requested by server (attempt {d}, backoff {d}ms)", .{ reconnect.attempt, reconnect.backoff_ms });
+                    log.info("Discord gateway reconnect (attempt {d}, backoff {d}ms)", .{ reconnect.attempt, reconnect.backoff_ms });
                     if (reconnect.cleared_session) log.warn(
-                        "Discord: {d} consecutive reconnects without READY; clearing session for fresh IDENTIFY",
+                        "Discord: {d} reconnects without READY/RESUMED; clearing session for fresh IDENTIFY",
                         .{reconnect.attempt},
                     );
                 },
@@ -882,7 +925,7 @@ pub const DiscordChannel = struct {
         // Refresh the watchdog baseline before DNS/TCP/TLS. A restart should get a
         // full stale-gateway grace window instead of inheriting the old dead socket's
         // last activity timestamp.
-        self.markGatewayActivityNow();
+        self.prepareGatewayAttemptAt(std_compat.time.milliTimestamp());
 
         // Determine host
         const default_host = "gateway.discord.gg";
@@ -900,7 +943,10 @@ pub const DiscordChannel = struct {
             return err;
         };
         // Store fd now so vtableStop can interrupt even during the TLS handshake below.
-        self.ws_fd.store(ws_stream.handle, .release);
+        if (!self.publishGatewaySocket(ws_stream.handle)) {
+            self.closeOwnedGatewayStream(ws_stream);
+            return error.ConnectionClosed;
+        }
 
         // Phase 2: TLS init + WebSocket handshake (interruptible via vtableStop shutdown).
         var ws = websocket.WsClient.connectFromStream(
@@ -910,8 +956,8 @@ pub const DiscordChannel = struct {
             "/?v=10&encoding=json",
             &.{},
         ) catch |err| {
-            // connectFromStream closed ws_stream on failure; clear the now-invalid fd.
-            self.ws_fd.store(invalid_socket, .release);
+            // Unpublish before close so stop cannot race with descriptor-number reuse.
+            self.closeOwnedGatewayStream(ws_stream);
             // Clear stale resume URL same as TCP failure path above.
             if (self.resume_gateway_url) |u| {
                 self.allocator.free(u);
@@ -924,9 +970,10 @@ pub const DiscordChannel = struct {
         // Start heartbeat thread — on failure, clean up ws manually (no errdefer to avoid
         // double-deinit with the defer block below once spawn succeeds).
         self.heartbeat_stop.store(false, .release);
-        self.heartbeat_interval_ms.store(0, .release);
         const hbt = std.Thread.spawn(.{ .stack_size = thread_stacks.AUXILIARY_LOOP_STACK_SIZE }, heartbeatLoop, .{ self, &ws }) catch |err| {
-            ws.deinit();
+            // Unpublish before the final close so a concurrent stop cannot apply
+            // shutdown to this descriptor after the OS has reused its number.
+            self.closeOwnedGatewaySocket(&ws);
             return err;
         };
         defer {
@@ -936,7 +983,7 @@ pub const DiscordChannel = struct {
             // strand the gateway loop with the fd in CLOSE_WAIT.
             self.shutdownActiveGatewaySocket();
             hbt.join();
-            ws.deinit();
+            self.closeOwnedGatewaySocket(&ws);
         }
 
         // Wait for HELLO (first message)
@@ -959,10 +1006,11 @@ pub const DiscordChannel = struct {
         while (self.running.load(.acquire)) {
             const maybe_text = ws.readTextMessage() catch |err| {
                 log.warn("Discord gateway read failed: {}", .{err});
+                if (shouldBackoffAfterGatewayClose(attempting_resume, self.running.load(.acquire))) return error.ShouldReconnect;
                 break;
             };
             const text = maybe_text orelse {
-                if (attempting_resume) return error.ShouldReconnect;
+                if (shouldBackoffAfterGatewayClose(attempting_resume, self.running.load(.acquire))) return error.ShouldReconnect;
                 break;
             };
             defer self.allocator.free(text);
@@ -1088,6 +1136,10 @@ pub const DiscordChannel = struct {
                     self.handleReady(root_val) catch |err| {
                         log.warn("Discord: handleReady error: {}", .{err});
                     };
+                } else if (std.mem.eql(u8, event_type, "RESUMED")) {
+                    // A RESUMED dispatch confirms the saved session is healthy. Without
+                    // this reset, ordinary later disconnects eventually discard it.
+                    self.consecutive_reconnects = 0;
                 } else if (std.mem.eql(u8, event_type, "MESSAGE_CREATE")) {
                     self.handleMessageCreate(root_val) catch |err| {
                         log.warn("Discord: handleMessageCreate error: {}", .{err});
@@ -2198,11 +2250,12 @@ test "discord gateway restart refreshes stale activity baseline" {
     try std.testing.expect(!ch.gatewayHealthyAt(1_120_001));
 
     // Regression: after the watchdog restarts the gateway, the next connection
-    // attempt must not inherit the stale socket timestamp and immediately fail
-    // health checks before DNS/TCP/TLS has its own grace window.
-    ch.last_gateway_activity_ms.store(1_120_001, .release);
+    // attempt must clear the old heartbeat interval and use the bounded pre-HELLO
+    // grace window while DNS/TCP/TLS are in progress.
+    ch.prepareGatewayAttemptAt(1_120_001);
+    try std.testing.expectEqual(@as(u64, 0), ch.heartbeat_interval_ms.load(.acquire));
     try std.testing.expect(ch.gatewayHealthyAt(1_130_001));
-    try std.testing.expect(!ch.gatewayHealthyAt(1_240_002));
+    try std.testing.expect(!ch.gatewayHealthyAt(1_150_002));
 }
 
 test "discord health check fails stalled pre-hello reconnect after grace window" {
@@ -2217,15 +2270,50 @@ test "discord health check fails stalled pre-hello reconnect after grace window"
     try std.testing.expect(!ch.gatewayHealthyAt(2_030_001));
 }
 
-test "discord shutdown active gateway socket clears tracked fd" {
-    var ch = DiscordChannel.init(std.testing.allocator, "token", null, false);
-    ch.ws_fd.store(DiscordChannel.invalid_socket, .release);
+test "discord shutdown active gateway socket clears fd and closes peer" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
+        @TypeOf(std.posix.system.socketpair) == void)
+    {
+        return error.SkipZigTest;
+    } else {
+        const sockets = try websocket.createTestSocketPair();
+        defer std.Io.Threaded.closeFd(sockets[0]);
+        defer std.Io.Threaded.closeFd(sockets[1]);
 
-    // Regression: reconnect cleanup must clear ws_fd before waiting on heartbeat
-    // shutdown so health/restart paths don't keep seeing the stale descriptor.
-    ch.shutdownActiveGatewaySocket();
+        var ch = DiscordChannel.init(std.testing.allocator, "token", null, false);
+        ch.ws_fd.store(sockets[0], .release);
 
-    try std.testing.expectEqual(DiscordChannel.invalid_socket, ch.ws_fd.load(.acquire));
+        // Regression: reconnect cleanup must invalidate and shut down a real socket
+        // before joining a heartbeat thread that may be blocked in TLS write/flush.
+        ch.shutdownActiveGatewaySocket();
+
+        try std.testing.expectEqual(DiscordChannel.invalid_socket, ch.ws_fd.load(.acquire));
+        var byte: [1]u8 = undefined;
+        try std.testing.expectEqual(@as(usize, 0), try std.posix.read(sockets[1], &byte));
+    }
+}
+
+test "discord socket published after stop is shut down immediately" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
+        @TypeOf(std.posix.system.socketpair) == void)
+    {
+        return error.SkipZigTest;
+    } else {
+        const sockets = try websocket.createTestSocketPair();
+        defer std.Io.Threaded.closeFd(sockets[0]);
+        defer std.Io.Threaded.closeFd(sockets[1]);
+
+        var ch = DiscordChannel.init(std.testing.allocator, "token", null, false);
+        ch.running.store(false, .release);
+
+        // Regression: stop may finish its initial fd swap while connectTcp is still
+        // returning. Publishing that late fd must not let the gateway enter TLS.
+        try std.testing.expect(!ch.publishGatewaySocket(sockets[0]));
+        try std.testing.expectEqual(DiscordChannel.invalid_socket, ch.ws_fd.load(.acquire));
+
+        var byte: [1]u8 = undefined;
+        try std.testing.expectEqual(@as(usize, 0), try std.posix.read(sockets[1], &byte));
+    }
 }
 
 test "discord handleReady resets consecutive_reconnects to zero" {
@@ -2248,8 +2336,32 @@ test "discord handleReady resets consecutive_reconnects to zero" {
     try std.testing.expectEqual(@as(u32, 0), ch.consecutive_reconnects);
 }
 
+test "discord resumed dispatch resets consecutive reconnects" {
+    var ch = DiscordChannel.init(std.testing.allocator, "token", null, false);
+    ch.consecutive_reconnects = 4;
+
+    // Regression: a successful RESUME must prevent later routine disconnects from
+    // accumulating across healthy sessions and clearing valid resume state.
+    const resumed_json =
+        \\{"op":0,"s":78,"t":"RESUMED","d":{}}
+    ;
+    var ws_dummy: websocket.WsClient = undefined;
+    try ch.handleGatewayMessage(&ws_dummy, resumed_json);
+
+    try std.testing.expectEqual(@as(u32, 0), ch.consecutive_reconnects);
+    try std.testing.expectEqual(@as(i64, 78), ch.sequence.load(.acquire));
+}
+
+test "discord failed resume close backs off only while running" {
+    // Regression: both a WebSocket close frame and an abrupt transport EOF during
+    // RESUME must advance the bounded fallback, but shutdown-generated EOF must not.
+    try std.testing.expect(DiscordChannel.shouldBackoffAfterGatewayClose(true, true));
+    try std.testing.expect(!DiscordChannel.shouldBackoffAfterGatewayClose(false, true));
+    try std.testing.expect(!DiscordChannel.shouldBackoffAfterGatewayClose(true, false));
+}
+
 test "discord reconnect backoff clears session on exhaustion" {
-    // Regression: after MAX_RECONNECT_ATTEMPTS consecutive op-7s the session must be
+    // Regression: after MAX_RECONNECT_ATTEMPTS failed reconnects the session must be
     // cleared so the next attempt does a fresh IDENTIFY rather than looping forever.
     const alloc = std.testing.allocator;
     var ch = DiscordChannel.init(alloc, "token", null, false);

--- a/src/channels/lark.zig
+++ b/src/channels/lark.zig
@@ -70,7 +70,7 @@ const LarkWsEventBuffer = struct {
 
 const LarkWsPingLoopCtx = struct {
     ws: *websocket.WsClient,
-    running: *const std.atomic.Value(bool),
+    connection_running: *const std.atomic.Value(bool),
     ping_interval_ms: *AtomicU32,
     service_id: i32,
 };
@@ -95,6 +95,8 @@ pub const LarkChannel = struct {
     running: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     connected: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     ws_thread: ?std.Thread = null,
+    lifecycle_mu: std_compat.sync.Mutex = .{},
+    ws_mu: std_compat.sync.Mutex = .{},
     ws_fd: std.atomic.Value(SocketFd) = std.atomic.Value(SocketFd).init(invalid_socket),
     /// Cached tenant access token (heap-allocated, owned by allocator).
     cached_token: ?[]const u8 = null,
@@ -462,6 +464,35 @@ pub const LarkChannel = struct {
             .webhook => self.running.load(.acquire),
             .websocket => self.running.load(.acquire) and self.connected.load(.acquire),
         };
+    }
+
+    fn shutdownActiveWebsocket(self: *LarkChannel) void {
+        self.ws_mu.lock();
+        defer self.ws_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+    }
+
+    fn closeOwnedWebsocket(self: *LarkChannel, ws: *websocket.WsClient) void {
+        self.ws_mu.lock();
+        defer self.ws_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        ws.deinit();
+    }
+
+    fn closeOwnedWebsocketStream(self: *LarkChannel, stream: std_compat.net.Stream) void {
+        self.ws_mu.lock();
+        defer self.ws_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        stream.close();
+    }
+
+    fn publishWebsocket(self: *LarkChannel, fd: SocketFd) bool {
+        self.ws_mu.lock();
+        defer self.ws_mu.unlock();
+        self.ws_fd.store(fd, .release);
+        if (self.running.load(.acquire)) return true;
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        return false;
     }
 
     fn componentAsSlice(component: std.Uri.Component) []const u8 {
@@ -1490,32 +1521,38 @@ pub const LarkChannel = struct {
         var path_buf: [2048]u8 = undefined;
         const connect_parts = try parseWebsocketConnectUrl(connect_cfg.url, &host_buf, &path_buf);
 
-        var ws = try websocket.WsClient.connect(
+        const ws_stream = try websocket.WsClient.connectTcp(self.allocator, connect_parts.host, connect_parts.port);
+        if (!self.publishWebsocket(ws_stream.handle)) {
+            self.closeOwnedWebsocketStream(ws_stream);
+            return error.ConnectionClosed;
+        }
+        var ws = websocket.WsClient.connectFromStream(
             self.allocator,
+            ws_stream,
             connect_parts.host,
-            connect_parts.port,
             connect_parts.path,
             &.{},
-        );
-
-        self.ws_fd.store(ws.stream.handle, .release);
+        ) catch |err| {
+            self.closeOwnedWebsocketStream(ws_stream);
+            return err;
+        };
         self.connected.store(true, .release);
         defer {
             self.connected.store(false, .release);
-            self.ws_fd.store(invalid_socket, .release);
-            ws.deinit();
+            self.closeOwnedWebsocket(&ws);
         }
 
         var event_buffers: std.StringHashMapUnmanaged(LarkWsEventBuffer) = .empty;
         defer deinitLarkWsEventBuffers(self.allocator, &event_buffers);
 
         var ping_interval_ms = AtomicU32.init(connect_cfg.ping_interval_ms);
+        var connection_running = std.atomic.Value(bool).init(true);
         var ping_thread: ?std.Thread = null;
         var ping_ctx: LarkWsPingLoopCtx = undefined;
         if (connect_parts.service_id) |service_id| {
             ping_ctx = .{
                 .ws = &ws,
-                .running = &self.running,
+                .connection_running = &connection_running,
                 .ping_interval_ms = &ping_interval_ms,
                 .service_id = service_id,
             };
@@ -1524,7 +1561,13 @@ pub const LarkChannel = struct {
                 break :blk null;
             };
         }
-        defer if (ping_thread) |t| t.join();
+        defer {
+            // A connection cycle can end while the channel remains running. Stop the
+            // per-connection ping loop and unblock any TLS write before joining it.
+            connection_running.store(false, .release);
+            self.shutdownActiveWebsocket();
+            if (ping_thread) |t| t.join();
+        }
 
         while (self.running.load(.acquire)) {
             const maybe_message = ws.readMessage() catch |err| {
@@ -1572,6 +1615,8 @@ pub const LarkChannel = struct {
 
     fn vtableStart(ptr: *anyopaque) anyerror!void {
         const self: *LarkChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
         if (self.running.load(.acquire)) return;
         self.running.store(true, .release);
 
@@ -1589,13 +1634,14 @@ pub const LarkChannel = struct {
 
     fn vtableStop(ptr: *anyopaque) void {
         const self: *LarkChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
         self.running.store(false, .release);
         self.connected.store(false, .release);
 
-        const fd = self.ws_fd.swap(invalid_socket, .acq_rel);
-        if (fd != invalid_socket) {
-            (std_compat.net.Stream{ .handle = fd }).close();
-        }
+        // shutdown() interrupts the gateway read and any ping write. The websocket
+        // thread retains final close ownership through WsClient.deinit().
+        self.shutdownActiveWebsocket();
 
         if (self.ws_thread) |t| {
             t.join();
@@ -2239,19 +2285,19 @@ fn deinitLarkWsEventBuffers(
 }
 
 fn larkWsPingLoop(ctx: *LarkWsPingLoopCtx) void {
-    while (ctx.running.load(.acquire)) {
+    while (ctx.connection_running.load(.acquire)) {
         const interval_ms = blk: {
             const current = ctx.ping_interval_ms.load(.acquire);
             break :blk if (current > 0) current else DEFAULT_LARK_PING_INTERVAL_MS;
         };
 
         var waited_ms: u32 = 0;
-        while (waited_ms < interval_ms and ctx.running.load(.acquire)) {
+        while (waited_ms < interval_ms and ctx.connection_running.load(.acquire)) {
             const step_ms: u32 = @min(interval_ms - waited_ms, @as(u32, 1000));
             std_compat.thread.sleep(@as(u64, step_ms) * std.time.ns_per_ms);
             waited_ms += step_ms;
         }
-        if (!ctx.running.load(.acquire)) break;
+        if (!ctx.connection_running.load(.acquire)) break;
 
         var ping_buf: [256]u8 = undefined;
         const ping = buildLarkWsPingFrame(&ping_buf, ctx.service_id) catch {
@@ -2259,7 +2305,7 @@ fn larkWsPingLoop(ctx: *LarkWsPingLoopCtx) void {
             continue;
         };
         ctx.ws.writeBinary(ping) catch |err| {
-            if (ctx.running.load(.acquire)) {
+            if (ctx.connection_running.load(.acquire)) {
                 log.warn("lark websocket ping failed: {}", .{err});
             }
             break;
@@ -2270,6 +2316,28 @@ fn larkWsPingLoop(ctx: *LarkWsPingLoopCtx) void {
 // ════════════════════════════════════════════════════════════════════════════
 // Tests
 // ════════════════════════════════════════════════════════════════════════════
+
+test "lark shutdown active websocket clears fd and closes peer" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
+        @TypeOf(std.posix.system.socketpair) == void)
+    {
+        return error.SkipZigTest;
+    } else {
+        const sockets = try websocket.createTestSocketPair();
+        defer std.Io.Threaded.closeFd(sockets[0]);
+        defer std.Io.Threaded.closeFd(sockets[1]);
+
+        var ch = LarkChannel.init(std.testing.allocator, "id", "secret", "token", 9898, &.{});
+        ch.ws_fd.store(sockets[0], .release);
+
+        // Regression: per-connection ping cleanup must unblock TLS writes before join.
+        ch.shutdownActiveWebsocket();
+
+        try std.testing.expectEqual(invalid_socket, ch.ws_fd.load(.acquire));
+        var byte: [1]u8 = undefined;
+        try std.testing.expectEqual(@as(usize, 0), try std.posix.read(sockets[1], &byte));
+    }
+}
 
 test "lark parse valid text message" {
     const allocator = std.testing.allocator;

--- a/src/channels/mattermost.zig
+++ b/src/channels/mattermost.zig
@@ -152,6 +152,8 @@ pub const MattermostChannel = struct {
     connected: Atomic(bool) = Atomic(bool).init(false),
     ws_seq: Atomic(u64) = Atomic(u64).init(0),
     tmp_counter: Atomic(u64) = Atomic(u64).init(0),
+    lifecycle_mu: std_compat.sync.Mutex = .{},
+    gateway_socket_mu: std_compat.sync.Mutex = .{},
     ws_fd: Atomic(SocketFd) = Atomic(SocketFd).init(invalid_socket),
     gateway_thread: ?std.Thread = null,
 
@@ -198,6 +200,35 @@ pub const MattermostChannel = struct {
 
     pub fn healthCheck(self: *const MattermostChannel) bool {
         return self.running.load(.acquire);
+    }
+
+    fn shutdownActiveGatewaySocket(self: *MattermostChannel) void {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+    }
+
+    fn closeOwnedGatewaySocket(self: *MattermostChannel, ws: *websocket.WsClient) void {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        ws.deinit();
+    }
+
+    fn closeOwnedGatewayStream(self: *MattermostChannel, stream: std_compat.net.Stream) void {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        stream.close();
+    }
+
+    fn publishGatewaySocket(self: *MattermostChannel, fd: SocketFd) bool {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        self.ws_fd.store(fd, .release);
+        if (self.running.load(.acquire)) return true;
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        return false;
     }
 
     pub fn sendMessage(self: *MattermostChannel, target: []const u8, text: []const u8) !void {
@@ -372,6 +403,8 @@ pub const MattermostChannel = struct {
 
     fn vtableStart(ptr: *anyopaque) anyerror!void {
         const self: *MattermostChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
         if (self.running.load(.acquire)) return;
         self.running.store(true, .release);
         errdefer self.running.store(false, .release);
@@ -381,14 +414,14 @@ pub const MattermostChannel = struct {
 
     fn vtableStop(ptr: *anyopaque) void {
         const self: *MattermostChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
         self.running.store(false, .release);
         self.connected.store(false, .release);
 
-        const fd = self.ws_fd.load(.acquire);
-        if (fd != invalid_socket) {
-            (std_compat.net.Stream{ .handle = fd }).close();
-            self.ws_fd.store(invalid_socket, .release);
-        }
+        // shutdown() interrupts the gateway read while WsClient retains final close
+        // ownership in runGatewayOnce's defer.
+        self.shutdownActiveGatewaySocket();
 
         if (self.gateway_thread) |t| {
             t.join();
@@ -473,18 +506,24 @@ pub const MattermostChannel = struct {
 
         log.info("mattermost: connecting to wss://{s}:{d}{s}", .{ parts.host, parts.port, parts.path });
 
-        var ws = try websocket.WsClient.connect(
+        const ws_stream = try websocket.WsClient.connectTcp(self.allocator, parts.host, parts.port);
+        if (!self.publishGatewaySocket(ws_stream.handle)) {
+            self.closeOwnedGatewayStream(ws_stream);
+            return error.ConnectionClosed;
+        }
+        var ws = websocket.WsClient.connectFromStream(
             self.allocator,
+            ws_stream,
             parts.host,
-            parts.port,
             parts.path,
             &.{},
-        );
+        ) catch |err| {
+            self.closeOwnedGatewayStream(ws_stream);
+            return err;
+        };
         defer {
-            self.ws_fd.store(invalid_socket, .release);
-            ws.deinit();
+            self.closeOwnedGatewaySocket(&ws);
         }
-        self.ws_fd.store(ws.stream.handle, .release);
 
         var auth_buf: [1024]u8 = undefined;
         const seq = self.ws_seq.fetchAdd(1, .monotonic) + 1;
@@ -956,6 +995,29 @@ fn jsonString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
 // ════════════════════════════════════════════════════════════════════════════
 // Tests
 // ════════════════════════════════════════════════════════════════════════════
+
+test "mattermost gateway socket published after stop is shut down safely" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
+        @TypeOf(std.posix.system.socketpair) == void)
+    {
+        return error.SkipZigTest;
+    } else {
+        const sockets = try websocket.createTestSocketPair();
+        defer std.Io.Threaded.closeFd(sockets[0]);
+        defer std.Io.Threaded.closeFd(sockets[1]);
+
+        var ch = MattermostChannel.init(std.testing.allocator, "tok", "https://chat.example.com");
+        ch.running.store(false, .release);
+
+        // Regression: close() before joining could fail to wake the reader and let
+        // WsClient.deinit double-close a descriptor whose number was already reused.
+        try std.testing.expect(!ch.publishGatewaySocket(sockets[0]));
+        try std.testing.expectEqual(invalid_socket, ch.ws_fd.load(.acquire));
+
+        var byte: [1]u8 = undefined;
+        try std.testing.expectEqual(@as(usize, 0), try std.posix.read(sockets[1], &byte));
+    }
+}
 
 test "mattermost parseTarget supports prefixes and thread suffix" {
     const a = try parseTarget("channel:chan-1");

--- a/src/channels/qq.zig
+++ b/src/channels/qq.zig
@@ -832,9 +832,14 @@ pub const QQChannel = struct {
     running: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     reconnect_requested: bool = false,
     gateway_thread: ?std.Thread = null,
+    lifecycle_mu: std_compat.sync.Mutex = .{},
     heartbeat_stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     force_heartbeat: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    gateway_socket_mu: std_compat.sync.Mutex = .{},
     ws_fd: std.atomic.Value(std.posix.socket_t) = std.atomic.Value(std.posix.socket_t).init(invalid_socket),
+    gateway_attempt_started_ms: std.atomic.Value(i64) = std.atomic.Value(i64).init(0),
+    last_gateway_activity_ms: std.atomic.Value(i64) = std.atomic.Value(i64).init(0),
+    hello_received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     token_mu: std_compat.sync.Mutex = .{},
 
     // ── Access token state ──
@@ -843,6 +848,8 @@ pub const QQChannel = struct {
 
     pub const MAX_MESSAGE_LEN: usize = 4096;
     pub const RECONNECT_DELAY_NS: u64 = 5 * std.time.ns_per_s;
+    const GATEWAY_CONNECT_GRACE_MS: i64 = 30 * std.time.ms_per_s;
+    const GATEWAY_STALE_GRACE_MS: i64 = 90 * std.time.ms_per_s;
 
     pub fn init(allocator: std.mem.Allocator, config: config_types.QQConfig) QQChannel {
         return .{
@@ -864,11 +871,55 @@ pub const QQChannel = struct {
 
     pub fn healthCheck(self: *QQChannel) bool {
         if (self.config.receive_mode == .websocket) {
-            return self.running.load(.acquire) and self.ws_fd.load(.acquire) != invalid_socket;
+            return self.websocketHealthyAt(std_compat.time.milliTimestamp());
         }
         const result = fetchAccessToken(self.allocator, self.config.app_id, self.config.app_secret) catch return false;
         self.allocator.free(result.token);
         return true;
+    }
+
+    fn websocketHealthyAt(self: *QQChannel, now_ms: i64) bool {
+        if (!self.running.load(.acquire) or self.ws_fd.load(.acquire) == invalid_socket) return false;
+
+        const started_ms = self.gateway_attempt_started_ms.load(.acquire);
+        if (!self.hello_received.load(.acquire)) {
+            if (started_ms == 0 or now_ms <= started_ms) return true;
+            return (now_ms - started_ms) <= GATEWAY_CONNECT_GRACE_MS;
+        }
+
+        const last_activity_ms = self.last_gateway_activity_ms.load(.acquire);
+        if (last_activity_ms == 0 or now_ms <= last_activity_ms) return true;
+        const heartbeat_window_ms: i64 = @as(i64, self.heartbeat_interval_ms.load(.acquire)) * 3;
+        return (now_ms - last_activity_ms) <= @max(heartbeat_window_ms, GATEWAY_STALE_GRACE_MS);
+    }
+
+    fn shutdownActiveGatewaySocket(self: *QQChannel) void {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+    }
+
+    fn closeOwnedGatewaySocket(self: *QQChannel, ws: *websocket.WsClient) void {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        ws.deinit();
+    }
+
+    fn closeOwnedGatewayStream(self: *QQChannel, stream: std_compat.net.Stream) void {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        stream.close();
+    }
+
+    fn publishGatewaySocket(self: *QQChannel, fd: std.posix.socket_t) bool {
+        self.gateway_socket_mu.lock();
+        defer self.gateway_socket_mu.unlock();
+        self.ws_fd.store(fd, .release);
+        if (self.running.load(.acquire)) return true;
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        return false;
     }
 
     /// Set the event bus for publishing inbound messages.
@@ -1525,26 +1576,31 @@ pub const QQChannel = struct {
 
     fn vtableStart(ptr: *anyopaque) anyerror!void {
         const self: *QQChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
+        if (self.running.load(.acquire)) return;
+        self.running.store(true, .release);
         if (self.config.receive_mode == .webhook) {
             log.info("QQ channel in webhook receive_mode; websocket listener not started", .{});
-            self.running.store(true, .release);
             return;
         }
-        self.running.store(true, .release);
         self.heartbeat_stop.store(false, .release);
         log.info("QQ channel starting (sandbox={s}, app_id={s})", .{ if (self.config.sandbox) "true" else "false", self.config.app_id });
-        self.gateway_thread = try std.Thread.spawn(.{ .stack_size = thread_stacks.HEAVY_RUNTIME_STACK_SIZE }, gatewayLoop, .{self});
+        self.gateway_thread = std.Thread.spawn(.{ .stack_size = thread_stacks.HEAVY_RUNTIME_STACK_SIZE }, gatewayLoop, .{self}) catch |err| {
+            self.running.store(false, .release);
+            return err;
+        };
     }
 
     fn vtableStop(ptr: *anyopaque) void {
         const self: *QQChannel = @ptrCast(@alignCast(ptr));
+        self.lifecycle_mu.lock();
+        defer self.lifecycle_mu.unlock();
         self.running.store(false, .release);
         self.heartbeat_stop.store(true, .release);
-        // Close socket to unblock blocking read
-        const fd = self.ws_fd.load(.acquire);
-        if (fd != invalid_socket) {
-            (std_compat.net.Stream{ .handle = fd }).close();
-        }
+        // shutdown() interrupts blocked reads and heartbeat writes; WsClient keeps
+        // final close ownership in the gateway thread.
+        self.shutdownActiveGatewaySocket();
         if (self.gateway_thread) |t| {
             t.join();
             self.gateway_thread = null;
@@ -1624,6 +1680,7 @@ pub const QQChannel = struct {
     /// Single connection attempt: connect WS, HELLO, IDENTIFY, read loop.
     fn runGatewayOnce(self: *QQChannel) !void {
         self.reconnect_requested = false;
+        self.hello_received.store(false, .release);
         // Fresh IDENTIFY session: do not carry sequence from a previous connection.
         self.has_sequence.store(false, .release);
         self.sequence.store(0, .release);
@@ -1649,24 +1706,34 @@ pub const QQChannel = struct {
         const path = parseGatewayPath(gw_url);
         log.info("Connecting to gateway: host={s} port={d} path={s}", .{ host, port, path });
 
-        var ws = try websocket.WsClient.connect(self.allocator, host, port, path, &.{});
+        const ws_stream = try websocket.WsClient.connectTcp(self.allocator, host, port);
 
-        // Store fd for interrupt-on-stop
-        self.ws_fd.store(ws.stream.handle, .release);
+        // Publish before TLS/WebSocket handshake so stop can interrupt blocked I/O.
+        self.gateway_attempt_started_ms.store(std_compat.time.milliTimestamp(), .release);
+        if (!self.publishGatewaySocket(ws_stream.handle)) {
+            self.closeOwnedGatewayStream(ws_stream);
+            return error.ConnectionClosed;
+        }
+        var ws = websocket.WsClient.connectFromStream(self.allocator, ws_stream, host, path, &.{}) catch |err| {
+            self.closeOwnedGatewayStream(ws_stream);
+            return err;
+        };
 
         // Start heartbeat thread
         self.heartbeat_stop.store(false, .release);
         self.force_heartbeat.store(false, .release);
         self.heartbeat_interval_ms.store(0, .release);
         const hbt = std.Thread.spawn(.{ .stack_size = thread_stacks.AUXILIARY_LOOP_STACK_SIZE }, heartbeatLoop, .{ self, &ws }) catch |err| {
-            ws.deinit();
+            self.closeOwnedGatewaySocket(&ws);
             return err;
         };
         defer {
             self.heartbeat_stop.store(true, .release);
+            // The writer may be blocked in TLS flush after a remote close. Shutdown
+            // must happen before join; WsClient.deinit performs the final close.
+            self.shutdownActiveGatewaySocket();
             hbt.join();
-            self.ws_fd.store(invalid_socket, .release);
-            ws.deinit();
+            self.closeOwnedGatewaySocket(&ws);
         }
 
         log.info("WebSocket connected, waiting for HELLO...", .{});
@@ -1681,6 +1748,8 @@ pub const QQChannel = struct {
             log.info("ERROR: No heartbeat_interval in HELLO", .{});
             return error.InvalidHello;
         }
+        self.last_gateway_activity_ms.store(std_compat.time.milliTimestamp(), .release);
+        self.hello_received.store(true, .release);
 
         // Send IDENTIFY
         var identify_buf: [2048]u8 = undefined;
@@ -1691,6 +1760,7 @@ pub const QQChannel = struct {
         // Read READY (dispatch with t=READY)
         const ready_text = try ws.readTextMessage() orelse return error.ConnectionClosed;
         defer self.allocator.free(ready_text);
+        self.last_gateway_activity_ms.store(std_compat.time.milliTimestamp(), .release);
         log.info("Received READY frame", .{});
         try self.handleGatewayEvent(ready_text);
 
@@ -1715,6 +1785,7 @@ pub const QQChannel = struct {
                 break;
             };
             defer self.allocator.free(text);
+            self.last_gateway_activity_ms.store(std_compat.time.milliTimestamp(), .release);
 
             log.debug("Gateway event received: len={d}", .{text.len});
 
@@ -2195,6 +2266,49 @@ test "qq healthCheck websocket requires running socket" {
         42;
     ch.ws_fd.store(fake_socket, .release);
     try std.testing.expect(ch.healthCheck());
+}
+
+test "qq health check rejects a stalled pre-hello gateway" {
+    var ch = QQChannel.init(std.testing.allocator, .{ .receive_mode = .websocket });
+    ch.running.store(true, .release);
+    ch.gateway_attempt_started_ms.store(1_000_000, .release);
+
+    const fake_socket: std.posix.socket_t = if (builtin.os.tag == .windows)
+        @ptrFromInt(1)
+    else
+        42;
+    ch.ws_fd.store(fake_socket, .release);
+
+    // Regression: a valid fd before HELLO must not report healthy forever.
+    try std.testing.expect(ch.websocketHealthyAt(1_029_999));
+    try std.testing.expect(!ch.websocketHealthyAt(1_030_001));
+    ch.hello_received.store(true, .release);
+    ch.heartbeat_interval_ms.store(40_000, .release);
+    ch.last_gateway_activity_ms.store(1_000_000, .release);
+    try std.testing.expect(ch.websocketHealthyAt(1_119_999));
+    try std.testing.expect(!ch.websocketHealthyAt(1_120_001));
+}
+
+test "qq shutdown active gateway socket clears fd and closes peer" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
+        @TypeOf(std.posix.system.socketpair) == void)
+    {
+        return error.SkipZigTest;
+    } else {
+        const sockets = try websocket.createTestSocketPair();
+        defer std.Io.Threaded.closeFd(sockets[0]);
+        defer std.Io.Threaded.closeFd(sockets[1]);
+
+        var ch = QQChannel.init(std.testing.allocator, .{ .receive_mode = .websocket });
+        ch.ws_fd.store(sockets[0], .release);
+
+        // Regression: reconnect cleanup must unblock a heartbeat writer before join.
+        ch.shutdownActiveGatewaySocket();
+
+        try std.testing.expectEqual(invalid_socket, ch.ws_fd.load(.acquire));
+        var byte: [1]u8 = undefined;
+        try std.testing.expectEqual(@as(usize, 0), try std.posix.read(sockets[1], &byte));
+    }
 }
 
 test "qq QQChannel vtable compiles" {

--- a/src/channels/slack.zig
+++ b/src/channels/slack.zig
@@ -129,6 +129,7 @@ pub const SlackChannel = struct {
     lifecycle_mu: std_compat.sync.Mutex = .{},
     poll_thread: ?std.Thread = null,
     socket_thread: ?std.Thread = null,
+    socket_mu: std_compat.sync.Mutex = .{},
     ws_fd: std.atomic.Value(SocketFd) = std.atomic.Value(SocketFd).init(invalid_socket),
     bot_user_id: ?[]u8 = null,
     bot_team_id: ?[]u8 = null,
@@ -266,6 +267,35 @@ pub const SlackChannel = struct {
             .http => true,
             .socket => (self.connected.load(.acquire) and self.socket_thread != null) or self.poll_thread != null,
         };
+    }
+
+    fn shutdownActiveSocket(self: *SlackChannel) void {
+        self.socket_mu.lock();
+        defer self.socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+    }
+
+    fn closeOwnedSocket(self: *SlackChannel, ws: *websocket.WsClient) void {
+        self.socket_mu.lock();
+        defer self.socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        ws.deinit();
+    }
+
+    fn closeOwnedSocketStream(self: *SlackChannel, stream: std_compat.net.Stream) void {
+        self.socket_mu.lock();
+        defer self.socket_mu.unlock();
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        stream.close();
+    }
+
+    fn publishSocket(self: *SlackChannel, fd: SocketFd) bool {
+        self.socket_mu.lock();
+        defer self.socket_mu.unlock();
+        self.ws_fd.store(fd, .release);
+        if (self.running.load(.acquire)) return true;
+        websocket.shutdownTrackedSocket(&self.ws_fd, invalid_socket, .both);
+        return false;
     }
 
     fn setLastTs(self: *SlackChannel, ts: []const u8) !void {
@@ -860,13 +890,19 @@ pub const SlackChannel = struct {
         var host_buf: [std.Io.net.HostName.max_len]u8 = undefined;
         var path_buf: [2048]u8 = undefined;
         const parts = try parseSocketConnectParts(ws_url, &host_buf, &path_buf);
-        var ws = try websocket.WsClient.connect(self.allocator, parts.host, parts.port, parts.path, &.{});
+        const ws_stream = try websocket.WsClient.connectTcp(self.allocator, parts.host, parts.port);
+        if (!self.publishSocket(ws_stream.handle)) {
+            self.closeOwnedSocketStream(ws_stream);
+            return error.ConnectionClosed;
+        }
+        var ws = websocket.WsClient.connectFromStream(self.allocator, ws_stream, parts.host, parts.path, &.{}) catch |err| {
+            self.closeOwnedSocketStream(ws_stream);
+            return err;
+        };
         defer {
             self.connected.store(false, .release);
-            self.ws_fd.store(invalid_socket, .release);
-            ws.deinit();
+            self.closeOwnedSocket(&ws);
         }
-        self.ws_fd.store(ws.stream.handle, .release);
         self.connected.store(true, .release);
 
         while (self.running.load(.acquire)) {
@@ -1292,11 +1328,9 @@ pub const SlackChannel = struct {
         self.running.store(false, .release);
         self.connected.store(false, .release);
 
-        const fd = self.ws_fd.load(.acquire);
-        if (fd != invalid_socket) {
-            (std_compat.net.Stream{ .handle = fd }).close();
-            self.ws_fd.store(invalid_socket, .release);
-        }
+        // shutdown() unblocks the socket reader while WsClient retains final close
+        // ownership in runSocketOnce's defer.
+        self.shutdownActiveSocket();
 
         if (self.socket_thread) |t| {
             t.join();
@@ -1626,6 +1660,29 @@ test "slack channel health check" {
     ch.poll_thread = t;
     defer ch.poll_thread = null;
     try std.testing.expect(ch.healthCheck());
+}
+
+test "slack socket published after stop is shut down without stealing close ownership" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
+        @TypeOf(std.posix.system.socketpair) == void)
+    {
+        return error.SkipZigTest;
+    } else {
+        const sockets = try websocket.createTestSocketPair();
+        defer std.Io.Threaded.closeFd(sockets[0]);
+        defer std.Io.Threaded.closeFd(sockets[1]);
+
+        var ch = SlackChannel.init(std.testing.allocator, "tok", null, null, &.{});
+        ch.running.store(false, .release);
+
+        // Regression: close() before joining could leave a blocked reader alive and
+        // let the later WsClient.deinit double-close a reused descriptor.
+        try std.testing.expect(!ch.publishSocket(sockets[0]));
+        try std.testing.expectEqual(invalid_socket, ch.ws_fd.load(.acquire));
+
+        var byte: [1]u8 = undefined;
+        try std.testing.expectEqual(@as(usize, 0), try std.posix.read(sockets[1], &byte));
+    }
 }
 
 test "slack socket thread stack size is 2MB" {

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -31,6 +31,15 @@ pub const Frame = struct {
     payload: []u8,
 };
 
+/// Atomically stop tracking an active socket and interrupt any blocking I/O.
+/// The caller must serialize this with the owning WsClient's final close.
+pub fn shutdownTrackedSocket(tracked_fd: anytype, invalid_socket: anytype, how: std.Io.net.ShutdownHow) void {
+    const fd = tracked_fd.swap(invalid_socket, .acq_rel);
+    if (fd != invalid_socket) {
+        (std_compat.net.Stream{ .handle = fd }).shutdown(how) catch {};
+    }
+}
+
 /// Heap-allocated TLS state.
 /// Must be heap-allocated so internal pointers remain stable after init.
 pub const TlsState = struct {
@@ -85,6 +94,7 @@ pub const WsClient = struct {
         extra_headers: []const []const u8,
     ) !WsClient {
         const stream = try connectTcp(allocator, host, port);
+        errdefer stream.close();
         return connectFromStream(allocator, stream, host, path, extra_headers);
     }
 
@@ -105,7 +115,8 @@ pub const WsClient = struct {
 
     /// Complete TLS init + WebSocket handshake on an already-established TCP stream.
     ///
-    /// On failure the stream is closed and an error is returned.
+    /// On failure the caller still owns the stream and must close it. Keeping failure
+    /// ownership with the caller allows tracked-fd users to unpublish before close.
     /// On success the returned `WsClient` owns the stream (call `deinit()` to release).
     ///
     /// A single adaptive errdefer handles tls_state cleanup across all failure stages:
@@ -120,9 +131,6 @@ pub const WsClient = struct {
         path: []const u8,
         extra_headers: []const []const u8,
     ) !WsClient {
-        // Ensures stream is closed on any failure path.
-        errdefer stream.close();
-
         const tls_buf_len = std.crypto.tls.Client.min_buffer_len;
 
         // Stage flags for the single adaptive tls_state errdefer below.
@@ -706,7 +714,7 @@ pub fn applyMask(payload: []u8, mask_key: [4]u8) void {
     for (payload, 0..) |*b, i| b.* ^= mask_key[i % 4];
 }
 
-fn createWsTestSocketPair() ![2]std.posix.socket_t {
+pub fn createTestSocketPair() ![2]std.posix.socket_t {
     if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi or
         @TypeOf(std.posix.system.socketpair) == void)
     {
@@ -1056,7 +1064,7 @@ test "ws buildFrame zero-len payload close" {
 }
 
 test "ws readMessage aggregates fragmented text and binary frames" {
-    const sockets = try createWsTestSocketPair();
+    const sockets = try createTestSocketPair();
     defer std.Io.Threaded.closeFd(sockets[1]);
 
     var client = WsClient{
@@ -1084,7 +1092,7 @@ test "ws readMessage aggregates fragmented text and binary frames" {
 }
 
 test "ws readFrame auto-pongs ping and returns null on close frame" {
-    const sockets = try createWsTestSocketPair();
+    const sockets = try createTestSocketPair();
     defer std.Io.Threaded.closeFd(sockets[1]);
 
     var client = WsClient{
@@ -1114,15 +1122,16 @@ test "ws readFrame auto-pongs ping and returns null on close frame" {
     try std.testing.expect(closed == null);
 }
 
-// Regression: connectFromStream must free all TLS buffers and close the stream on
-// TLS init failure, leaving no leaks detectable by the test allocator.
+// Regression: connectFromStream must free all TLS buffers on TLS init failure while
+// leaving stream ownership with the caller, with no test-allocator leaks.
 test "connectFromStream cleans up TLS state on init failure" {
     // Use a socketpair as the stream; close the server side immediately so
     // std.crypto.tls.Client.init() sees EOF during the TLS handshake and fails.
-    const sockets = try createWsTestSocketPair();
+    const sockets = try createTestSocketPair();
     std.Io.Threaded.closeFd(sockets[1]); // server side → EOF on first read
 
     const stream = std_compat.net.Stream{ .handle = sockets[0] };
+    defer stream.close();
     const result = WsClient.connectFromStream(
         std.testing.allocator,
         stream,
@@ -1288,7 +1297,7 @@ test "readFrame rejects oversized payload claim before allocation" {
     // triggers before any heap allocation. We send only the 10-byte header
     // claiming 5 MiB — readFrame must return error.FrameTooLarge without
     // attempting to allocate or read the (absent) payload bytes.
-    const sockets = try createWsTestSocketPair();
+    const sockets = try createTestSocketPair();
     defer std.Io.Threaded.closeFd(sockets[1]);
 
     var client = WsClient{


### PR DESCRIPTION
## Summary

- close the active Discord gateway socket before joining the heartbeat thread during reconnect cleanup
- treat stalled pre-HELLO gateway reconnects as unhealthy after a bounded grace window
- add regression coverage for stalled pre-HELLO reconnect health and reconnect session preservation

## Test plan

- `HOME=$(mktemp -d ...) zig build test --summary all`

## Risk

- Low-to-medium: Discord channel reconnect behavior only. The change preserves session resume state until reconnect exhaustion and makes stale pre-HELLO sockets fail health checks instead of remaining masked indefinitely.