### PR TITLE
docs(providers): document native Anthropic provider with API key and OAuth support

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -15,6 +15,9 @@
       "evolink": {
         "api_key": "YOUR_EVOLINK_API_KEY"
       },
+      "anthropic": {
+        "api_key": "YOUR_ANTHROPIC_API_KEY"
+      },
       "azure": {
         "api_key": "YOUR_AZURE_OPENAI_API_KEY",
         "base_url": "https://your-resource.openai.azure.com"

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -145,6 +145,43 @@ Common per-provider fields:
 - `max_streaming_prompt_bytes`: skip streaming above this estimated prompt size.
 - `chat_template_enable_thinking_param`: for custom OpenAI-compatible vLLM/Qwen endpoints, map `reasoning_effort` to `chat_template_kwargs.enable_thinking`.
 
+#### Native Anthropic Provider
+
+NullClaw has a dedicated Anthropic provider that connects directly to the Anthropic API
+— no OpenRouter or proxy needed. It supports:
+
+- **Standard API keys** via the `x-api-key` header (keys starting with `sk-ant-api...`).
+- **OAuth / Pro-Plan tokens** via Bearer auth (keys starting with `sk-ant-oat01-`).
+  OAuth tokens are detected automatically — no extra config required.
+- **Custom base URLs** for proxies or self-hosted endpoints (set `base_url`).
+- **Streaming, native tool use, vision (multimodal images), and extended thinking.**
+
+Example (direct Anthropic API key):
+
+```json
+{
+  "models": {
+    "providers": {
+      "anthropic": { "api_key": "sk-ant-api03-..." }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": { "primary": "anthropic/claude-sonnet-4-20250514" }
+    }
+  }
+}
+```
+
+Notes:
+
+- Use the **Anthropic model ID** (e.g. `claude-sonnet-4-20250514`) with the
+  `anthropic/` provider prefix. List available models with
+  `nullclaw --list-models --provider anthropic`.
+- The `base_url` field is optional and defaults to `https://api.anthropic.com`.
+- OAuth setup tokens (`sk-ant-oat01-...`) work automatically; NullClaw detects
+  them and switches to Bearer token authentication.
+
 ### `agents.defaults.model.primary`
 
 - Sets default model route, typically `provider/vendor/model`.

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -139,22 +139,34 @@ Example:
 Common per-provider fields:
 
 - `api_key`: credential for that provider entry.
-- `base_url`: override for custom or self-hosted OpenAI-compatible endpoints.
+- `base_url`: provider-specific API endpoint override. The expected path shape
+  depends on the provider; OpenAI-compatible providers usually expect a `/v1`
+  base, while the native Anthropic provider does not.
 - `api_mode`: select `chat_completions` or `responses` for compatible providers.
 - `user_agent`: optional `User-Agent` header override.
 - `max_streaming_prompt_bytes`: skip streaming above this estimated prompt size.
 - `chat_template_enable_thinking_param`: for custom OpenAI-compatible vLLM/Qwen endpoints, map `reasoning_effort` to `chat_template_kwargs.enable_thinking`.
 
-#### Native Anthropic Provider
+#### Native Anthropic provider
 
 NullClaw has a dedicated Anthropic provider that connects directly to the Anthropic API
-— no OpenRouter or proxy needed. It supports:
+— no OpenRouter or proxy is required.
 
-- **Standard API keys** via the `x-api-key` header (keys starting with `sk-ant-api...`).
-- **OAuth / Pro-Plan tokens** via Bearer auth (keys starting with `sk-ant-oat01-`).
-  OAuth tokens are detected automatically — no extra config required.
-- **Custom base URLs** for proxies or self-hosted endpoints (set `base_url`).
-- **Streaming, native tool use, vision (multimodal images), and extended thinking.**
+Authentication options:
+
+- **Anthropic Console API keys** are sent in the `x-api-key` header. Put the key
+  in `models.providers.anthropic.api_key` or set `ANTHROPIC_API_KEY`.
+- **Claude subscription setup tokens** beginning with `sk-ant-oat01-` are sent
+  with Bearer authentication. Generate a long-lived token with `claude setup-token`,
+  then put it in `models.providers.anthropic.api_key` or set
+  `ANTHROPIC_OAUTH_TOKEN`. NullClaw does not read Claude Code's credential store
+  or refresh the token. See the [Claude Code authentication guide](https://code.claude.com/docs/en/authentication#generate-a-long-lived-token).
+
+The provider supports text streaming, URL and base64 image inputs, and native
+tool calls on non-streaming requests. Setting `reasoning_effort` (or using
+`/think`) enables Anthropic extended thinking on models that support it.
+NullClaw uses adaptive thinking for Claude Opus/Sonnet 4.6 and a manual budget
+for older supported models; model-specific Anthropic restrictions still apply.
 
 Example (direct Anthropic API key):
 
@@ -167,7 +179,7 @@ Example (direct Anthropic API key):
   },
   "agents": {
     "defaults": {
-      "model": { "primary": "anthropic/claude-sonnet-4-20250514" }
+      "model": { "primary": "anthropic/claude-sonnet-4-6" }
     }
   }
 }
@@ -175,12 +187,17 @@ Example (direct Anthropic API key):
 
 Notes:
 
-- Use the **Anthropic model ID** (e.g. `claude-sonnet-4-20250514`) with the
-  `anthropic/` provider prefix. List available models with
-  `nullclaw --list-models --provider anthropic`.
+- In `agents.defaults.model.primary`, prefix the Anthropic model ID with
+  `anthropic/`, for example `anthropic/claude-sonnet-4-6`. When an agent entry
+  has a separate `"provider": "anthropic"` field, use the bare model ID instead.
+  Browse NullClaw's cataloged Anthropic model IDs with
+  `nullclaw --list-models --provider anthropic`; this command does not inspect
+  the models enabled for your Anthropic account.
 - The `base_url` field is optional and defaults to `https://api.anthropic.com`.
-- OAuth setup tokens (`sk-ant-oat01-...`) work automatically; NullClaw detects
-  them and switches to Bearer token authentication.
+  For an Anthropic-compatible proxy or gateway, set it to the API root before
+  `/v1/messages` (do not include the final `/v1`); NullClaw appends that path.
+  Remote endpoints must use HTTPS. Plain HTTP is accepted only for local or
+  private-network hosts.
 
 ### `agents.defaults.model.primary`
 

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -130,6 +130,42 @@ nullclaw onboard --interactive
 - `max_streaming_prompt_bytes`：当估算 prompt 大小超过该阈值时跳过流式请求。
 - `chat_template_enable_thinking_param`：针对自定义 OpenAI 兼容的 vLLM/Qwen 端点，把 `reasoning_effort` 映射到 `chat_template_kwargs.enable_thinking`。
 
+#### 原生 Anthropic Provider
+
+NullClaw 内置了原生的 Anthropic provider，可直接连接 Anthropic API，无需经过 OpenRouter 或代理。支持：
+
+- **标准 API Key** 通过 `x-api-key` header（以 `sk-ant-api...` 开头的密钥）。
+- **OAuth / Pro-Plan 令牌** 通过 Bearer auth（以 `sk-ant-oat01-` 开头的密钥）。
+  OAuth 令牌会被自动检测，无需额外配置。
+- **自定义 base_url** 用于代理或自托管端点（设置 `base_url`）。
+- **流式输出、原生工具调用、视觉（多模态图片）与 extended thinking。**
+
+示例（直接使用 Anthropic API Key）：
+
+```json
+{
+  "models": {
+    "providers": {
+      "anthropic": { "api_key": "sk-ant-api03-..." }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": { "primary": "anthropic/claude-sonnet-4-20250514" }
+    }
+  }
+}
+```
+
+说明：
+
+- 使用 **Anthropic 模型 ID**（例如 `claude-sonnet-4-20250514`）并加上
+  `anthropic/` provider 前缀。通过 `nullclaw --list-models --provider anthropic`
+  查看可用模型列表。
+- `base_url` 字段是可选的，默认值为 `https://api.anthropic.com`。
+- OAuth 设置令牌（`sk-ant-oat01-...`）自动生效；NullClaw 会检测它们并自动切换为
+  Bearer 令牌认证。
+
 ### `agents.defaults.model.primary`
 
 - 设置默认模型路由，通常是 `provider/vendor/model`。

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -124,21 +124,31 @@ nullclaw onboard --interactive
 常见的 provider 级字段：
 
 - `api_key`：该 provider 条目的凭据。
-- `base_url`：用于自定义或自托管 OpenAI 兼容端点的地址覆盖。
+- `base_url`：provider 专用的 API 端点覆盖。所需的路径格式取决于 provider；
+  OpenAI 兼容 provider 通常需要以 `/v1` 结尾的 base，而原生 Anthropic provider 不需要。
 - `api_mode`：为兼容 provider 选择 `chat_completions` 或 `responses`。
 - `user_agent`：可选的 `User-Agent` 请求头覆盖。
 - `max_streaming_prompt_bytes`：当估算 prompt 大小超过该阈值时跳过流式请求。
 - `chat_template_enable_thinking_param`：针对自定义 OpenAI 兼容的 vLLM/Qwen 端点，把 `reasoning_effort` 映射到 `chat_template_kwargs.enable_thinking`。
 
-#### 原生 Anthropic Provider
+#### 原生 Anthropic provider
 
-NullClaw 内置了原生的 Anthropic provider，可直接连接 Anthropic API，无需经过 OpenRouter 或代理。支持：
+NullClaw 内置了原生的 Anthropic provider，可直接连接 Anthropic API，无需经过 OpenRouter 或代理。
 
-- **标准 API Key** 通过 `x-api-key` header（以 `sk-ant-api...` 开头的密钥）。
-- **OAuth / Pro-Plan 令牌** 通过 Bearer auth（以 `sk-ant-oat01-` 开头的密钥）。
-  OAuth 令牌会被自动检测，无需额外配置。
-- **自定义 base_url** 用于代理或自托管端点（设置 `base_url`）。
-- **流式输出、原生工具调用、视觉（多模态图片）与 extended thinking。**
+认证方式：
+
+- **Anthropic Console API Key** 通过 `x-api-key` 请求头发送。请将密钥写入
+  `models.providers.anthropic.api_key`，或设置 `ANTHROPIC_API_KEY`。
+- **Claude 订阅 setup token**（以 `sk-ant-oat01-` 开头）通过 Bearer 认证发送。
+  先运行 `claude setup-token` 生成长期令牌，再将其写入
+  `models.providers.anthropic.api_key`，或设置 `ANTHROPIC_OAUTH_TOKEN`。
+  NullClaw 不会读取 Claude Code 的凭据存储，也不会刷新该令牌。请参阅
+  [Claude Code 认证指南](https://code.claude.com/docs/en/authentication#generate-a-long-lived-token)。
+
+该 provider 支持文本流式输出、URL 和 base64 图片输入，以及非流式请求中的原生工具调用。
+设置 `reasoning_effort`（或使用 `/think`）可在支持该功能的模型上启用 Anthropic
+扩展思考。NullClaw 对 Claude Opus/Sonnet 4.6 使用自适应思考，对支持该功能的旧模型
+使用手动预算；Anthropic 针对具体模型的限制仍然适用。
 
 示例（直接使用 Anthropic API Key）：
 
@@ -151,7 +161,7 @@ NullClaw 内置了原生的 Anthropic provider，可直接连接 Anthropic API�
   },
   "agents": {
     "defaults": {
-      "model": { "primary": "anthropic/claude-sonnet-4-20250514" }
+      "model": { "primary": "anthropic/claude-sonnet-4-6" }
     }
   }
 }
@@ -159,12 +169,15 @@ NullClaw 内置了原生的 Anthropic provider，可直接连接 Anthropic API�
 
 说明：
 
-- 使用 **Anthropic 模型 ID**（例如 `claude-sonnet-4-20250514`）并加上
-  `anthropic/` provider 前缀。通过 `nullclaw --list-models --provider anthropic`
-  查看可用模型列表。
+- 在 `agents.defaults.model.primary` 中，为 Anthropic 模型 ID 添加
+  `anthropic/` provider 前缀，例如 `anthropic/claude-sonnet-4-6`。如果 agent
+  条目单独设置了 `"provider": "anthropic"`，则使用不带前缀的模型 ID。
+  可通过 `nullclaw --list-models --provider anthropic` 浏览 NullClaw 收录的
+  Anthropic 模型 ID；该命令不会检查你的 Anthropic 账户实际启用了哪些模型。
 - `base_url` 字段是可选的，默认值为 `https://api.anthropic.com`。
-- OAuth 设置令牌（`sk-ant-oat01-...`）自动生效；NullClaw 会检测它们并自动切换为
-  Bearer 令牌认证。
+  对于 Anthropic 兼容的代理或网关，请将其设为 `/v1/messages` 之前的 API root
+  （不要包含末尾的 `/v1`）；NullClaw 会自行追加该路径。远程端点必须使用 HTTPS；
+  只有本地或私有网络主机才允许使用普通 HTTP。
 
 ### `agents.defaults.model.primary`
 

--- a/src/providers/anthropic.zig
+++ b/src/providers/anthropic.zig
@@ -19,7 +19,7 @@ const TokenUsage = root.TokenUsage;
 /// Supports:
 /// - x-api-key authentication (standard API keys)
 /// - Bearer token authentication (setup/OAuth tokens starting with sk-ant-oat01-)
-/// - Custom base URLs for proxies/self-hosted endpoints
+/// - Custom base URLs for Anthropic-compatible proxies and gateways
 pub const AnthropicProvider = struct {
     credential: ?[]const u8,
     base_url: []const u8,
@@ -28,6 +28,8 @@ pub const AnthropicProvider = struct {
     const DEFAULT_BASE_URL = "https://api.anthropic.com";
     const API_VERSION = "2023-06-01";
     const DEFAULT_MAX_TOKENS: u32 = config_types.DEFAULT_MODEL_MAX_TOKENS;
+    const OAUTH_BETA_HEADER = "anthropic-beta: oauth-2025-04-20";
+    const OAUTH_USER_AGENT_HEADER = "User-Agent: claude-cli/2.1.2 (external, cli)";
 
     pub fn init(allocator: std.mem.Allocator, api_key: ?[]const u8, base_url: ?[]const u8) AnthropicProvider {
         const url = if (base_url) |u| trimTrailingSlash(u) else DEFAULT_BASE_URL;
@@ -62,6 +64,19 @@ pub const AnthropicProvider = struct {
     /// Build the messages endpoint URL.
     pub fn messagesUrl(self: AnthropicProvider, allocator: std.mem.Allocator) ![]const u8 {
         return std.fmt.allocPrint(allocator, "{s}/v1/messages", .{self.base_url});
+    }
+
+    fn formatMessagesUrl(self: AnthropicProvider, buffer: []u8, is_oauth: bool) ![]const u8 {
+        const path: []const u8 = if (is_oauth) "/v1/messages?beta=true" else "/v1/messages";
+        return std.fmt.bufPrint(buffer, "{s}{s}", .{ self.base_url, path });
+    }
+
+    fn appendOAuthHeaders(headers_buf: *[4][]const u8, hdr_count: *usize, is_oauth: bool) void {
+        if (!is_oauth) return;
+        headers_buf[hdr_count.*] = OAUTH_BETA_HEADER;
+        hdr_count.* += 1;
+        headers_buf[hdr_count.*] = OAUTH_USER_AGENT_HEADER;
+        hdr_count.* += 1;
     }
 
     /// Build a simple chat request JSON body.
@@ -266,10 +281,7 @@ pub const AnthropicProvider = struct {
 
         // URL: stack-allocated (base_url + path is bounded)
         var url_buf: [2048]u8 = undefined;
-        const url = if (is_oauth)
-            std.fmt.bufPrint(&url_buf, "{s}/v1/messages?beta=true", .{self.base_url}) catch return error.AnthropicApiError
-        else
-            std.fmt.bufPrint(&url_buf, "{s}/v1/messages", .{self.base_url}) catch return error.AnthropicApiError;
+        const url = self.formatMessagesUrl(&url_buf, is_oauth) catch return error.AnthropicApiError;
 
         const body = try buildSimpleRequestBody(allocator, system_prompt, message, model, temperature);
         defer allocator.free(body);
@@ -290,12 +302,7 @@ pub const AnthropicProvider = struct {
         hdr_count += 1;
         headers_buf[hdr_count] = version_hdr;
         hdr_count += 1;
-        if (is_oauth) {
-            headers_buf[hdr_count] = "anthropic-beta: oauth-2025-04-20";
-            hdr_count += 1;
-            headers_buf[hdr_count] = "User-Agent: claude-cli/2.1.2 (external, cli)";
-            hdr_count += 1;
-        }
+        appendOAuthHeaders(&headers_buf, &hdr_count, is_oauth);
 
         const resp_body = root.curlPostTimed(allocator, url, body, headers_buf[0..hdr_count], 0) catch |err| return root.preserveCurlTransportError(err, error.AnthropicApiError);
         defer allocator.free(resp_body);
@@ -316,10 +323,7 @@ pub const AnthropicProvider = struct {
 
         // URL: stack-allocated (base_url + path is bounded)
         var url_buf: [2048]u8 = undefined;
-        const url = if (is_oauth)
-            std.fmt.bufPrint(&url_buf, "{s}/v1/messages?beta=true", .{self.base_url}) catch return error.AnthropicApiError
-        else
-            std.fmt.bufPrint(&url_buf, "{s}/v1/messages", .{self.base_url}) catch return error.AnthropicApiError;
+        const url = self.formatMessagesUrl(&url_buf, is_oauth) catch return error.AnthropicApiError;
 
         const body = try buildChatRequestBody(allocator, request, model, temperature);
         defer allocator.free(body);
@@ -340,12 +344,7 @@ pub const AnthropicProvider = struct {
         hdr_count += 1;
         headers_buf[hdr_count] = version_hdr;
         hdr_count += 1;
-        if (is_oauth) {
-            headers_buf[hdr_count] = "anthropic-beta: oauth-2025-04-20";
-            hdr_count += 1;
-            headers_buf[hdr_count] = "User-Agent: claude-cli/2.1.2 (external, cli)";
-            hdr_count += 1;
-        }
+        appendOAuthHeaders(&headers_buf, &hdr_count, is_oauth);
 
         const resp_body = root.curlPostTimed(allocator, url, body, headers_buf[0..hdr_count], request.timeout_secs) catch |err| return root.preserveCurlTransportError(err, error.AnthropicApiError);
         defer allocator.free(resp_body);
@@ -382,15 +381,15 @@ pub const AnthropicProvider = struct {
     ) anyerror!root.StreamChatResult {
         const self: *AnthropicProvider = @ptrCast(@alignCast(ptr));
         const credential = self.credential orelse return error.CredentialsNotSet;
+        const is_oauth = isSetupToken(credential);
 
         var url_buf: [2048]u8 = undefined;
-        const url = std.fmt.bufPrint(&url_buf, "{s}/v1/messages", .{self.base_url}) catch return error.AnthropicApiError;
+        const url = self.formatMessagesUrl(&url_buf, is_oauth) catch return error.AnthropicApiError;
 
         const body = try buildStreamingChatRequestBody(allocator, request, model, temperature);
         defer allocator.free(body);
 
         // Build auth header directly on stack
-        const is_oauth = isSetupToken(credential);
         var auth_hdr_buf: [512]u8 = undefined;
         const auth_hdr = if (is_oauth)
             std.fmt.bufPrint(&auth_hdr_buf, "authorization: Bearer {s}", .{credential}) catch return error.AnthropicApiError
@@ -407,10 +406,7 @@ pub const AnthropicProvider = struct {
         hdr_count += 1;
         headers_buf[hdr_count] = version_hdr;
         hdr_count += 1;
-        if (isSetupToken(credential)) {
-            headers_buf[hdr_count] = "anthropic-beta: oauth-2025-04-20";
-            hdr_count += 1;
-        }
+        appendOAuthHeaders(&headers_buf, &hdr_count, is_oauth);
 
         return sse.curlStreamAnthropic(allocator, url, body, headers_buf[0..hdr_count], callback, callback_ctx) catch |err| {
             if (err == error.CurlWaitError or err == error.CurlFailed) {
@@ -509,10 +505,7 @@ fn buildChatRequestBody(
         try buf.append(allocator, '}');
     }
 
-    try buf.appendSlice(allocator, "],\"temperature\":");
-    var temp_buf: [16]u8 = undefined;
-    const temp_str = std.fmt.bufPrint(&temp_buf, "{d:.2}", .{temperature}) catch return error.AnthropicApiError;
-    try buf.appendSlice(allocator, temp_str);
+    try buf.append(allocator, ']');
 
     if (request.tools) |tools| {
         if (tools.len > 0) {
@@ -520,7 +513,7 @@ fn buildChatRequestBody(
             try root.convertToolsAnthropic(&buf, allocator, tools);
         }
     }
-    try appendAnthropicThinkingConfig(&buf, allocator, max_tokens, request.reasoning_effort);
+    try appendAnthropicGenerationConfig(&buf, allocator, model, max_tokens, temperature, request.reasoning_effort);
 
     try buf.append(allocator, '}');
     return try buf.toOwnedSlice(allocator);
@@ -576,10 +569,7 @@ fn buildStreamingChatRequestBody(
         try buf.append(allocator, '}');
     }
 
-    try buf.appendSlice(allocator, "],\"temperature\":");
-    var temp_buf: [16]u8 = undefined;
-    const temp_str = std.fmt.bufPrint(&temp_buf, "{d:.2}", .{temperature}) catch return error.AnthropicApiError;
-    try buf.appendSlice(allocator, temp_str);
+    try buf.append(allocator, ']');
 
     if (request.tools) |tools| {
         if (tools.len > 0) {
@@ -587,29 +577,55 @@ fn buildStreamingChatRequestBody(
             try root.convertToolsAnthropic(&buf, allocator, tools);
         }
     }
-    try appendAnthropicThinkingConfig(&buf, allocator, max_tokens, request.reasoning_effort);
+    try appendAnthropicGenerationConfig(&buf, allocator, model, max_tokens, temperature, request.reasoning_effort);
 
     try buf.appendSlice(allocator, ",\"stream\":true}");
     return try buf.toOwnedSlice(allocator);
 }
 
-fn appendAnthropicThinkingConfig(
+fn appendAnthropicGenerationConfig(
     buf: *std.ArrayListUnmanaged(u8),
     allocator: std.mem.Allocator,
+    model: []const u8,
     max_tokens: u32,
+    temperature: f64,
     reasoning_effort: ?[]const u8,
 ) !void {
-    const effort = root.normalizeOpenAiReasoningEffort(reasoning_effort) orelse return;
-    if (std.ascii.eqlIgnoreCase(effort, "none")) return;
+    const effort = root.normalizeOpenAiReasoningEffort(reasoning_effort);
+    if (effort == null or std.ascii.eqlIgnoreCase(effort.?, "none")) {
+        try buf.appendSlice(allocator, ",\"temperature\":");
+        var temp_buf: [16]u8 = undefined;
+        const temp_str = std.fmt.bufPrint(&temp_buf, "{d:.2}", .{temperature}) catch return error.AnthropicApiError;
+        try buf.appendSlice(allocator, temp_str);
+        return;
+    }
 
-    // Anthropic extended thinking requires a budget. Keep a conservative floor
-    // and never exceed output budget.
-    const budget: u32 = if (std.ascii.eqlIgnoreCase(effort, "low"))
-        @min(max_tokens, 1024)
-    else if (std.ascii.eqlIgnoreCase(effort, "medium"))
-        @min(max_tokens, 4096)
+    const normalized_effort: []const u8 = if (std.ascii.eqlIgnoreCase(effort.?, "low"))
+        "low"
+    else if (std.ascii.eqlIgnoreCase(effort.?, "medium"))
+        "medium"
     else
-        @min(max_tokens, 8192);
+        "high";
+
+    if (std.mem.eql(u8, model, "claude-opus-4-6") or std.mem.eql(u8, model, "claude-sonnet-4-6")) {
+        try buf.appendSlice(allocator, ",\"thinking\":{\"type\":\"adaptive\"},\"output_config\":{\"effort\":\"");
+        try buf.appendSlice(allocator, normalized_effort);
+        try buf.appendSlice(allocator, "\"}");
+        return;
+    }
+
+    const MIN_THINKING_BUDGET: u32 = 1024;
+    if (max_tokens <= MIN_THINKING_BUDGET) return error.AnthropicThinkingBudgetTooSmall;
+
+    // Manual extended thinking requires at least 1,024 tokens and a budget
+    // strictly smaller than max_tokens.
+    const requested_budget: u32 = if (std.mem.eql(u8, normalized_effort, "low"))
+        MIN_THINKING_BUDGET
+    else if (std.mem.eql(u8, normalized_effort, "medium"))
+        4096
+    else
+        8192;
+    const budget = @min(requested_budget, max_tokens - 1);
 
     try buf.appendSlice(allocator, ",\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":");
     var budget_buf: [16]u8 = undefined;
@@ -671,6 +687,30 @@ test "messages url with custom base" {
     const url = try p.messagesUrl(std.testing.allocator);
     defer std.testing.allocator.free(url);
     try std.testing.expectEqualStrings("https://proxy.example.com/v1/messages", url);
+}
+
+test "OAuth request metadata matches blocking and streaming paths" {
+    // Regression: setup-token streaming must use the same beta URL and headers
+    // as blocking requests, otherwise authentication can fail as an empty stream.
+    const p = AnthropicProvider.init(std.testing.allocator, null, null);
+    var url_buf: [256]u8 = undefined;
+    const oauth_url = try p.formatMessagesUrl(&url_buf, true);
+    try std.testing.expectEqualStrings("https://api.anthropic.com/v1/messages?beta=true", oauth_url);
+
+    var headers: [4][]const u8 = undefined;
+    headers[0] = "authorization: Bearer token";
+    headers[1] = "anthropic-version: 2023-06-01";
+    var header_count: usize = 2;
+    AnthropicProvider.appendOAuthHeaders(&headers, &header_count, true);
+    try std.testing.expectEqual(@as(usize, 4), header_count);
+    try std.testing.expectEqualStrings(AnthropicProvider.OAUTH_BETA_HEADER, headers[2]);
+    try std.testing.expectEqualStrings(AnthropicProvider.OAUTH_USER_AGENT_HEADER, headers[3]);
+
+    const api_key_url = try p.formatMessagesUrl(&url_buf, false);
+    try std.testing.expectEqualStrings("https://api.anthropic.com/v1/messages", api_key_url);
+    header_count = 2;
+    AnthropicProvider.appendOAuthHeaders(&headers, &header_count, false);
+    try std.testing.expectEqual(@as(usize, 2), header_count);
 }
 
 test "auth header for regular key" {
@@ -885,7 +925,7 @@ test "parseNativeResponse multiple tool calls" {
 
 test "parseNativeResponse model field extracted" {
     const body =
-        \\{"content":[{"type":"text","text":"Hi"}],"model":"claude-sonnet-4-20250514"}
+        \\{"content":[{"type":"text","text":"Hi"}],"model":"claude-sonnet-4-6"}
     ;
     const response = try AnthropicProvider.parseNativeResponse(std.testing.allocator, body);
     defer {
@@ -893,7 +933,7 @@ test "parseNativeResponse model field extracted" {
         std.testing.allocator.free(response.tool_calls);
         std.testing.allocator.free(response.model);
     }
-    try std.testing.expectEqualStrings("claude-sonnet-4-20250514", response.model);
+    try std.testing.expectEqualStrings("claude-sonnet-4-6", response.model);
 }
 
 test "parseNativeResponse trims whitespace text" {
@@ -998,7 +1038,7 @@ test "buildChatRequestBody defaults max_tokens to runtime fallback" {
     try std.testing.expectEqual(@as(i64, config_types.DEFAULT_MODEL_MAX_TOKENS), max_tokens.integer);
 }
 
-test "buildChatRequestBody emits thinking config when reasoning_effort is set" {
+test "buildChatRequestBody uses adaptive thinking for Claude 4.6" {
     const allocator = std.testing.allocator;
     const msgs = [_]ChatMessage{
         .{ .role = .user, .content = "hello" },
@@ -1008,11 +1048,16 @@ test "buildChatRequestBody emits thinking config when reasoning_effort is set" {
         .reasoning_effort = "high",
     };
 
-    const body = try buildChatRequestBody(allocator, req, "claude-3-opus", 0.7);
+    const body = try buildChatRequestBody(allocator, req, "claude-sonnet-4-6", 0.7);
     defer allocator.free(body);
 
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"thinking\":{\"type\":\"enabled\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"budget_tokens\":") != null);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try std.testing.expectEqualStrings("adaptive", obj.get("thinking").?.object.get("type").?.string);
+    try std.testing.expectEqualStrings("high", obj.get("output_config").?.object.get("effort").?.string);
+    try std.testing.expect(obj.get("temperature") == null);
+    try std.testing.expect(obj.get("thinking").?.object.get("budget_tokens") == null);
 }
 
 test "buildChatRequestBody omits thinking config when reasoning_effort is none" {
@@ -1028,7 +1073,80 @@ test "buildChatRequestBody omits thinking config when reasoning_effort is none" 
     const body = try buildChatRequestBody(allocator, req, "claude-3-opus", 0.7);
     defer allocator.free(body);
 
-    try std.testing.expect(std.mem.indexOf(u8, body, "\"thinking\"") == null);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value.object.get("thinking") == null);
+    try std.testing.expectEqual(@as(f64, 0.7), parsed.value.object.get("temperature").?.float);
+}
+
+test "buildChatRequestBody keeps manual thinking budget below max tokens" {
+    const allocator = std.testing.allocator;
+    const msgs = [_]ChatMessage{.{ .role = .user, .content = "hello" }};
+    const req = ChatRequest{
+        .messages = &msgs,
+        .max_tokens = 8192,
+        .reasoning_effort = "high",
+    };
+
+    const body = try buildChatRequestBody(allocator, req, "claude-haiku-4-5", 0.7);
+    defer allocator.free(body);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try std.testing.expectEqualStrings("enabled", obj.get("thinking").?.object.get("type").?.string);
+    try std.testing.expectEqual(@as(i64, 8191), obj.get("thinking").?.object.get("budget_tokens").?.integer);
+    try std.testing.expect(obj.get("temperature") == null);
+}
+
+test "buildChatRequestBody uses minimum valid manual thinking budget" {
+    const allocator = std.testing.allocator;
+    const msgs = [_]ChatMessage{.{ .role = .user, .content = "hello" }};
+    const req = ChatRequest{
+        .messages = &msgs,
+        .max_tokens = 1025,
+        .reasoning_effort = "low",
+    };
+
+    const body = try buildChatRequestBody(allocator, req, "claude-haiku-4-5", 0.7);
+    defer allocator.free(body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(i64, 1024), parsed.value.object.get("thinking").?.object.get("budget_tokens").?.integer);
+}
+
+test "buildChatRequestBody rejects max tokens too small for manual thinking" {
+    const allocator = std.testing.allocator;
+    const msgs = [_]ChatMessage{.{ .role = .user, .content = "hello" }};
+    const req = ChatRequest{
+        .messages = &msgs,
+        .max_tokens = 1024,
+        .reasoning_effort = "low",
+    };
+
+    try std.testing.expectError(
+        error.AnthropicThinkingBudgetTooSmall,
+        buildChatRequestBody(allocator, req, "claude-haiku-4-5", 0.7),
+    );
+}
+
+test "buildStreamingChatRequestBody uses adaptive thinking without temperature" {
+    const allocator = std.testing.allocator;
+    const msgs = [_]ChatMessage{.{ .role = .user, .content = "hello" }};
+    const req = ChatRequest{
+        .messages = &msgs,
+        .reasoning_effort = "medium",
+    };
+
+    const body = try buildStreamingChatRequestBody(allocator, req, "claude-opus-4-6", 0.7);
+    defer allocator.free(body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try std.testing.expectEqualStrings("adaptive", obj.get("thinking").?.object.get("type").?.string);
+    try std.testing.expectEqualStrings("medium", obj.get("output_config").?.object.get("effort").?.string);
+    try std.testing.expect(obj.get("temperature") == null);
+    try std.testing.expect(obj.get("stream").?.bool);
 }
 
 test "buildStreamingChatRequestBody contains same messages as non-streaming" {

--- a/src/providers/router.zig
+++ b/src/providers/router.zig
@@ -517,9 +517,9 @@ test "non-hint model uses default provider" {
     );
     defer router.deinit();
 
-    const result = router.resolve("anthropic/claude-sonnet-4-20250514");
+    const result = router.resolve("anthropic/claude-sonnet-4-6");
     try std.testing.expect(result[0] == 0);
-    try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", result[1]);
+    try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-6", result[1]);
 }
 
 test "explicit provider ref resolves provider prefix" {

--- a/src/providers/sse.zig
+++ b/src/providers/sse.zig
@@ -741,6 +741,8 @@ pub fn curlStreamAnthropic(
     argc += 1;
     argv_buf[argc] = "--no-buffer";
     argc += 1;
+    argv_buf[argc] = curlFailFastArg(allocator);
+    argc += 1;
     argv_buf[argc] = "-X";
     argc += 1;
     argv_buf[argc] = "POST";
@@ -897,8 +899,15 @@ pub fn curlStreamAnthropic(
         },
     }
 
+    try validateAnthropicStreamOutcome(accumulated.items.len, saw_done);
     callback(ctx, root.StreamChunk.finalChunk());
     return finalizeStreamResult(allocator, accumulated.items, anthropic_usage);
+}
+
+fn validateAnthropicStreamOutcome(accumulated_len: usize, saw_done: bool) !void {
+    if (!root.shouldRecoverPartialStream(accumulated_len, saw_done)) {
+        return error.CurlFailed;
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -1157,6 +1166,14 @@ test "parseAnthropicSseLine data with unknown event returns skip" {
     const json = "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\"}}";
     const result = try parseAnthropicSseLine(std.testing.allocator, json, "message_start");
     try std.testing.expect(result == .skip);
+}
+
+test "Anthropic stream rejects response without SSE progress" {
+    // Regression: #767 JSON API errors and event:error have neither text
+    // deltas nor message_stop and must trigger the non-streaming fallback.
+    try std.testing.expectError(error.CurlFailed, validateAnthropicStreamOutcome(0, false));
+    try validateAnthropicStreamOutcome(0, true);
+    try validateAnthropicStreamOutcome(1, false);
 }
 
 test "extractAnthropicDelta correct JSON returns text" {


### PR DESCRIPTION
## Summary

Adds a dedicated **Native Anthropic Provider** subsection under `models.providers` in both English and Chinese configuration docs.

Closes #767

## What is documented

- Direct Anthropic API key usage — no OpenRouter or proxy needed
- OAuth / Pro-Plan token auto-detection (`sk-ant-oat01-` prefix → Bearer auth)
- Custom `base_url` support for proxies/self-hosted
- Full capabilities: streaming, native tool use, vision (multimodal), extended thinking
- Model ID format with `anthropic/` prefix (e.g. `anthropic/claude-sonnet-4-20250514`)
- `--list-models --provider anthropic` tip

## Why

Issue #767 revealed that users did not know NullClaw supports native Anthropic API keys — the minimal config uses OpenRouter, the provider table lists `anthropic` but without explanation, and OAuth token auto-detection is implemented in code but never mentioned in docs.

## Files changed

- `docs/en/configuration.md` — new "Native Anthropic Provider" subsection (after Common per-provider fields)
- `docs/zh/configuration.md` — matching Chinese translation