### PR TITLE
fix(channels): document and harden Weixin iLink QR auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Config: `~/.nullclaw/config.json` (created by `onboard`)
           "host": "irc.libera.chat",
           "port": 6697,
           "nick": "nullclaw",
-          "channel": "#nullclaw",
+          "channels": ["#nullclaw"],
           "tls": true,
           "allow_from": ["user1"]
         },

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -527,6 +527,53 @@ WeChat notes:
 - `allow_from` should list trusted OpenIDs. Keep it explicit; do not rely on an empty allowlist for privacy.
 - Build with `-Dchannels=wechat` (or `-Dchannels=all`) if your binary was compiled without the WeChat channel.
 
+#### Weixin — Personal WeChat Account (QR Code Login)
+
+The `weixin` channel connects to a **personal WeChat account** via the iLink bot API
+using QR code authentication. This is separate from the `wechat` Official Account channel
+above — `weixin` is for personal accounts, not business/public accounts.
+
+First, log in and obtain a token:
+
+```bash
+nullclaw auth login weixin
+```
+
+This renders a QR code in the terminal. Scan it with your WeChat app, confirm login
+on your phone, and the resulting `token` and `base_url` are saved to your config.
+
+After login, add a `weixin` channel entry:
+
+```json
+{
+  "channels": {
+    "weixin": [
+      {
+        "token": "<bot-token-from-qr-login>",
+        "base_url": "https://ilinkai.weixin.qq.com/",
+        "allow_from": ["<your-wechat-user-id>"]
+      }
+    ]
+  }
+}
+```
+
+Weixin channel fields:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `token` | `""` | Bot token from `nullclaw auth login weixin` (required) |
+| `base_url` | `https://ilinkai.weixin.qq.com/` | iLink API base URL (may change after region redirect) |
+| `proxy` | `null` | Optional HTTP proxy URL for API requests |
+| `allow_from` | `[]` | WeChat user IDs allowed to message the bot |
+
+Notes:
+
+- Use `nullclaw auth status weixin` to check whether you are logged in.
+- Use `nullclaw auth login weixin --proxy http://localhost:7890` if behind a proxy.
+- Build with `-Dchannels=weixin` (or `-Dchannels=all`) if your binary was compiled without it.
+- On boot, nullclaw starts the `weixin` polling thread automatically for each configured account.
+
 Telegram forum topics:
 
 - Topic session isolation is automatic; there is no separate `topic_id` field under `channels.telegram`.

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -520,16 +520,17 @@ WeChat example:
 ```json
 {
   "channels": {
-    "wechat": [
-      {
-        "account_id": "main",
-        "callback_token": "wechat-callback-token",
-        "encoding_aes_key": "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG",
-        "app_id": "wx1234567890abcdef",
-        "app_secret": "wechat-app-secret",
-        "allow_from": ["openid_123"]
+    "wechat": {
+      "accounts": {
+        "main": {
+          "callback_token": "wechat-callback-token",
+          "encoding_aes_key": "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG",
+          "app_id": "wx1234567890abcdef",
+          "app_secret": "wechat-app-secret",
+          "allow_from": ["openid_123"]
+        }
       }
-    ]
+    }
   }
 }
 ```
@@ -541,14 +542,13 @@ WeChat notes:
 - `callback_token` is required for signature verification.
 - `encoding_aes_key` is optional but required when your WeChat callback is configured for `encrypt_type=aes`.
 - `app_id` and `app_secret` are optional unless you want outbound active-message delivery through the WeChat custom message API.
-- `allow_from` should list trusted OpenIDs. Keep it explicit; do not rely on an empty allowlist for privacy.
+- An empty `allow_from` denies inbound messages; list trusted OpenIDs explicitly, or use `"*"` only for an intentionally open account.
 - Build with `-Dchannels=wechat` (or `-Dchannels=all`) if your binary was compiled without the WeChat channel.
 
-#### Weixin — Personal WeChat Account (QR Code Login)
+#### Weixin — WeChat iLink Bot (QR Code Login)
 
-The `weixin` channel connects to a **personal WeChat account** via the iLink bot API
-using QR code authentication. This is separate from the `wechat` Official Account channel
-above — `weixin` is for personal accounts, not business/public accounts.
+The `weixin` channel authorizes a WeChat iLink bot by QR code. This is separate
+from the `wechat` Official Account channel above, which uses signed webhooks.
 
 First, log in and obtain a token:
 
@@ -556,21 +556,26 @@ First, log in and obtain a token:
 nullclaw auth login weixin
 ```
 
-This renders a QR code in the terminal. Scan it with your WeChat app, confirm login
-on your phone, and the resulting `token` and `base_url` are saved to your config.
+This renders a QR code in the terminal. Scan it with WeChat and confirm the
+authorization on your phone. The command saves the resulting `token` and, when
+the service returns a non-default host, its `base_url` to your config.
 
-After login, add a `weixin` channel entry:
+After login, edit the Weixin account entry updated by the command to set an
+explicit `allow_from` list. On a new config this is the inline entry shown
+below; an existing `accounts` object keeps its layout. When supplied, the login
+command's `--proxy` value is saved in the same account and reused for runtime
+API requests.
 
 ```json
 {
   "channels": {
-    "weixin": [
-      {
-        "token": "<bot-token-from-qr-login>",
-        "base_url": "https://ilinkai.weixin.qq.com/",
-        "allow_from": ["<your-wechat-user-id>"]
-      }
-    ]
+    "weixin": {
+      "account_id": "default",
+      "token": "<bot-token-from-qr-login>",
+      "base_url": "https://ilinkai.weixin.qq.com/",
+      "proxy": null,
+      "allow_from": ["<your-wechat-user-id>"]
+    }
   }
 }
 ```
@@ -579,17 +584,25 @@ Weixin channel fields:
 
 | Field | Default | Description |
 |-------|---------|-------------|
+| `account_id` | `"default"` | Internal account identifier used by routing and session keys |
 | `token` | `""` | Bot token from `nullclaw auth login weixin` (required) |
-| `base_url` | `https://ilinkai.weixin.qq.com/` | iLink API base URL (may change after region redirect) |
-| `proxy` | `null` | Optional HTTP proxy URL for API requests |
-| `allow_from` | `[]` | WeChat user IDs allowed to message the bot |
+| `base_url` | `https://ilinkai.weixin.qq.com/` | Absolute HTTPS iLink API URL without query/fragment (may change after region redirect) |
+| `proxy` | `null` | Optional `http://`, `https://`, or `socks5://` proxy URL for runtime API requests |
+| `allow_from` | `[]` | Exact WeChat user IDs allowed to message the bot; configure this explicitly |
 
 Notes:
 
-- Use `nullclaw auth status weixin` to check whether you are logged in.
-- Use `nullclaw auth login weixin --proxy http://localhost:7890` if behind a proxy.
+- No inbound messages are accepted until `allow_from` lists trusted user IDs
+  (or the intentional wildcard `"*"`).
+- `nullclaw auth status weixin` reports whether a non-empty token is configured;
+  it does not probe the remote iLink session.
+- Use `nullclaw auth logout weixin` to remove the configured token.
+- Use `nullclaw auth login weixin --proxy http://localhost:7890` when a proxy is
+  required; the command persists it for both login and runtime API requests.
 - Build with `-Dchannels=weixin` (or `-Dchannels=all`) if your binary was compiled without it.
-- On boot, nullclaw starts the `weixin` polling thread automatically for each configured account.
+- `nullclaw gateway` starts and supervises the configured `weixin` polling loop.
+- The current adapter treats inbound conversations as direct messages and sends
+  text replies; group routing and media/file delivery are not implemented.
 
 Telegram forum topics:
 
@@ -782,39 +795,40 @@ Rules:
 - Empty `allow_from` denies inbound messages on allowlist-based channels. Set explicit IDs/OpenIDs for a private bot.
 - `allow_from: ["*"]` allows all sources on allowlist-based channels; use it only when you intentionally want an open bot.
 - Telegram webhooks require `channels.telegram.accounts.<id>.webhook_secret` and Telegram's `X-Telegram-Bot-Api-Secret-Token` header to match.
-- Teams inbound webhooks are authenticated with Bot Framework JWT bearer tokens against Microsoft's OpenID metadata. `channels.teams[].webhook_secret` is optional and, when set, acts as an additional `X-Webhook-Secret` check.
+- Teams inbound webhooks are authenticated with Bot Framework JWT bearer tokens against Microsoft's OpenID metadata. `channels.teams.accounts.<id>.webhook_secret` is optional and, when set, acts as an additional `X-Webhook-Secret` check.
 
 Max example:
 
 ```json
 {
   "channels": {
-    "max": [
-      {
-        "account_id": "main",
-        "bot_token": "MAX_BOT_TOKEN",
-        "allow_from": ["YOUR_MAX_USER_ID"],
-        "group_allow_from": ["YOUR_MAX_USER_ID"],
-        "group_policy": "allowlist",
-        "mode": "webhook",
-        "webhook_url": "https://bot.example.com/max?account_id=main",
-        "webhook_secret": "replace-with-random-secret",
-        "require_mention": true,
-        "streaming": true,
-        "interactive": {
-          "enabled": true,
-          "ttl_secs": 900,
-          "owner_only": true
+    "max": {
+      "accounts": {
+        "main": {
+          "bot_token": "MAX_BOT_TOKEN",
+          "allow_from": ["YOUR_MAX_USER_ID"],
+          "group_allow_from": ["YOUR_MAX_USER_ID"],
+          "group_policy": "allowlist",
+          "mode": "webhook",
+          "webhook_url": "https://bot.example.com/max?account_id=main",
+          "webhook_secret": "replace-with-random-secret",
+          "require_mention": true,
+          "streaming": true,
+          "interactive": {
+            "enabled": true,
+            "ttl_secs": 900,
+            "owner_only": true
+          }
         }
       }
-    ]
+    }
   }
 }
 ```
 
 Max notes:
 
-- `channels.max` is an array of account entries; `account_id` distinguishes multiple Max bots.
+- `channels.max.accounts` is an object of account entries; each object key is the `account_id` that distinguishes multiple Max bots.
 - Prefer `mode = "webhook"` for production. Max documents long polling as suitable for development/testing, while webhooks are the recommended production path.
 - `webhook_url` must be HTTPS.
 - For multi-account webhook setups, give each account either a unique `webhook_secret` or a unique `account_id` query in the webhook URL, for example `/max?account_id=main`.

--- a/docs/en/gateway-api.md
+++ b/docs/en/gateway-api.md
@@ -117,7 +117,7 @@ curl -X POST \
 Max webhook notes:
 
 - `nullclaw` routes `/max` to the configured Max account by `account_id` query first, then by `X-Max-Bot-Api-Secret`.
-- If `channels.max[].webhook_secret` is configured, the header is required and must match exactly.
+- If `channels.max.accounts.<id>.webhook_secret` is configured, the header is required and must match exactly.
 - Use HTTPS in the configured Max-side webhook URL.
 
 Teams webhook notes:
@@ -125,7 +125,7 @@ Teams webhook notes:
 - `nullclaw` validates the Bot Framework bearer token against Microsoft's OpenID metadata and signing keys before accepting the activity.
 - The token issuer must be `https://api.botframework.com`, the audience must match the configured Teams `client_id`, and the token `serviceUrl` must match the activity body.
 - Teams `channelId` endorsements are enforced from the published Bot Framework key metadata.
-- If `channels.teams[].webhook_secret` is configured, `X-Webhook-Secret` must also match exactly.
+- If `channels.teams.accounts.<id>.webhook_secret` is configured, `X-Webhook-Secret` must also match exactly.
 
 ## Media Transcription
 

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -467,6 +467,53 @@ WeChat 说明：
 - `allow_from` 应显式列出可信 OpenID，不要依赖空 allowlist 来实现隐私隔离。
 - 如果当前二进制未编译 WeChat channel，请使用 `-Dchannels=wechat`（或 `-Dchannels=all`）重新构建。
 
+#### Weixin — 个人微信账号（扫码登录）
+
+`weixin` channel 通过 iLink bot API 连接**个人微信账号**，使用 QR 扫码认证。
+这与上方的 `wechat` Official Account channel 不同——`weixin` 用于个人账号，而非
+企业/公众号。
+
+首先，扫码登录获取 token：
+
+```bash
+nullclaw auth login weixin
+```
+
+此命令会在终端渲染 QR 码。用微信 App 扫码并在手机上确认登录后，生成的 `token`
+和 `base_url` 会自动保存到配置文件中。
+
+登录后，添加 `weixin` channel 条目：
+
+```json
+{
+  "channels": {
+    "weixin": [
+      {
+        "token": "<扫码登录获取的 bot token>",
+        "base_url": "https://ilinkai.weixin.qq.com/",
+        "allow_from": ["<你的微信用户 ID>"]
+      }
+    ]
+  }
+}
+```
+
+Weixin channel 字段：
+
+| 字段 | 默认值 | 说明 |
+|------|--------|------|
+| `token` | `""` | 从 `nullclaw auth login weixin` 获取的 bot token（必填） |
+| `base_url` | `https://ilinkai.weixin.qq.com/` | iLink API 基础 URL（地区重定向后可能变化） |
+| `proxy` | `null` | 可选的 HTTP 代理 URL |
+| `allow_from` | `[]` | 允许向 bot 发消息的微信用户 ID 列表 |
+
+说明：
+
+- 使用 `nullclaw auth status weixin` 查看当前登录状态。
+- 如果在代理后方，使用 `nullclaw auth login weixin --proxy http://localhost:7890`。
+- 如果二进制未编译 weixin channel，请使用 `-Dchannels=weixin`（或 `-Dchannels=all`）重新构建。
+- 启动时，nullclaw 会自动为每个已配置的 weixin 账号启动轮询线程。
+
 规则说明：
 
 - 对基于 allowlist 的渠道，空 `allow_from` 会拒绝入站消息；如果要做私有机器人，请显式填写 ID/OpenID。

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -460,16 +460,17 @@ WeChat 示例：
 ```json
 {
   "channels": {
-    "wechat": [
-      {
-        "account_id": "main",
-        "callback_token": "wechat-callback-token",
-        "encoding_aes_key": "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG",
-        "app_id": "wx1234567890abcdef",
-        "app_secret": "wechat-app-secret",
-        "allow_from": ["openid_123"]
+    "wechat": {
+      "accounts": {
+        "main": {
+          "callback_token": "wechat-callback-token",
+          "encoding_aes_key": "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG",
+          "app_id": "wx1234567890abcdef",
+          "app_secret": "wechat-app-secret",
+          "allow_from": ["openid_123"]
+        }
       }
-    ]
+    }
   }
 }
 ```
@@ -481,14 +482,13 @@ WeChat 说明：
 - `callback_token` 是签名校验必填项。
 - `encoding_aes_key` 是可选项；当 WeChat 回调配置为 `encrypt_type=aes` 时必须提供。
 - `app_id` 和 `app_secret` 只有在需要通过 WeChat custom message API 主动发送消息时才需要。
-- `allow_from` 应显式列出可信 OpenID，不要依赖空 allowlist 来实现隐私隔离。
+- 空 `allow_from` 会拒绝入站消息；请显式列出可信 OpenID，仅在有意开放账号时使用 `"*"`。
 - 如果当前二进制未编译 WeChat channel，请使用 `-Dchannels=wechat`（或 `-Dchannels=all`）重新构建。
 
-#### Weixin — 个人微信账号（扫码登录）
+#### Weixin — 微信 iLink Bot（扫码登录）
 
-`weixin` channel 通过 iLink bot API 连接**个人微信账号**，使用 QR 扫码认证。
-这与上方的 `wechat` Official Account channel 不同——`weixin` 用于个人账号，而非
-企业/公众号。
+`weixin` channel 通过二维码授权微信 iLink bot。这与上方使用签名 webhook 的
+`wechat` 公众号 channel 不同。
 
 首先，扫码登录获取 token：
 
@@ -496,21 +496,23 @@ WeChat 说明：
 nullclaw auth login weixin
 ```
 
-此命令会在终端渲染 QR 码。用微信 App 扫码并在手机上确认登录后，生成的 `token`
-和 `base_url` 会自动保存到配置文件中。
+此命令会在终端渲染二维码。使用微信扫码并在手机上确认授权后，命令会把生成的
+`token` 保存到配置文件；如果服务返回了非默认主机，也会保存对应的 `base_url`。
 
-登录后，添加 `weixin` channel 条目：
+登录后，编辑该命令更新的 Weixin 账号条目，显式设置 `allow_from`。新配置会使用
+下方所示的内联条目；已有的 `accounts` 对象会保留原布局。如果登录命令提供了
+`--proxy`，该代理会保存到同一账号，并继续用于运行时 API 请求。
 
 ```json
 {
   "channels": {
-    "weixin": [
-      {
-        "token": "<扫码登录获取的 bot token>",
-        "base_url": "https://ilinkai.weixin.qq.com/",
-        "allow_from": ["<你的微信用户 ID>"]
-      }
-    ]
+    "weixin": {
+      "account_id": "default",
+      "token": "<扫码登录获取的 bot token>",
+      "base_url": "https://ilinkai.weixin.qq.com/",
+      "proxy": null,
+      "allow_from": ["<你的微信用户 ID>"]
+    }
   }
 }
 ```
@@ -519,24 +521,29 @@ Weixin channel 字段：
 
 | 字段 | 默认值 | 说明 |
 |------|--------|------|
+| `account_id` | `"default"` | routing 和 session key 使用的内部账号标识 |
 | `token` | `""` | 从 `nullclaw auth login weixin` 获取的 bot token（必填） |
-| `base_url` | `https://ilinkai.weixin.qq.com/` | iLink API 基础 URL（地区重定向后可能变化） |
-| `proxy` | `null` | 可选的 HTTP 代理 URL |
-| `allow_from` | `[]` | 允许向 bot 发消息的微信用户 ID 列表 |
+| `base_url` | `https://ilinkai.weixin.qq.com/` | 不含 query/fragment 的绝对 HTTPS iLink API URL（地区重定向后可能变化） |
+| `proxy` | `null` | 运行时 API 请求使用的可选 `http://`、`https://` 或 `socks5://` 代理 URL |
+| `allow_from` | `[]` | 允许向 bot 发消息的精确微信用户 ID 列表；请显式配置 |
 
 说明：
 
-- 使用 `nullclaw auth status weixin` 查看当前登录状态。
-- 如果在代理后方，使用 `nullclaw auth login weixin --proxy http://localhost:7890`。
+- 在 `allow_from` 列出可信用户 ID（或明确使用通配符 `"*"`）之前，不会接受任何入站消息。
+- `nullclaw auth status weixin` 只报告是否配置了非空 token，不会探测远端 iLink session。
+- 使用 `nullclaw auth logout weixin` 删除已配置的 token。
+- 需要代理时，使用 `nullclaw auth login weixin --proxy http://localhost:7890`；
+  该命令会保存代理，供登录流程和运行时 API 请求共同使用。
 - 如果二进制未编译 weixin channel，请使用 `-Dchannels=weixin`（或 `-Dchannels=all`）重新构建。
-- 启动时，nullclaw 会自动为每个已配置的 weixin 账号启动轮询线程。
+- `nullclaw gateway` 会启动并监管已配置的 `weixin` 轮询循环。
+- 当前 adapter 把入站会话视为私聊并发送文本回复；尚未实现群聊 routing 和媒体/文件投递。
 
 规则说明：
 
 - 对基于 allowlist 的渠道，空 `allow_from` 会拒绝入站消息；如果要做私有机器人，请显式填写 ID/OpenID。
 - `allow_from: ["*"]` 会在基于 allowlist 的渠道上允许所有来源，仅在你明确接受风险时使用。
 - Telegram webhook 必须配置 `channels.telegram.accounts.<id>.webhook_secret`，并要求 Telegram 的 `X-Telegram-Bot-Api-Secret-Token` header 匹配。
-- Teams 入站 webhook 现在会使用 Bot Framework JWT bearer token 并对照 Microsoft OpenID metadata 做认证。`channels.teams[].webhook_secret` 变为可选项；如果配置，会额外要求 `X-Webhook-Secret` 匹配。
+- Teams 入站 webhook 现在会使用 Bot Framework JWT bearer token 并对照 Microsoft OpenID metadata 做认证。`channels.teams.accounts.<id>.webhook_secret` 变为可选项；如果配置，会额外要求 `X-Webhook-Secret` 匹配。
 
 Telegram forum topics：
 
@@ -719,32 +726,33 @@ Max 示例：
 ```json
 {
   "channels": {
-    "max": [
-      {
-        "account_id": "main",
-        "bot_token": "MAX_BOT_TOKEN",
-        "allow_from": ["YOUR_MAX_USER_ID"],
-        "group_allow_from": ["YOUR_MAX_USER_ID"],
-        "group_policy": "allowlist",
-        "mode": "webhook",
-        "webhook_url": "https://bot.example.com/max?account_id=main",
-        "webhook_secret": "replace-with-random-secret",
-        "require_mention": true,
-        "streaming": true,
-        "interactive": {
-          "enabled": true,
-          "ttl_secs": 900,
-          "owner_only": true
+    "max": {
+      "accounts": {
+        "main": {
+          "bot_token": "MAX_BOT_TOKEN",
+          "allow_from": ["YOUR_MAX_USER_ID"],
+          "group_allow_from": ["YOUR_MAX_USER_ID"],
+          "group_policy": "allowlist",
+          "mode": "webhook",
+          "webhook_url": "https://bot.example.com/max?account_id=main",
+          "webhook_secret": "replace-with-random-secret",
+          "require_mention": true,
+          "streaming": true,
+          "interactive": {
+            "enabled": true,
+            "ttl_secs": 900,
+            "owner_only": true
+          }
         }
       }
-    ]
+    }
   }
 }
 ```
 
 Max 说明：
 
-- `channels.max` 是账号条目数组；`account_id` 用于区分多个 Max bot。
+- `channels.max.accounts` 是账号条目对象；每个对象 key 就是用于区分多个 Max bot 的 `account_id`。
 - 生产环境推荐 `mode = "webhook"`。Max 文档将 long polling 定位为开发/测试用途，webhook 是推荐的生产路径。
 - `webhook_url` 必须使用 HTTPS。
 - 多账号 webhook 场景下，每个账号应使用独立的 `webhook_secret` 或在 webhook URL 中使用独立的 `account_id` query，例如 `/max?account_id=main`。

--- a/docs/zh/gateway-api.md
+++ b/docs/zh/gateway-api.md
@@ -103,7 +103,7 @@ curl -X POST \
 Max webhook 说明：
 
 - `nullclaw` 对 `/max` 路由优先按 `account_id` query 参数匹配，其次按 `X-Max-Bot-Api-Secret` 匹配。
-- 如果 `channels.max[].webhook_secret` 已配置，header 必须存在且完全匹配。
+- 如果 `channels.max.accounts.<id>.webhook_secret` 已配置，header 必须存在且完全匹配。
 - Max 侧配置的 webhook URL 必须使用 HTTPS。
 
 Teams webhook 说明：
@@ -111,7 +111,7 @@ Teams webhook 说明：
 - `nullclaw` 会先用 Microsoft 发布的 OpenID metadata 和 signing keys 验证 Bot Framework bearer token，再接受该 activity。
 - token 的 issuer 必须是 `https://api.botframework.com`，audience 必须匹配配置中的 Teams `client_id`，并且 token 中的 `serviceUrl` 必须与 activity body 一致。
 - 会按 Bot Framework key metadata 中公布的 endorsement 校验 Teams `channelId`。
-- 如果配置了 `channels.teams[].webhook_secret`，还会额外要求 `X-Webhook-Secret` 精确匹配。
+- 如果配置了 `channels.teams.accounts.<id>.webhook_secret`，还会额外要求 `X-Webhook-Secret` 精确匹配。
 
 ## Media Transcription
 

--- a/examples/meshrelay/README.md
+++ b/examples/meshrelay/README.md
@@ -67,7 +67,7 @@ NullClaw supports multiple IRC accounts simultaneously. You can connect to both 
           "host": "irc.libera.chat",
           "port": 6697,
           "nick": "my-agent",
-          "channel": "#my-channel",
+        "channels": ["#my-channel"],
           "tls": true,
           "allow_from": ["my-username"]
         },

--- a/src/channels/irc.zig
+++ b/src/channels/irc.zig
@@ -241,7 +241,7 @@ pub const IrcChannel = struct {
 
         const sender_nick = parsed.nick() orelse return;
         if (IrcChannel.isServiceBot(sender_nick)) return;
-        if (self.allow_from.len > 0 and !self.isUserAllowed(sender_nick)) return;
+        if (!self.isUserAllowed(sender_nick)) return;
 
         const target = parsed.params[0];
         const text = std.mem.trim(u8, parsed.params[parsed.params.len - 1], " \t\r\n");
@@ -1017,6 +1017,21 @@ test "irc handleInboundLine drops disallowed sender" {
     ch.setBus(&eb);
 
     try ch.handleInboundLine(":mallory!u@h PRIVMSG #general :hello team\r\n");
+    eb.close();
+    try std.testing.expect(eb.consumeInbound() == null);
+}
+
+test "irc handleInboundLine empty allow_from denies sender" {
+    const alloc = std.testing.allocator;
+    var eb = bus_mod.Bus.init();
+    defer eb.close();
+
+    var ch = IrcChannel.init(alloc, "irc.test", 6667, "mybot", null, &.{}, &.{}, null, null, null, false);
+    ch.account_id = "irc-main";
+    ch.setBus(&eb);
+
+    // Regression: IRC authentication does not replace sender authorization.
+    try ch.handleInboundLine(":alice!u@h PRIVMSG #general :hello team\r\n");
     eb.close();
     try std.testing.expect(eb.consumeInbound() == null);
 }

--- a/src/channels/onebot.zig
+++ b/src/channels/onebot.zig
@@ -267,7 +267,7 @@ pub const OneBotChannel = struct {
         const user_str = std.fmt.bufPrint(&user_buf, "{d}", .{user_id}) catch return;
 
         // Allowlist check
-        if (self.config.allow_from.len > 0 and !root.isAllowedScoped("onebot channel", self.config.allow_from, user_str)) return;
+        if (!root.isAllowedScoped("onebot channel", self.config.allow_from, user_str)) return;
 
         // Extract chat_id (group_id for group messages, user_id for private)
         const chat_id_int = if (is_group) getJsonInt(val, "group_id") orelse return else user_id;
@@ -949,7 +949,10 @@ test "handleEvent private message" {
     var event_bus_inst = bus.Bus.init();
     defer event_bus_inst.close();
 
-    var ch = OneBotChannel.init(alloc, .{ .account_id = "onebot-main" });
+    var ch = OneBotChannel.init(alloc, .{
+        .account_id = "onebot-main",
+        .allow_from = &.{"12345"},
+    });
     ch.setBus(&event_bus_inst);
     ch.running.store(true, .release);
 
@@ -977,6 +980,7 @@ test "handleEvent group message with prefix" {
 
     var ch = OneBotChannel.init(alloc, .{
         .group_trigger_prefix = "/bot",
+        .allow_from = &.{"111"},
     });
     ch.setBus(&event_bus_inst);
     ch.running.store(true, .release);
@@ -1002,6 +1006,7 @@ test "handleEvent group message without prefix skipped" {
 
     var ch = OneBotChannel.init(alloc, .{
         .group_trigger_prefix = "/bot",
+        .allow_from = &.{"111"},
     });
     ch.setBus(&event_bus_inst);
     ch.running.store(true, .release);
@@ -1021,7 +1026,7 @@ test "handleEvent deduplication" {
     var event_bus_inst = bus.Bus.init();
     defer event_bus_inst.close();
 
-    var ch = OneBotChannel.init(alloc, .{});
+    var ch = OneBotChannel.init(alloc, .{ .allow_from = &.{"42"} });
     ch.setBus(&event_bus_inst);
     ch.running.store(true, .release);
 
@@ -1074,7 +1079,7 @@ test "handleEvent with CQ tags in message" {
     var event_bus_inst = bus.Bus.init();
     defer event_bus_inst.close();
 
-    var ch = OneBotChannel.init(alloc, .{});
+    var ch = OneBotChannel.init(alloc, .{ .allow_from = &.{"55"} });
     ch.setBus(&event_bus_inst);
 
     const event_json =
@@ -1097,6 +1102,7 @@ test "handleEvent group message with mention passes prefix check" {
 
     var ch = OneBotChannel.init(alloc, .{
         .group_trigger_prefix = "/bot",
+        .allow_from = &.{"77"},
     });
     ch.setBus(&event_bus_inst);
 
@@ -1155,7 +1161,7 @@ test "handleEvent allow_from permits listed user" {
     try std.testing.expectEqualStrings("allowed user", msg.content);
 }
 
-test "handleEvent allow_from empty allows all" {
+test "handleEvent empty allow_from denies all" {
     const alloc = std.testing.allocator;
     var event_bus_inst = bus.Bus.init();
     defer event_bus_inst.close();
@@ -1170,9 +1176,8 @@ test "handleEvent allow_from empty allows all" {
     ;
     try ch.handleEvent(event_json);
 
-    var msg = event_bus_inst.consumeInbound() orelse return try std.testing.expect(false);
-    defer msg.deinit(alloc);
-    try std.testing.expectEqualStrings("anyone allowed", msg.content);
+    // Regression: an omitted OneBot allowlist must fail closed.
+    try std.testing.expectEqual(@as(usize, 0), event_bus_inst.inboundDepth());
 }
 
 test "extractParam finds correct values" {

--- a/src/channels/weixin.zig
+++ b/src/channels/weixin.zig
@@ -6,7 +6,7 @@ const config_types = @import("../config_types.zig");
 const qr_mod = @import("../qr.zig");
 const url_percent = @import("../url_percent.zig");
 
-const ILINK_BASE_URL = "https://ilinkai.weixin.qq.com/";
+const ILINK_BASE_URL = config_types.WeixinConfig.DEFAULT_BASE_URL;
 const ILINK_APP_ID = "bot";
 const ILINK_CLIENT_VERSION = "131329"; // 2.1.1 encoded as 0x00020101
 const CHANNEL_VERSION = "2.1.1";
@@ -181,7 +181,10 @@ pub const WeixinChannel = struct {
             &headers.headers,
             self.config.proxy,
             SEND_TIMEOUT_SECS,
-        ) catch return error.WeixinApiError;
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.WeixinApiError,
+        };
         defer self.allocator.free(resp_body);
 
         try ensureApiResponseOk(self.allocator, resp_body);
@@ -208,7 +211,10 @@ pub const WeixinChannel = struct {
             &headers.headers,
             self.config.proxy,
             GET_UPDATES_TIMEOUT_SECS,
-        ) catch return error.WeixinApiError;
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.WeixinApiError,
+        };
         defer self.allocator.free(resp_body);
 
         var parsed = try parseGetUpdatesResponse(allocator, resp_body, self.config.allow_from);
@@ -303,6 +309,11 @@ pub const WeixinChannel = struct {
 pub const QrCodeResponse = struct {
     qrcode: []const u8 = "",
     qrcode_img_content: []const u8 = "",
+
+    fn deinit(self: *const QrCodeResponse, allocator: std.mem.Allocator) void {
+        allocator.free(self.qrcode);
+        allocator.free(self.qrcode_img_content);
+    }
 };
 
 pub const StatusResponse = struct {
@@ -312,6 +323,15 @@ pub const StatusResponse = struct {
     baseurl: []const u8 = "",
     ilink_user_id: []const u8 = "",
     redirect_host: []const u8 = "",
+
+    fn deinit(self: *const StatusResponse, allocator: std.mem.Allocator) void {
+        allocator.free(self.status);
+        allocator.free(self.bot_token);
+        allocator.free(self.ilink_bot_id);
+        allocator.free(self.baseurl);
+        allocator.free(self.ilink_user_id);
+        allocator.free(self.redirect_host);
+    }
 };
 
 pub const LoginResult = struct {
@@ -337,18 +357,24 @@ pub const LoginOptions = struct {
 // ── QR Login Flow ──────────────────────────────────────────────────
 
 pub fn performLogin(allocator: std.mem.Allocator, opts: LoginOptions) !LoginResult {
+    if (!isValidBaseUrl(opts.base_url)) return error.InvalidWeixinBaseUrl;
+    if (opts.proxy) |proxy| {
+        if (!config_types.WeixinConfig.isValidProxyUrl(proxy)) return error.InvalidWeixinProxyUrl;
+    }
+
     if (builtin.is_test) {
-        return LoginResult{
-            .bot_token = try allocator.dupe(u8, "test-bot-token"),
-            .user_id = try allocator.dupe(u8, "test-user-id"),
-            .account_id = try allocator.dupe(u8, "test-account-id"),
-            .base_url = try allocator.dupe(u8, "https://test.example.com/"),
-        };
+        const bot_token = try allocator.dupe(u8, "test-bot-token");
+        errdefer allocator.free(bot_token);
+        const user_id = try allocator.dupe(u8, "test-user-id");
+        errdefer allocator.free(user_id);
+        const account_id = try allocator.dupe(u8, "test-account-id");
+        errdefer allocator.free(account_id);
+        const base_url = try allocator.dupe(u8, "https://test.example.com/");
+        return .{ .bot_token = bot_token, .user_id = user_id, .account_id = account_id, .base_url = base_url };
     }
 
     const qr_resp = try requestQrCode(allocator, opts.base_url, opts.proxy);
-    defer allocator.free(qr_resp.qrcode);
-    defer allocator.free(qr_resp.qrcode_img_content);
+    defer qr_resp.deinit(allocator);
 
     // Display QR code in terminal
     try displayQrCode(qr_resp.qrcode_img_content);
@@ -364,15 +390,12 @@ pub fn performLogin(allocator: std.mem.Allocator, opts: LoginOptions) !LoginResu
         std_compat.thread.sleep(QR_POLL_INTERVAL_NS);
 
         const effective_base = if (poll_base_url) |u| u else opts.base_url;
-        const status_resp = pollQrStatus(allocator, effective_base, qr_resp.qrcode, opts.proxy) catch continue;
-        defer {
-            allocator.free(status_resp.status);
-            allocator.free(status_resp.bot_token);
-            allocator.free(status_resp.ilink_bot_id);
-            allocator.free(status_resp.baseurl);
-            allocator.free(status_resp.ilink_user_id);
-            allocator.free(status_resp.redirect_host);
-        }
+        const status_resp = pollQrStatus(allocator, effective_base, qr_resp.qrcode, opts.proxy) catch |err| switch (err) {
+            // Allocation failure is not a transient transport error; retrying only masks it as a timeout.
+            error.OutOfMemory => return err,
+            else => continue,
+        };
+        defer status_resp.deinit(allocator);
 
         if (std.mem.eql(u8, status_resp.status, "wait")) {
             continue;
@@ -385,21 +408,20 @@ pub fn performLogin(allocator: std.mem.Allocator, opts: LoginOptions) !LoginResu
             if (status_resp.bot_token.len == 0 or status_resp.ilink_bot_id.len == 0) {
                 return error.WeixinLoginMissingCredentials;
             }
-            const result_base = if (status_resp.baseurl.len > 0)
-                try allocator.dupe(u8, status_resp.baseurl)
-            else
-                try allocator.dupe(u8, opts.base_url);
-            errdefer allocator.free(result_base);
+            const result_base_source = if (status_resp.baseurl.len > 0) status_resp.baseurl else opts.base_url;
+            if (!isValidBaseUrl(result_base_source)) return error.InvalidWeixinBaseUrl;
 
-            return LoginResult{
-                .bot_token = try allocator.dupe(u8, status_resp.bot_token),
-                .user_id = try allocator.dupe(u8, status_resp.ilink_user_id),
-                .account_id = try allocator.dupe(u8, status_resp.ilink_bot_id),
-                .base_url = result_base,
-            };
+            const result_base = try allocator.dupe(u8, result_base_source);
+            errdefer allocator.free(result_base);
+            const bot_token = try allocator.dupe(u8, status_resp.bot_token);
+            errdefer allocator.free(bot_token);
+            const user_id = try allocator.dupe(u8, status_resp.ilink_user_id);
+            errdefer allocator.free(user_id);
+            const account_id = try allocator.dupe(u8, status_resp.ilink_bot_id);
+            return .{ .bot_token = bot_token, .user_id = user_id, .account_id = account_id, .base_url = result_base };
         } else if (std.mem.eql(u8, status_resp.status, "scaned_but_redirect")) {
             if (status_resp.redirect_host.len > 0) {
-                const new_url = try std.fmt.allocPrint(allocator, "https://{s}/", .{status_resp.redirect_host});
+                const new_url = try buildRedirectBaseUrl(allocator, status_resp.redirect_host);
                 if (poll_base_url) |old| allocator.free(old);
                 poll_base_url = new_url;
                 std.debug.print("Switched polling host to {s}\n", .{status_resp.redirect_host});
@@ -462,27 +484,69 @@ fn buildWechatUinHeader(allocator: std.mem.Allocator) ![]u8 {
     return std.fmt.allocPrint(allocator, "X-WECHAT-UIN: {s}", .{encoded});
 }
 
+/// iLink requests carry bot credentials, so remote base URLs must use HTTPS
+/// and must not contain a query or fragment that could alter API endpoints.
+pub fn isValidBaseUrl(raw: []const u8) bool {
+    return config_types.WeixinConfig.isValidBaseUrl(raw);
+}
+
 fn buildUrl(allocator: std.mem.Allocator, base_url: []const u8, endpoint: []const u8) ![]u8 {
+    if (!isValidBaseUrl(base_url)) return error.InvalidWeixinBaseUrl;
+
     var base_end = base_url.len;
     while (base_end > 0 and base_url[base_end - 1] == '/') : (base_end -= 1) {}
     const base = base_url[0..base_end];
-    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ base, endpoint });
+
+    var endpoint_start: usize = 0;
+    while (endpoint_start < endpoint.len and endpoint[endpoint_start] == '/') : (endpoint_start += 1) {}
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ base, endpoint[endpoint_start..] });
 }
 
-fn requestQrCode(allocator: std.mem.Allocator, base_url: []const u8, proxy: ?[]const u8) !struct { qrcode: []u8, qrcode_img_content: []u8 } {
-    const url = try std.fmt.allocPrint(allocator, "{s}ilink/bot/get_bot_qrcode?bot_type=3", .{
-        if (std.mem.endsWith(u8, base_url, "/")) base_url else blk: {
-            // base_url always ends with / from default
-            break :blk base_url;
-        },
-    });
+fn buildQrCodeUrl(allocator: std.mem.Allocator, base_url: []const u8) ![]u8 {
+    return buildUrl(allocator, base_url, "ilink/bot/get_bot_qrcode?bot_type=3");
+}
+
+fn buildQrStatusUrl(allocator: std.mem.Allocator, base_url: []const u8, qrcode: []const u8) ![]u8 {
+    const encoded_qrcode = try url_percent.encode(allocator, qrcode);
+    defer allocator.free(encoded_qrcode);
+
+    const endpoint = try std.fmt.allocPrint(allocator, "ilink/bot/get_qrcode_status?qrcode={s}", .{encoded_qrcode});
+    defer allocator.free(endpoint);
+    return buildUrl(allocator, base_url, endpoint);
+}
+
+fn buildRedirectBaseUrl(allocator: std.mem.Allocator, redirect_host: []const u8) ![]u8 {
+    if (redirect_host.len == 0 or std.mem.indexOfAny(u8, redirect_host, "/\\@?#% \t\r\n") != null) {
+        return error.InvalidWeixinBaseUrl;
+    }
+    const base_url = try std.fmt.allocPrint(allocator, "https://{s}/", .{redirect_host});
+    errdefer allocator.free(base_url);
+    if (!isValidBaseUrl(base_url)) return error.InvalidWeixinBaseUrl;
+    return base_url;
+}
+
+fn dupeQrCodeResponse(allocator: std.mem.Allocator, qrcode: []const u8, image: []const u8) !QrCodeResponse {
+    const owned_qrcode = try allocator.dupe(u8, qrcode);
+    errdefer allocator.free(owned_qrcode);
+    const owned_image = try allocator.dupe(u8, image);
+    return .{ .qrcode = owned_qrcode, .qrcode_img_content = owned_image };
+}
+
+fn requestQrCode(allocator: std.mem.Allocator, base_url: []const u8, proxy: ?[]const u8) !QrCodeResponse {
+    const url = try buildQrCodeUrl(allocator, base_url);
     defer allocator.free(url);
 
     const headers = ilinkHeaders();
-    const resp_body = root.http_util.curlGetWithProxy(allocator, url, &headers, SEND_TIMEOUT_SECS, proxy) catch return error.WeixinApiError;
+    const resp_body = root.http_util.curlGetWithProxy(allocator, url, &headers, SEND_TIMEOUT_SECS, proxy) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.WeixinApiError,
+    };
     defer allocator.free(resp_body);
 
-    var parsed = std.json.parseFromSlice(std.json.Value, allocator, resp_body, .{}) catch return error.WeixinApiError;
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, resp_body, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.WeixinApiError,
+    };
     defer parsed.deinit();
 
     if (parsed.value != .object) return error.WeixinApiError;
@@ -493,28 +557,28 @@ fn requestQrCode(allocator: std.mem.Allocator, base_url: []const u8, proxy: ?[]c
     if (qrcode_val != .string or img_val != .string) return error.WeixinApiError;
     if (qrcode_val.string.len == 0) return error.WeixinApiError;
 
-    return .{
-        .qrcode = try allocator.dupe(u8, qrcode_val.string),
-        .qrcode_img_content = try allocator.dupe(u8, img_val.string),
-    };
+    return dupeQrCodeResponse(allocator, qrcode_val.string, img_val.string);
 }
 
 fn pollQrStatus(allocator: std.mem.Allocator, base_url: []const u8, qrcode: []const u8, proxy: ?[]const u8) !StatusResponse {
-    const base = if (std.mem.endsWith(u8, base_url, "/")) base_url else base_url;
-    const encoded_qrcode = try url_percent.encode(allocator, qrcode);
-    defer allocator.free(encoded_qrcode);
-    const url = try std.fmt.allocPrint(allocator, "{s}ilink/bot/get_qrcode_status?qrcode={s}", .{ base, encoded_qrcode });
+    const url = try buildQrStatusUrl(allocator, base_url, qrcode);
     defer allocator.free(url);
 
     const headers = ilinkHeaders();
-    const resp_body = root.http_util.curlGetWithProxy(allocator, url, &headers, GET_UPDATES_TIMEOUT_SECS, proxy) catch return error.WeixinApiError;
+    const resp_body = root.http_util.curlGetWithProxy(allocator, url, &headers, GET_UPDATES_TIMEOUT_SECS, proxy) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.WeixinApiError,
+    };
     defer allocator.free(resp_body);
 
     return parseStatusResponse(allocator, resp_body);
 }
 
 pub fn parseStatusResponse(allocator: std.mem.Allocator, json_body: []const u8) !StatusResponse {
-    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_body, .{}) catch return error.WeixinApiError;
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_body, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.WeixinApiError,
+    };
     defer parsed.deinit();
 
     if (parsed.value != .object) return error.WeixinApiError;
@@ -523,13 +587,24 @@ pub fn parseStatusResponse(allocator: std.mem.Allocator, json_body: []const u8) 
     const status = obj.get("status") orelse return error.WeixinApiError;
     if (status != .string) return error.WeixinApiError;
 
-    return StatusResponse{
-        .status = try allocator.dupe(u8, status.string),
-        .bot_token = try dupeOptionalString(allocator, obj, "bot_token"),
-        .ilink_bot_id = try dupeOptionalString(allocator, obj, "ilink_bot_id"),
-        .baseurl = try dupeOptionalString(allocator, obj, "baseurl"),
-        .ilink_user_id = try dupeOptionalString(allocator, obj, "ilink_user_id"),
-        .redirect_host = try dupeOptionalString(allocator, obj, "redirect_host"),
+    const owned_status = try allocator.dupe(u8, status.string);
+    errdefer allocator.free(owned_status);
+    const bot_token = try dupeOptionalString(allocator, obj, "bot_token");
+    errdefer allocator.free(bot_token);
+    const ilink_bot_id = try dupeOptionalString(allocator, obj, "ilink_bot_id");
+    errdefer allocator.free(ilink_bot_id);
+    const baseurl = try dupeOptionalString(allocator, obj, "baseurl");
+    errdefer allocator.free(baseurl);
+    const ilink_user_id = try dupeOptionalString(allocator, obj, "ilink_user_id");
+    errdefer allocator.free(ilink_user_id);
+    const redirect_host = try dupeOptionalString(allocator, obj, "redirect_host");
+    return .{
+        .status = owned_status,
+        .bot_token = bot_token,
+        .ilink_bot_id = ilink_bot_id,
+        .baseurl = baseurl,
+        .ilink_user_id = ilink_user_id,
+        .redirect_host = redirect_host,
     };
 }
 
@@ -658,7 +733,10 @@ fn parseGetUpdatesResponse(
 ) !ParsedUpdates {
     var parsed = std.json.parseFromSlice(GetUpdatesResponse, allocator, json_body, .{
         .ignore_unknown_fields = true,
-    }) catch return error.WeixinApiError;
+    }) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.WeixinApiError,
+    };
     defer parsed.deinit();
 
     if (parsed.value.ret) |ret| {
@@ -680,18 +758,24 @@ fn parseGetUpdatesResponse(
     for (inbound_messages) |message| {
         const sender = message.from_user_id orelse continue;
         if (sender.len == 0) continue;
-        if (allow_from.len > 0 and !root.isAllowedExactScoped("weixin channel", allow_from, sender)) {
+        if (!root.isAllowedExactScoped("weixin channel", allow_from, sender)) {
             continue;
         }
 
         const text = extractInboundText(message.item_list) orelse continue;
         const reply_target = try encodeReplyTarget(allocator, sender, message.context_token);
         errdefer allocator.free(reply_target);
+        const owned_id = try buildInboundMessageId(allocator, message, sender);
+        errdefer allocator.free(owned_id);
+        const owned_sender = try allocator.dupe(u8, sender);
+        errdefer allocator.free(owned_sender);
+        const owned_content = try allocator.dupe(u8, text);
+        errdefer allocator.free(owned_content);
 
         try messages.append(allocator, .{
-            .id = try buildInboundMessageId(allocator, message, sender),
-            .sender = try allocator.dupe(u8, sender),
-            .content = try allocator.dupe(u8, text),
+            .id = owned_id,
+            .sender = owned_sender,
+            .content = owned_content,
             .channel = "weixin",
             .timestamp = message.create_time_ms orelse 0,
             .reply_target = reply_target,
@@ -700,12 +784,19 @@ fn parseGetUpdatesResponse(
         });
     }
 
+    const owned_messages = try messages.toOwnedSlice(allocator);
+    errdefer {
+        for (owned_messages) |*message| message.deinit(allocator);
+        if (owned_messages.len > 0) allocator.free(owned_messages);
+    }
+    const next_updates_buf = if (parsed.value.get_updates_buf) |next_updates_buf|
+        try allocator.dupe(u8, next_updates_buf)
+    else
+        null;
+
     return .{
-        .messages = try messages.toOwnedSlice(allocator),
-        .next_updates_buf = if (parsed.value.get_updates_buf) |next_updates_buf|
-            try allocator.dupe(u8, next_updates_buf)
-        else
-            null,
+        .messages = owned_messages,
+        .next_updates_buf = next_updates_buf,
         .longpolling_timeout_ms = parsed.value.longpolling_timeout_ms,
     };
 }
@@ -721,7 +812,10 @@ fn ensureApiResponseOk(allocator: std.mem.Allocator, body: []const u8) !void {
 
     var parsed = std.json.parseFromSlice(Response, allocator, trimmed, .{
         .ignore_unknown_fields = true,
-    }) catch return error.WeixinApiError;
+    }) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return error.WeixinApiError,
+    };
     defer parsed.deinit();
 
     if (parsed.value.ret) |ret| {
@@ -807,6 +901,49 @@ test "parseStatusResponse rejects missing status field" {
     try std.testing.expectError(error.WeixinApiError, parseStatusResponse(std.testing.allocator, "{}"));
 }
 
+fn parseStatusAllocationTest(allocator: std.mem.Allocator) !void {
+    const json =
+        \\{"status":"confirmed","bot_token":"token","ilink_bot_id":"bot","baseurl":"https://example.com/","ilink_user_id":"user","redirect_host":"region.example.com"}
+    ;
+    const response = try parseStatusResponse(allocator, json);
+    defer response.deinit(allocator);
+}
+
+test "parseStatusResponse frees partial results on allocation failure" {
+    // Regression: every owned response field allocated before OOM must be released.
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, parseStatusAllocationTest, .{});
+}
+
+fn parseUpdatesAllocationTest(allocator: std.mem.Allocator) !void {
+    const json =
+        \\{"ret":0,"msgs":[{"message_id":1,"from_user_id":"user-1","context_token":"ctx-1","item_list":[{"type":1,"text_item":{"text":"one"}}]},{"message_id":2,"from_user_id":"user-2","context_token":"ctx-2","item_list":[{"type":1,"text_item":{"text":"two"}}]}],"get_updates_buf":"next-buf"}
+    ;
+    var updates = try parseGetUpdatesResponse(allocator, json, &.{"*"});
+    defer updates.deinit(allocator);
+}
+
+test "parseGetUpdatesResponse frees partial results on allocation failure" {
+    // Regression: partially constructed messages and the owned result slice must not leak on OOM.
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, parseUpdatesAllocationTest, .{});
+}
+
+fn ensureApiResponseAllocationTest(allocator: std.mem.Allocator) !void {
+    try ensureApiResponseOk(allocator, "{\"ret\":0,\"errcode\":0}");
+}
+
+test "ensureApiResponseOk preserves allocation failures" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, ensureApiResponseAllocationTest, .{});
+}
+
+fn qrCodeResponseAllocationTest(allocator: std.mem.Allocator) !void {
+    const response = try dupeQrCodeResponse(allocator, "qr-id", "https://example.com/qr");
+    defer response.deinit(allocator);
+}
+
+test "QR response duplication frees partial results on allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, qrCodeResponseAllocationTest, .{});
+}
+
 test "appendSendMessagePayload builds correct JSON" {
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
@@ -841,7 +978,7 @@ test "parseGetUpdatesResponse extracts text message and context token" {
         \\{"ret":0,"msgs":[{"message_id":42,"from_user_id":"user-123","create_time_ms":1712345678901,"context_token":"ctx-456","item_list":[{"type":1,"text_item":{"text":"hello from weixin"}}]}],"get_updates_buf":"next-buf"}
     ;
 
-    var parsed = try parseGetUpdatesResponse(std.testing.allocator, json, &.{});
+    var parsed = try parseGetUpdatesResponse(std.testing.allocator, json, &.{"user-123"});
     defer parsed.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 1), parsed.messages.len);
@@ -866,6 +1003,30 @@ test "parseGetUpdatesResponse filters allow_from when configured" {
     try std.testing.expectEqualStrings("allowed", parsed.messages[0].sender);
 }
 
+test "parseGetUpdatesResponse empty allow_from denies all senders" {
+    // Regression: an empty Weixin allowlist must fail closed instead of accepting every sender.
+    const json =
+        \\{"ret":0,"msgs":[{"from_user_id":"user-123","item_list":[{"type":1,"text_item":{"text":"blocked"}}]}]}
+    ;
+
+    var parsed = try parseGetUpdatesResponse(std.testing.allocator, json, &.{});
+    defer parsed.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), parsed.messages.len);
+}
+
+test "parseGetUpdatesResponse wildcard allow_from accepts sender" {
+    const json =
+        \\{"ret":0,"msgs":[{"from_user_id":"user-123","item_list":[{"type":1,"text_item":{"text":"allowed"}}]}]}
+    ;
+
+    var parsed = try parseGetUpdatesResponse(std.testing.allocator, json, &.{"*"});
+    defer parsed.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), parsed.messages.len);
+    try std.testing.expectEqualStrings("user-123", parsed.messages[0].sender);
+}
+
 test "weixin channel stores latest context token per user" {
     var ch = WeixinChannel.init(std.testing.allocator, .{});
     defer ch.deinit();
@@ -887,11 +1048,93 @@ test "buildUrl handles base without trailing slash" {
     try std.testing.expectEqualStrings("https://example.com/ilink/bot/test", url);
 }
 
+test "weixin base URL requires HTTPS host without query or fragment" {
+    try std.testing.expect(isValidBaseUrl("https://example.com/ilink/"));
+    try std.testing.expect(!isValidBaseUrl("http://example.com/"));
+    try std.testing.expect(!isValidBaseUrl("https:///missing-host"));
+    try std.testing.expect(!isValidBaseUrl("https://example.com/?region=1"));
+    try std.testing.expect(!isValidBaseUrl("https://example.com/#fragment"));
+    try std.testing.expect(!isValidBaseUrl("https://user:password@example.com/"));
+    try std.testing.expect(!isValidBaseUrl("https://example.com:0/"));
+    try std.testing.expect(!isValidBaseUrl("not-a-url"));
+}
+
+test "buildUrl rejects invalid credential-bearing base URL" {
+    try std.testing.expectError(
+        error.InvalidWeixinBaseUrl,
+        buildUrl(std.testing.allocator, "http://example.com", "ilink/bot/test"),
+    );
+}
+
+test "QR URLs join bases with or without trailing slash" {
+    for ([_][]const u8{ "https://example.com/", "https://example.com" }) |base_url| {
+        const qr_code_url = try buildQrCodeUrl(std.testing.allocator, base_url);
+        defer std.testing.allocator.free(qr_code_url);
+        try std.testing.expectEqualStrings(
+            "https://example.com/ilink/bot/get_bot_qrcode?bot_type=3",
+            qr_code_url,
+        );
+
+        const status_url = try buildQrStatusUrl(std.testing.allocator, base_url, "qr value/+?");
+        defer std.testing.allocator.free(status_url);
+        try std.testing.expectEqualStrings(
+            "https://example.com/ilink/bot/get_qrcode_status?qrcode=qr%20value%2F%2B%3F",
+            status_url,
+        );
+    }
+}
+
+test "redirect base URL rejects injected query or fragment" {
+    const valid_url = try buildRedirectBaseUrl(std.testing.allocator, "region.example.com:443");
+    defer std.testing.allocator.free(valid_url);
+    try std.testing.expectEqualStrings("https://region.example.com:443/", valid_url);
+
+    try std.testing.expectError(
+        error.InvalidWeixinBaseUrl,
+        buildRedirectBaseUrl(std.testing.allocator, "region.example.com?next=evil.example"),
+    );
+    try std.testing.expectError(
+        error.InvalidWeixinBaseUrl,
+        buildRedirectBaseUrl(std.testing.allocator, "region.example.com#fragment"),
+    );
+    try std.testing.expectError(
+        error.InvalidWeixinBaseUrl,
+        buildRedirectBaseUrl(std.testing.allocator, "trusted.example@evil.example"),
+    );
+    try std.testing.expectError(
+        error.InvalidWeixinBaseUrl,
+        buildRedirectBaseUrl(std.testing.allocator, "region.example.com/unexpected-path"),
+    );
+}
+
 test "performLogin returns test data in test mode" {
     var result = try performLogin(std.testing.allocator, .{});
     defer result.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("test-bot-token", result.bot_token);
     try std.testing.expectEqualStrings("test-account-id", result.account_id);
+}
+
+fn performLoginAllocationTest(allocator: std.mem.Allocator) !void {
+    var result = try performLogin(allocator, .{});
+    defer result.deinit(allocator);
+}
+
+test "performLogin frees partial test result on allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, performLoginAllocationTest, .{});
+}
+
+test "performLogin rejects invalid initial base URL in test mode" {
+    try std.testing.expectError(
+        error.InvalidWeixinBaseUrl,
+        performLogin(std.testing.allocator, .{ .base_url = "http://example.com/" }),
+    );
+}
+
+test "performLogin rejects invalid proxy URL in test mode" {
+    try std.testing.expectError(
+        error.InvalidWeixinProxyUrl,
+        performLogin(std.testing.allocator, .{ .proxy = "ftp://proxy.example.com" }),
+    );
 }
 
 test "sendMessage returns in test mode" {

--- a/src/channels/whatsapp.zig
+++ b/src/channels/whatsapp.zig
@@ -141,7 +141,7 @@ pub const WhatsAppChannel = struct {
                         false;
 
                     if (!is_group_msg) {
-                        if (self.allow_from.len > 0 and !self.isNumberAllowed(normalized)) continue;
+                        if (!self.isNumberAllowed(normalized)) continue;
                     } else {
                         if (std.mem.eql(u8, self.group_policy, "disabled")) continue;
                         if (!std.mem.eql(u8, self.group_policy, "open")) {
@@ -435,6 +435,19 @@ test "whatsapp parse unauthorized number filtered" {
         \\{"entry":[{"changes":[{"value":{"messages":[{"from":"9999999999","timestamp":"1","type":"text","text":{"body":"Spam"}}]}}]}]}
     ;
 
+    const msgs = try ch.parseWebhookPayload(allocator, payload);
+    defer allocator.free(msgs);
+    try std.testing.expectEqual(@as(usize, 0), msgs.len);
+}
+
+test "whatsapp direct message empty allow_from denies sender" {
+    const allocator = std.testing.allocator;
+    const ch = WhatsAppChannel.init(allocator, "tok", "123", "ver", &.{}, &.{}, "allowlist");
+    const payload =
+        \\{"entry":[{"changes":[{"value":{"messages":[{"from":"1234567890","timestamp":"1","type":"text","text":{"body":"Blocked"}}]}}]}]}
+    ;
+
+    // Regression: Meta webhook delivery does not authorize the end-user number.
     const msgs = try ch.parseWebhookPayload(allocator, payload);
     defer allocator.free(msgs);
     try std.testing.expectEqual(@as(usize, 0), msgs.len);

--- a/src/config.zig
+++ b/src/config.zig
@@ -1539,6 +1539,8 @@ pub const Config = struct {
         InvalidRetryCount,
         InvalidBackoffMs,
         InvalidHttpProxyUrl,
+        InvalidWeixinBaseUrl,
+        InvalidWeixinProxyUrl,
         InvalidApiErrorMaxChars,
         InvalidOtelEndpoint,
         InvalidOtelHeader,
@@ -1631,6 +1633,16 @@ pub const Config = struct {
         if (self.http_request.proxy) |proxy_url| {
             if (!config_types.HttpRequestConfig.isValidProxyUrl(proxy_url)) {
                 return ValidationError.InvalidHttpProxyUrl;
+            }
+        }
+        for (self.channels.weixin) |weixin_cfg| {
+            if (!config_types.WeixinConfig.isValidBaseUrl(weixin_cfg.base_url)) {
+                return ValidationError.InvalidWeixinBaseUrl;
+            }
+            if (weixin_cfg.proxy) |proxy_url| {
+                if (!config_types.WeixinConfig.isValidProxyUrl(proxy_url)) {
+                    return ValidationError.InvalidWeixinProxyUrl;
+                }
             }
         }
         if (self.diagnostics.api_error_max_chars) |n| {
@@ -1822,6 +1834,8 @@ pub const Config = struct {
             ValidationError.InvalidRetryCount => std.debug.print("Config error: provider_retries must be <= 100.\n", .{}),
             ValidationError.InvalidBackoffMs => std.debug.print("Config error: provider_backoff_ms must be <= 600000.\n", .{}),
             ValidationError.InvalidHttpProxyUrl => std.debug.print("Config error: http_request.proxy must be a non-empty http://, https://, or socks5:// URL.\n", .{}),
+            ValidationError.InvalidWeixinBaseUrl => std.debug.print("Config error: channels.weixin base_url must be an absolute HTTPS URL without a query or fragment.\n", .{}),
+            ValidationError.InvalidWeixinProxyUrl => std.debug.print("Config error: channels.weixin proxy must be a valid http://, https://, or socks5:// proxy URL.\n", .{}),
             ValidationError.InvalidApiErrorMaxChars => std.debug.print("Config error: diagnostics.api_error_max_chars must be in [200, 10000].\n", .{}),
             ValidationError.InvalidOtelEndpoint => std.debug.print("Config error: diagnostics.otel.endpoint/otel_endpoint must be an absolute https:// URL (or http:// for localhost/private or container-local collector hosts).\n", .{}),
             ValidationError.InvalidOtelHeader => std.debug.print("Config error: diagnostics.otel.headers/otel_headers must contain valid HTTP header names/values (no CR/LF).\n", .{}),
@@ -3340,6 +3354,39 @@ test "validation rejects invalid http_request proxy URL" {
     };
     cfg.http_request.proxy = "ftp://proxy.example.com:21";
     try std.testing.expectError(Config.ValidationError.InvalidHttpProxyUrl, cfg.validate());
+}
+
+test "validation rejects insecure weixin base URL" {
+    const weixin_accounts = [_]config_types.WeixinConfig{.{
+        .token = "test-token",
+        .base_url = "http://ilink.example.com/",
+    }};
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .default_model = "x",
+        .allocator = std.testing.allocator,
+    };
+    cfg.channels.weixin = &weixin_accounts;
+
+    // Regression: bearer credentials must never be sent over plaintext HTTP.
+    try std.testing.expectError(Config.ValidationError.InvalidWeixinBaseUrl, cfg.validate());
+}
+
+test "validation rejects invalid weixin proxy URL" {
+    const weixin_accounts = [_]config_types.WeixinConfig{.{
+        .token = "test-token",
+        .proxy = "ftp://proxy.example.com",
+    }};
+    var cfg = Config{
+        .workspace_dir = "/tmp/yc",
+        .config_path = "/tmp/yc/config.json",
+        .default_model = "x",
+        .allocator = std.testing.allocator,
+    };
+    cfg.channels.weixin = &weixin_accounts;
+
+    try std.testing.expectError(Config.ValidationError.InvalidWeixinProxyUrl, cfg.validate());
 }
 
 test "validation rejects out-of-range diagnostics api_error_max_chars" {

--- a/src/config_types.zig
+++ b/src/config_types.zig
@@ -814,14 +814,31 @@ pub const WeComConfig = struct {
 };
 
 pub const WeixinConfig = struct {
+    pub const DEFAULT_BASE_URL = "https://ilinkai.weixin.qq.com/";
+
     account_id: []const u8 = "default",
     /// Bot token obtained from iLink QR code login flow.
     token: []const u8 = "",
     /// iLink API base URL (may be region-specific after login redirect).
-    base_url: []const u8 = "https://ilinkai.weixin.qq.com/",
+    base_url: []const u8 = DEFAULT_BASE_URL,
     /// Optional HTTP proxy URL for API requests.
     proxy: ?[]const u8 = null,
     allow_from: []const []const u8 = &.{},
+
+    /// iLink requests carry bot credentials, so plaintext remote endpoints are
+    /// never valid even when they point at a private or loopback address.
+    pub fn isValidBaseUrl(raw: []const u8) bool {
+        if (!ProviderEntry.isValidBaseUrl(raw)) return false;
+        const uri = std.Uri.parse(raw) catch return false;
+        if (!std.ascii.eqlIgnoreCase(uri.scheme, "https")) return false;
+        if (uri.user != null or uri.password != null) return false;
+        if (uri.port) |port| if (port == 0) return false;
+        return true;
+    }
+
+    pub fn isValidProxyUrl(raw: []const u8) bool {
+        return HttpRequestConfig.isValidProxyUrl(raw);
+    }
 };
 
 pub const SignalConfig = struct {

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -1777,6 +1777,15 @@ fn slackSessionKey(
     return std.fmt.bufPrint(buf, "slack:{s}:channel:{s}", .{ account_id, channel_id }) catch "slack:unknown";
 }
 
+const RoutedSessionKey = struct {
+    key: []const u8,
+    owned: bool = false,
+
+    fn deinit(self: RoutedSessionKey, allocator: std.mem.Allocator) void {
+        if (self.owned) allocator.free(self.key);
+    }
+};
+
 fn slackSessionKeyRouted(
     allocator: std.mem.Allocator,
     fallback_buf: []u8,
@@ -1785,7 +1794,7 @@ fn slackSessionKeyRouted(
     channel_id: []const u8,
     is_dm: bool,
     cfg_opt: ?*const Config,
-) []const u8 {
+) RoutedSessionKey {
     const fallback = slackSessionKey(fallback_buf, account_id, sender_id, channel_id, is_dm);
     return resolveRouteSessionKey(
         allocator,
@@ -1964,7 +1973,7 @@ fn whatsappSessionKeyRouted(
     body: []const u8,
     cfg_opt: ?*const Config,
     account_id: []const u8,
-) []const u8 {
+) RoutedSessionKey {
     const sender = jsonStringField(body, "from") orelse "unknown";
     const group_id = jsonStringField(body, "group_jid") orelse jsonStringField(body, "group_id");
     const peer_id = if (group_id) |gid|
@@ -1973,17 +1982,14 @@ fn whatsappSessionKeyRouted(
         sender;
     const peer_kind: agent_routing.ChatType = if (group_id != null) .group else .direct;
 
-    if (cfg_opt) |cfg| {
-        const route = agent_routing.resolveRouteWithSession(allocator, .{
-            .channel = "whatsapp",
-            .account_id = account_id,
-            .peer = .{ .kind = peer_kind, .id = peer_id },
-        }, cfg.agent_bindings, cfg.agents, cfg.session) catch return whatsappSessionKey(fallback_buf, body);
-        allocator.free(route.main_session_key);
-        return route.session_key;
-    }
-
-    return whatsappSessionKey(fallback_buf, body);
+    return resolveRouteSessionKey(
+        allocator,
+        cfg_opt,
+        "whatsapp",
+        account_id,
+        .{ .kind = peer_kind, .id = peer_id },
+        whatsappSessionKey(fallback_buf, body),
+    );
 }
 
 fn resolveRouteSessionKey(
@@ -1993,17 +1999,17 @@ fn resolveRouteSessionKey(
     account_id: []const u8,
     peer: agent_routing.PeerRef,
     fallback: []const u8,
-) []const u8 {
+) RoutedSessionKey {
     if (cfg_opt) |cfg| {
         const route = agent_routing.resolveRouteWithSession(allocator, .{
             .channel = channel,
             .account_id = account_id,
             .peer = peer,
-        }, cfg.agent_bindings, cfg.agents, cfg.session) catch return fallback;
+        }, cfg.agent_bindings, cfg.agents, cfg.session) catch return .{ .key = fallback };
         allocator.free(route.main_session_key);
-        return route.session_key;
+        return .{ .key = route.session_key, .owned = true };
     }
-    return fallback;
+    return .{ .key = fallback };
 }
 
 fn qqPeerRefFromInbound(inbound: *const bus_mod.InboundMessage) ?agent_routing.PeerRef {
@@ -2034,7 +2040,7 @@ fn qqSessionKeyRouted(
     allocator: std.mem.Allocator,
     inbound: *const bus_mod.InboundMessage,
     cfg_opt: ?*const Config,
-) ?[]const u8 {
+) ?RoutedSessionKey {
     const cfg = cfg_opt orelse return null;
     const account_id = if (inbound.metadata_json) |json|
         (jsonStringField(json, "account_id") orelse "default")
@@ -2048,7 +2054,7 @@ fn qqSessionKeyRouted(
         .peer = peer,
     }, cfg.agent_bindings, cfg.agents, cfg.session) catch return null;
     allocator.free(route.main_session_key);
-    return route.session_key;
+    return .{ .key = route.session_key, .owned = true };
 }
 
 fn teamsPeerRef(
@@ -2079,7 +2085,7 @@ fn teamsSessionKeyRouted(
     tenant_id: []const u8,
     conversation_id: []const u8,
     from_id: []const u8,
-) []const u8 {
+) RoutedSessionKey {
     const fallback = std.fmt.bufPrint(fallback_buf, "teams:{s}:{s}", .{ tenant_id, conversation_id }) catch "teams:default";
     const peer_info = teamsPeerRef(body, from_id, conversation_id);
     return resolveRouteSessionKey(
@@ -2237,23 +2243,27 @@ fn lineSenderAllowed(allow_from: []const []const u8, evt: channels.line.LineEven
     return channels.isAllowed(allow_from, user_id);
 }
 
+fn tencentSenderAllowed(allow_from: []const []const u8, sender: []const u8) bool {
+    return channels.isAllowedExactScoped("wechat/wecom channel", allow_from, sender);
+}
+
 fn telegramSessionKeyRouted(
     allocator: std.mem.Allocator,
     fallback_buf: []u8,
     body: []const u8,
     cfg_opt: ?*const Config,
     account_id: []const u8,
-) []const u8 {
-    const target = telegramWebhookTarget(allocator, body) orelse return "telegram:0";
+) RoutedSessionKey {
+    const target = telegramWebhookTarget(allocator, body) orelse return .{ .key = "telegram:0" };
     const fallback = telegramFallbackSessionKey(fallback_buf, target.chat_id, target.message_thread_id);
     var peer_buf: [64]u8 = undefined;
-    const peer_id = std.fmt.bufPrint(&peer_buf, "{d}", .{target.chat_id}) catch return fallback;
+    const peer_id = std.fmt.bufPrint(&peer_buf, "{d}", .{target.chat_id}) catch return .{ .key = fallback };
     const peer_kind: agent_routing.ChatType = if (target.is_group) .group else .direct;
 
     if (cfg_opt) |cfg| {
         if (target.is_group and target.message_thread_id != null) {
             const thread_id = target.message_thread_id.?;
-            const topic_peer_id = std.fmt.allocPrint(allocator, "{s}:thread:{d}", .{ peer_id, thread_id }) catch return fallback;
+            const topic_peer_id = std.fmt.allocPrint(allocator, "{s}:thread:{d}", .{ peer_id, thread_id }) catch return .{ .key = fallback };
             defer allocator.free(topic_peer_id);
 
             const route = agent_routing.resolveRouteWithSession(allocator, .{
@@ -2261,9 +2271,9 @@ fn telegramSessionKeyRouted(
                 .account_id = account_id,
                 .peer = .{ .kind = peer_kind, .id = topic_peer_id },
                 .parent_peer = .{ .kind = peer_kind, .id = peer_id },
-            }, cfg.agent_bindings, cfg.agents, cfg.session) catch return fallback;
+            }, cfg.agent_bindings, cfg.agents, cfg.session) catch return .{ .key = fallback };
             allocator.free(route.main_session_key);
-            return route.session_key;
+            return .{ .key = route.session_key, .owned = true };
         }
     }
 
@@ -2440,15 +2450,15 @@ fn lineSessionKeyRouted(
     evt: channels.line.LineEvent,
     cfg_opt: ?*const Config,
     account_id: []const u8,
-) []const u8 {
+) RoutedSessionKey {
     const fallback = lineSessionKey(fallback_buf, evt);
     const src_type = evt.source_type orelse "";
     const peer_kind: agent_routing.ChatType = if (std.mem.eql(u8, src_type, "group") or std.mem.eql(u8, src_type, "room")) .group else .direct;
     var peer_buf: [160]u8 = undefined;
     const peer_id = if (std.mem.eql(u8, src_type, "group"))
-        std.fmt.bufPrint(&peer_buf, "group:{s}", .{evt.group_id orelse evt.user_id orelse "unknown"}) catch return fallback
+        std.fmt.bufPrint(&peer_buf, "group:{s}", .{evt.group_id orelse evt.user_id orelse "unknown"}) catch return .{ .key = fallback }
     else if (std.mem.eql(u8, src_type, "room"))
-        std.fmt.bufPrint(&peer_buf, "room:{s}", .{evt.room_id orelse evt.user_id orelse "unknown"}) catch return fallback
+        std.fmt.bufPrint(&peer_buf, "room:{s}", .{evt.room_id orelse evt.user_id orelse "unknown"}) catch return .{ .key = fallback }
     else
         evt.user_id orelse "unknown";
     return resolveRouteSessionKey(
@@ -2471,7 +2481,7 @@ fn larkSessionKeyRouted(
     msg: channels.lark.ParsedLarkMessage,
     cfg_opt: ?*const Config,
     account_id: []const u8,
-) []const u8 {
+) RoutedSessionKey {
     const fallback = larkSessionKey(fallback_buf, msg);
     const peer_kind: agent_routing.ChatType = if (msg.is_group) .group else .direct;
     return resolveRouteSessionKey(
@@ -2498,7 +2508,7 @@ fn wechatSessionKeyRouted(
     sender: []const u8,
     cfg_opt: ?*const Config,
     account_id: []const u8,
-) []const u8 {
+) RoutedSessionKey {
     const fallback = wechatSessionKey(fallback_buf, sender);
     return resolveRouteSessionKey(
         allocator,
@@ -2516,7 +2526,7 @@ fn wecomSessionKeyRouted(
     sender: []const u8,
     cfg_opt: ?*const Config,
     account_id: []const u8,
-) []const u8 {
+) RoutedSessionKey {
     const fallback = wecomSessionKey(fallback_buf, sender);
     return resolveRouteSessionKey(
         allocator,
@@ -2543,7 +2553,7 @@ fn maxSessionKeyRouted(
     is_group: bool,
     cfg_opt: ?*const Config,
     account_id: []const u8,
-) []const u8 {
+) RoutedSessionKey {
     const fallback = maxSessionKey(fallback_buf, account_id, sender, reply_target, is_group);
     const peer_id = if (is_group) reply_target else sender;
     return resolveRouteSessionKey(
@@ -3663,13 +3673,17 @@ fn handleTelegramWebhookRoute(ctx: *WebhookHandlerContext) void {
                     }) catch null;
                 var kb: [64]u8 = undefined;
                 const tg_cfg_opt: ?*const Config = if (ctx.config_opt) |cfg| cfg else null;
-                const sk = telegramSessionKeyRouted(ctx.req_allocator, &kb, b, tg_cfg_opt, tg_account_id);
+                const routed_key = telegramSessionKeyRouted(ctx.req_allocator, &kb, b, tg_cfg_opt, tg_account_id);
+                defer routed_key.deinit(ctx.req_allocator);
+                const sk = routed_key.key;
                 _ = publishToBus(eb, ctx.state.allocator, "telegram", sender, chat_target, msg_text.?, sk, meta);
                 ctx.response_body = "{\"status\":\"ok\"}";
             } else if (ctx.session_mgr_opt) |sm| {
                 var kb: [64]u8 = undefined;
                 const tg_cfg_opt: ?*const Config = if (ctx.config_opt) |cfg| cfg else null;
-                const sk = telegramSessionKeyRouted(ctx.req_allocator, &kb, b, tg_cfg_opt, tg_account_id);
+                const routed_key = telegramSessionKeyRouted(ctx.req_allocator, &kb, b, tg_cfg_opt, tg_account_id);
+                defer routed_key.deinit(ctx.req_allocator);
+                const sk = routed_key.key;
                 const conversation_context: ?ConversationContext = simpleConversationContext(
                     "telegram",
                     tg_account_id,
@@ -3808,7 +3822,9 @@ fn handleWhatsAppWebhookRoute(ctx: *WebhookHandlerContext) void {
         if (msg_text) |mt| {
             var wa_key_buf: [256]u8 = undefined;
             const wa_cfg_opt: ?*const Config = if (ctx.config_opt) |cfg| cfg else null;
-            const wa_session_key = whatsappSessionKeyRouted(ctx.req_allocator, &wa_key_buf, body, wa_cfg_opt, wa_account_id);
+            const routed_key = whatsappSessionKeyRouted(ctx.req_allocator, &wa_key_buf, body, wa_cfg_opt, wa_account_id);
+            defer routed_key.deinit(ctx.req_allocator);
+            const wa_session_key = routed_key.key;
             const wa_sender_id = wa_sender orelse "unknown";
             const wa_chat_target = whatsappReplyTarget(body);
             const wa_peer_kind = if (wa_is_group) "group" else "direct";
@@ -3872,7 +3888,9 @@ fn handleWhatsAppWebhookRoute(ctx: *WebhookHandlerContext) void {
         if (msg_text) |mt| {
             var wa_key_buf: [256]u8 = undefined;
             const wa_cfg_opt: ?*const Config = if (ctx.config_opt) |cfg| cfg else null;
-            const wa_session_key = whatsappSessionKeyRouted(ctx.req_allocator, &wa_key_buf, b, wa_cfg_opt, wa_account_id);
+            const routed_key = whatsappSessionKeyRouted(ctx.req_allocator, &wa_key_buf, b, wa_cfg_opt, wa_account_id);
+            defer routed_key.deinit(ctx.req_allocator);
+            const wa_session_key = routed_key.key;
             const wa_sender_ns = wa_sender orelse "unknown";
             const wa_chat_target_ns = whatsappReplyTarget(b);
             const wa_peer_kind = if (wa_is_group) "group" else "direct";
@@ -4051,7 +4069,7 @@ fn handleSlackWebhookRoute(ctx: *WebhookHandlerContext) void {
                 const interactive_target = slackInteractiveTarget(selection.target, callback_channel_val.string);
 
                 var key_buf: [256]u8 = undefined;
-                const session_key = slackSessionKeyRouted(
+                const routed_key = slackSessionKeyRouted(
                     ctx.req_allocator,
                     &key_buf,
                     slack_cfg.account_id,
@@ -4060,6 +4078,8 @@ fn handleSlackWebhookRoute(ctx: *WebhookHandlerContext) void {
                     interactive_target.is_dm,
                     ctx.config_opt,
                 );
+                defer routed_key.deinit(ctx.req_allocator);
+                const session_key = routed_key.key;
 
                 if (ctx.state.event_bus) |eb| {
                     var meta_buf: [384]u8 = undefined;
@@ -4214,7 +4234,7 @@ fn handleSlackWebhookRoute(ctx: *WebhookHandlerContext) void {
     }
 
     var key_buf: [256]u8 = undefined;
-    const sk = slackSessionKeyRouted(
+    const routed_key = slackSessionKeyRouted(
         ctx.req_allocator,
         &key_buf,
         slack_cfg.account_id,
@@ -4223,6 +4243,8 @@ fn handleSlackWebhookRoute(ctx: *WebhookHandlerContext) void {
         is_dm,
         ctx.config_opt,
     );
+    defer routed_key.deinit(ctx.req_allocator);
+    const sk = routed_key.key;
 
     if (ctx.state.event_bus) |eb| {
         var meta_buf: [384]u8 = undefined;
@@ -4359,7 +4381,9 @@ fn handleLineWebhookRoute(ctx: *WebhookHandlerContext) void {
             if (evt.message_text) |text| {
                 var kb: [128]u8 = undefined;
                 const line_cfg_opt: ?*const Config = if (ctx.config_opt) |cfg| cfg else null;
-                const sk = lineSessionKeyRouted(ctx.req_allocator, &kb, evt, line_cfg_opt, line_account_id);
+                const routed_key = lineSessionKeyRouted(ctx.req_allocator, &kb, evt, line_cfg_opt, line_account_id);
+                defer routed_key.deinit(ctx.req_allocator);
+                const sk = routed_key.key;
                 const uid = evt.user_id orelse "unknown";
                 const line_target = lineReplyTarget(evt);
                 if (evt.reply_token) |rt| {
@@ -4497,7 +4521,9 @@ fn handleLarkWebhookRoute(ctx: *WebhookHandlerContext) void {
     for (messages) |msg| {
         var kb: [128]u8 = undefined;
         const lark_cfg_opt: ?*const Config = if (ctx.config_opt) |cfg| cfg else null;
-        const sk = larkSessionKeyRouted(ctx.req_allocator, &kb, msg, lark_cfg_opt, lark_account_id);
+        const routed_key = larkSessionKeyRouted(ctx.req_allocator, &kb, msg, lark_cfg_opt, lark_account_id);
+        defer routed_key.deinit(ctx.req_allocator);
+        const sk = routed_key.key;
 
         if (ctx.state.event_bus) |eb| {
             var meta_buf: [320]u8 = undefined;
@@ -4729,20 +4755,22 @@ fn handleWeChatWebhookRoute(ctx: *WebhookHandlerContext) void {
     };
     defer inbound.deinit(ctx.req_allocator);
 
-    if (wechat_allow_from.len > 0 and !channels.isAllowed(wechat_allow_from, inbound.from_user)) {
+    if (!tencentSenderAllowed(wechat_allow_from, inbound.from_user)) {
         setPlainTextResponse(ctx, "success");
         return;
     }
 
     if (ctx.state.event_bus) |eb| {
         var key_buf: [128]u8 = undefined;
-        const session_key = wechatSessionKeyRouted(
+        const routed_key = wechatSessionKeyRouted(
             ctx.req_allocator,
             &key_buf,
             inbound.from_user,
             ctx.config_opt,
             wechat_account_id,
         );
+        defer routed_key.deinit(ctx.req_allocator);
+        const session_key = routed_key.key;
         var meta_buf: [320]u8 = undefined;
         const meta = std.fmt.bufPrint(&meta_buf, "{{\"account_id\":\"{s}\",\"peer_kind\":\"direct\",\"peer_id\":\"{s}\"}}", .{
             wechat_account_id,
@@ -4755,13 +4783,15 @@ fn handleWeChatWebhookRoute(ctx: *WebhookHandlerContext) void {
 
     if (ctx.session_mgr_opt) |sm| {
         var key_buf: [128]u8 = undefined;
-        const session_key = wechatSessionKeyRouted(
+        const routed_key = wechatSessionKeyRouted(
             ctx.req_allocator,
             &key_buf,
             inbound.from_user,
             ctx.config_opt,
             wechat_account_id,
         );
+        defer routed_key.deinit(ctx.req_allocator);
+        const session_key = routed_key.key;
         const reply: ?[]const u8 = sm.processInboundMessage(session_key, inbound.content, null) catch null;
         if (reply) |r| {
             defer ctx.root_allocator.free(r);
@@ -4932,19 +4962,21 @@ fn handleWeComWebhookRoute(ctx: *WebhookHandlerContext) void {
     };
     defer inbound.deinit(ctx.req_allocator);
 
-    if (wecom_allow_from.len > 0 and !channels.isAllowed(wecom_allow_from, inbound.sender)) {
+    if (!tencentSenderAllowed(wecom_allow_from, inbound.sender)) {
         ctx.response_body = "{\"status\":\"unauthorized\"}";
         return;
     }
 
     var key_buf: [128]u8 = undefined;
-    const session_key = wecomSessionKeyRouted(
+    const routed_key = wecomSessionKeyRouted(
         ctx.req_allocator,
         &key_buf,
         inbound.sender,
         ctx.config_opt,
         wecom_account_id,
     );
+    defer routed_key.deinit(ctx.req_allocator);
+    const session_key = routed_key.key;
 
     if (ctx.state.event_bus) |eb| {
         var meta_buf: [320]u8 = undefined;
@@ -5066,9 +5098,9 @@ fn handleQqWebhookRoute(ctx: *WebhookHandlerContext) void {
         }
 
         if (ctx.session_mgr_opt) |sm| {
-            const routed_session_key: ?[]const u8 = qqSessionKeyRouted(ctx.req_allocator, &inbound, ctx.config_opt);
-            defer if (routed_session_key) |owned| ctx.req_allocator.free(owned);
-            const session_key = routed_session_key orelse inbound.session_key;
+            const routed_key = qqSessionKeyRouted(ctx.req_allocator, &inbound, ctx.config_opt);
+            defer if (routed_key) |key| key.deinit(ctx.req_allocator);
+            const session_key = if (routed_key) |key| key.key else inbound.session_key;
             const peer = qqPeerRefFromInbound(&inbound);
             const meta = inbound.metadata_json;
             const account_id = if (meta) |json| jsonStringField(json, "account_id") else null;
@@ -5164,7 +5196,7 @@ fn handleMaxWebhookRoute(ctx: *WebhookHandlerContext) void {
         const reply_target = inbound.reply_target orelse inbound.sender;
         const peer_id = if (inbound.is_group) reply_target else inbound.sender;
         var kb: [192]u8 = undefined;
-        const sk = maxSessionKeyRouted(
+        const routed_key = maxSessionKeyRouted(
             ctx.req_allocator,
             &kb,
             inbound.sender,
@@ -5173,6 +5205,8 @@ fn handleMaxWebhookRoute(ctx: *WebhookHandlerContext) void {
             ctx.config_opt,
             max_cfg.account_id,
         );
+        defer routed_key.deinit(ctx.req_allocator);
+        const sk = routed_key.key;
         const peer_kind: []const u8 = if (inbound.is_group) "group" else "direct";
 
         if (ctx.state.event_bus) |eb| {
@@ -5394,7 +5428,7 @@ fn handleTeamsWebhookRoute(ctx: *WebhookHandlerContext) void {
 
     const peer_info = teamsPeerRef(body, from_id, conversation_id);
     var key_buf: [256]u8 = undefined;
-    const sk = teamsSessionKeyRouted(
+    const routed_key = teamsSessionKeyRouted(
         ctx.req_allocator,
         &key_buf,
         config,
@@ -5404,6 +5438,8 @@ fn handleTeamsWebhookRoute(ctx: *WebhookHandlerContext) void {
         conversation_id,
         from_id,
     );
+    defer routed_key.deinit(ctx.req_allocator);
+    const sk = routed_key.key;
 
     // Build chat_id as "serviceUrl|conversationId" for outbound routing
     var chat_buf: [512]u8 = undefined;
@@ -8186,6 +8222,7 @@ test "handleWeChatWebhookRoute accepts secure encrypted callback" {
             .callback_token = token,
             .encoding_aes_key = encoding_aes_key,
             .app_id = app_id,
+            .allow_from = &.{"o_user123"},
         },
     };
     var cfg = Config{
@@ -8197,6 +8234,9 @@ test "handleWeChatWebhookRoute accepts secure encrypted callback" {
 
     var state = GatewayState.init(std.testing.allocator);
     defer state.deinit();
+    var event_bus = bus_mod.Bus.init();
+    defer event_bus.close();
+    state.event_bus = &event_bus;
 
     var ctx = WebhookHandlerContext{
         .root_allocator = std.testing.allocator,
@@ -8213,6 +8253,22 @@ test "handleWeChatWebhookRoute accepts secure encrypted callback" {
     try std.testing.expectEqualStrings("200 OK", ctx.response_status);
     try std.testing.expectEqualStrings(CONTENT_TYPE_TEXT, ctx.response_content_type);
     try std.testing.expectEqualStrings("success", ctx.response_body);
+
+    const allowed_message = event_bus.consumeInbound() orelse return error.TestUnexpectedResult;
+    defer allowed_message.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("o_user123", allowed_message.sender_id);
+
+    const blocked_wechat_accounts = [_]config_types.WeChatConfig{.{
+        .account_id = "main",
+        .callback_token = token,
+        .encoding_aes_key = encoding_aes_key,
+        .app_id = app_id,
+    }};
+    cfg.channels.wechat = &blocked_wechat_accounts;
+    ctx.client_identifier = "empty-allowlist-client";
+    handleWeChatWebhookRoute(&ctx);
+    // Regression: a valid signature authenticates the webhook, not the sender.
+    try std.testing.expectEqual(@as(usize, 0), event_bus.inboundDepth());
 }
 
 test "handleWeChatWebhookRoute rejects stale signed callbacks" {
@@ -8389,6 +8445,14 @@ test "lineSenderAllowed denies empty allow_from and permits wildcard" {
     try std.testing.expect(lineSenderAllowed(&.{"*"}, evt));
     try std.testing.expect(lineSenderAllowed(&.{"U123"}, evt));
     try std.testing.expect(!lineSenderAllowed(&.{"U999"}, evt));
+}
+
+test "tencentSenderAllowed denies empty allow_from and permits explicit access" {
+    try std.testing.expect(!tencentSenderAllowed(&.{}, "user-1"));
+    try std.testing.expect(tencentSenderAllowed(&.{"user-1"}, "user-1"));
+    try std.testing.expect(tencentSenderAllowed(&.{"*"}, "user-1"));
+    try std.testing.expect(!tencentSenderAllowed(&.{"user-2"}, "user-1"));
+    try std.testing.expect(!tencentSenderAllowed(&.{"User-1"}, "user-1"));
 }
 
 test "line webhook caches reply token only after sender allowlist passes" {
@@ -8605,12 +8669,48 @@ test "whatsappSenderAllowed matches with and without plus prefix" {
     try std.testing.expect(whatsappSenderAllowed("+15550001111", false, null, &allow_without_plus, &.{}, &.{}, "allowlist"));
 }
 
+test "resolveRouteSessionKey exposes ownership for cleanup" {
+    const allocator = std.testing.allocator;
+    const bindings = [_]agent_routing.AgentBinding{
+        .{
+            .agent_id = "wechat-agent",
+            .match = .{
+                .channel = "wechat",
+                .account_id = "wechat-main",
+                .peer = .{ .kind = .direct, .id = "openid_123" },
+            },
+        },
+    };
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .allocator = allocator,
+        .agent_bindings = &bindings,
+    };
+
+    // Regression: routed webhook session keys used to leak on every configured request.
+    const routed_key = resolveRouteSessionKey(
+        allocator,
+        &cfg,
+        "wechat",
+        "wechat-main",
+        .{ .kind = .direct, .id = "openid_123" },
+        "wechat:openid_123",
+    );
+    defer routed_key.deinit(allocator);
+
+    try std.testing.expect(routed_key.owned);
+    try std.testing.expectEqualStrings("agent:wechat-agent:wechat:direct:openid_123", routed_key.key);
+}
+
 test "whatsappSessionKeyRouted falls back without config" {
     const allocator = std.testing.allocator;
     const body = "{\"from\":\"15550001111\",\"text\":{\"body\":\"hi\"}}";
     var key_buf: [256]u8 = undefined;
-    const key = whatsappSessionKeyRouted(allocator, &key_buf, body, null, "default");
-    try std.testing.expectEqualStrings("whatsapp:15550001111", key);
+    const routed_key = whatsappSessionKeyRouted(allocator, &key_buf, body, null, "default");
+    defer routed_key.deinit(allocator);
+    try std.testing.expect(!routed_key.owned);
+    try std.testing.expectEqualStrings("whatsapp:15550001111", routed_key.key);
 }
 
 test "whatsappSessionKeyRouted uses route engine when config exists" {
@@ -8637,8 +8737,9 @@ test "whatsappSessionKeyRouted uses route engine when config exists" {
         },
     };
 
-    const key = whatsappSessionKeyRouted(allocator, &key_buf, body, &cfg, "wa-prod");
-    try std.testing.expectEqualStrings("agent:wa-agent:whatsapp:group:1203630@g.us", key);
+    const routed_key = whatsappSessionKeyRouted(allocator, &key_buf, body, &cfg, "wa-prod");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:wa-agent:whatsapp:group:1203630@g.us", routed_key.key);
 }
 
 test "whatsappSessionKeyRouted uses nested context.group_jid for group routing" {
@@ -8665,8 +8766,9 @@ test "whatsappSessionKeyRouted uses nested context.group_jid for group routing" 
         },
     };
 
-    const key = whatsappSessionKeyRouted(allocator, &key_buf, body, &cfg, "wa-main");
-    try std.testing.expectEqualStrings("agent:wa-context-agent:whatsapp:group:1203631@g.us", key);
+    const routed_key = whatsappSessionKeyRouted(allocator, &key_buf, body, &cfg, "wa-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:wa-context-agent:whatsapp:group:1203631@g.us", routed_key.key);
 }
 
 test "telegramSessionKeyRouted uses group peer for group chats" {
@@ -8695,8 +8797,9 @@ test "telegramSessionKeyRouted uses group peer for group chats" {
         },
     };
 
-    const key = telegramSessionKeyRouted(allocator, &key_buf, body, &cfg, "tg-main");
-    try std.testing.expectEqualStrings("agent:tg-group-agent:telegram:group:-10012345", key);
+    const routed_key = telegramSessionKeyRouted(allocator, &key_buf, body, &cfg, "tg-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:tg-group-agent:telegram:group:-10012345", routed_key.key);
 }
 
 test "telegramSessionKeyRouted uses direct peer for private chats" {
@@ -8725,8 +8828,9 @@ test "telegramSessionKeyRouted uses direct peer for private chats" {
         },
     };
 
-    const key = telegramSessionKeyRouted(allocator, &key_buf, body, &cfg, "tg-main");
-    try std.testing.expectEqualStrings("agent:tg-dm-agent:telegram:direct:4242", key);
+    const routed_key = telegramSessionKeyRouted(allocator, &key_buf, body, &cfg, "tg-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:tg-dm-agent:telegram:direct:4242", routed_key.key);
 }
 
 test "telegramSessionKeyRouted applies session dm_scope for direct chats" {
@@ -8758,8 +8862,9 @@ test "telegramSessionKeyRouted applies session dm_scope for direct chats" {
         },
     };
 
-    const key = telegramSessionKeyRouted(allocator, &key_buf, body, &cfg, "tg-main");
-    try std.testing.expectEqualStrings("agent:tg-dm-agent:direct:4242", key);
+    const routed_key = telegramSessionKeyRouted(allocator, &key_buf, body, &cfg, "tg-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:tg-dm-agent:direct:4242", routed_key.key);
 }
 
 test "telegramSessionKeyRouted uses topic peer before group fallback" {
@@ -8796,8 +8901,9 @@ test "telegramSessionKeyRouted uses topic peer before group fallback" {
         },
     };
 
-    const key = telegramSessionKeyRouted(allocator, &key_buf, body, &cfg, "tg-main");
-    try std.testing.expectEqualStrings("agent:tg-topic-agent:telegram:group:-10012345:thread:42", key);
+    const routed_key = telegramSessionKeyRouted(allocator, &key_buf, body, &cfg, "tg-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:tg-topic-agent:telegram:group:-10012345:thread:42", routed_key.key);
 }
 
 test "lineSessionKeyRouted uses group id for group events" {
@@ -8829,8 +8935,9 @@ test "lineSessionKeyRouted uses group id for group events" {
         },
     };
 
-    const key = lineSessionKeyRouted(allocator, &key_buf, evt, &cfg, "line-main");
-    try std.testing.expectEqualStrings("agent:line-group-agent:line:group:group:G222", key);
+    const routed_key = lineSessionKeyRouted(allocator, &key_buf, evt, &cfg, "line-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:line-group-agent:line:group:group:G222", routed_key.key);
 }
 
 test "lineSessionKeyRouted falls back to user session key without config" {
@@ -8841,8 +8948,9 @@ test "lineSessionKeyRouted falls back to user session key without config" {
         .user_id = "U777",
     };
 
-    const key = lineSessionKeyRouted(allocator, &key_buf, evt, null, "default");
-    try std.testing.expectEqualStrings("line:U777", key);
+    const routed_key = lineSessionKeyRouted(allocator, &key_buf, evt, null, "default");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("line:U777", routed_key.key);
 }
 
 test "lineSessionKeyRouted uses room-prefixed peer id for room events" {
@@ -8874,8 +8982,9 @@ test "lineSessionKeyRouted uses room-prefixed peer id for room events" {
         },
     };
 
-    const key = lineSessionKeyRouted(allocator, &key_buf, evt, &cfg, "line-main");
-    try std.testing.expectEqualStrings("agent:line-room-agent:line:group:room:R333", key);
+    const routed_key = lineSessionKeyRouted(allocator, &key_buf, evt, &cfg, "line-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:line-room-agent:line:group:room:R333", routed_key.key);
 }
 
 test "lineReplyTarget resolves conversation target for group events" {
@@ -8936,8 +9045,9 @@ test "larkSessionKeyRouted uses route engine when config exists" {
         },
     };
 
-    const key = larkSessionKeyRouted(allocator, &key_buf, msg, &cfg, "lark-main");
-    try std.testing.expectEqualStrings("agent:lark-group-agent:lark:group:ou_abc123", key);
+    const routed_key = larkSessionKeyRouted(allocator, &key_buf, msg, &cfg, "lark-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:lark-group-agent:lark:group:ou_abc123", routed_key.key);
 }
 
 test "wecomSessionKeyRouted uses route engine when config exists" {
@@ -8962,8 +9072,9 @@ test "wecomSessionKeyRouted uses route engine when config exists" {
         },
     };
 
-    const key = wecomSessionKeyRouted(allocator, &key_buf, "zhangsan", &cfg, "wecom-main");
-    try std.testing.expectEqualStrings("agent:wecom-dm-agent:wecom:direct:zhangsan", key);
+    const routed_key = wecomSessionKeyRouted(allocator, &key_buf, "zhangsan", &cfg, "wecom-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:wecom-dm-agent:wecom:direct:zhangsan", routed_key.key);
 }
 
 test "wechatSessionKeyRouted uses route engine when config exists" {
@@ -8988,8 +9099,9 @@ test "wechatSessionKeyRouted uses route engine when config exists" {
         },
     };
 
-    const key = wechatSessionKeyRouted(allocator, &key_buf, "openid_123", &cfg, "wechat-main");
-    try std.testing.expectEqualStrings("agent:wechat-dm-agent:wechat:direct:openid_123", key);
+    const routed_key = wechatSessionKeyRouted(allocator, &key_buf, "openid_123", &cfg, "wechat-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:wechat-dm-agent:wechat:direct:openid_123", routed_key.key);
 }
 
 test "maxSessionKeyRouted uses sender identity for direct chats" {
@@ -9014,8 +9126,9 @@ test "maxSessionKeyRouted uses sender identity for direct chats" {
         },
     };
 
-    const key = maxSessionKeyRouted(allocator, &key_buf, "alice", "dialog-123", false, &cfg, "max-main");
-    try std.testing.expectEqualStrings("agent:max-direct-agent:max:direct:alice", key);
+    const routed_key = maxSessionKeyRouted(allocator, &key_buf, "alice", "dialog-123", false, &cfg, "max-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:max-direct-agent:max:direct:alice", routed_key.key);
 }
 
 test "maxSessionKeyRouted uses chat target for group chats" {
@@ -9040,8 +9153,9 @@ test "maxSessionKeyRouted uses chat target for group chats" {
         },
     };
 
-    const key = maxSessionKeyRouted(allocator, &key_buf, "alice", "chat-777", true, &cfg, "max-main");
-    try std.testing.expectEqualStrings("agent:max-group-agent:max:group:chat-777", key);
+    const routed_key = maxSessionKeyRouted(allocator, &key_buf, "alice", "chat-777", true, &cfg, "max-main");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:max-group-agent:max:group:chat-777", routed_key.key);
 }
 
 test "qqSessionKeyRouted uses sender identity for direct chats" {
@@ -9077,8 +9191,9 @@ test "qqSessionKeyRouted uses sender identity for direct chats" {
     );
     defer inbound.deinit(allocator);
 
-    const key = qqSessionKeyRouted(allocator, &inbound, &cfg) orelse return error.TestUnexpectedResult;
-    try std.testing.expectEqualStrings("agent:qq-direct-agent:qq:direct:openid-user", key);
+    const routed_key = qqSessionKeyRouted(allocator, &inbound, &cfg) orelse return error.TestUnexpectedResult;
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:qq-direct-agent:qq:direct:openid-user", routed_key.key);
 }
 
 test "teamsSessionKeyRouted uses sender identity for personal chats" {
@@ -9106,8 +9221,9 @@ test "teamsSessionKeyRouted uses sender identity for personal chats" {
     const body =
         \\{"type":"message","text":"hi","conversation":{"id":"conv-1","conversationType":"personal"},"from":{"id":"user-42"}}
     ;
-    const key = teamsSessionKeyRouted(allocator, &key_buf, &cfg, body, "teams-main", "tenant-1", "conv-1", "user-42");
-    try std.testing.expectEqualStrings("agent:teams-direct-agent:teams:direct:user-42", key);
+    const routed_key = teamsSessionKeyRouted(allocator, &key_buf, &cfg, body, "teams-main", "tenant-1", "conv-1", "user-42");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:teams-direct-agent:teams:direct:user-42", routed_key.key);
 }
 
 test "teamsSessionKeyRouted uses conversation id for channel chats" {
@@ -9135,8 +9251,9 @@ test "teamsSessionKeyRouted uses conversation id for channel chats" {
     const body =
         \\{"type":"message","text":"hi","conversation":{"id":"conv-chan","conversationType":"channel"},"from":{"id":"user-42"}}
     ;
-    const key = teamsSessionKeyRouted(allocator, &key_buf, &cfg, body, "teams-main", "tenant-1", "conv-chan", "user-42");
-    try std.testing.expectEqualStrings("agent:teams-channel-agent:teams:channel:conv-chan", key);
+    const routed_key = teamsSessionKeyRouted(allocator, &key_buf, &cfg, body, "teams-main", "tenant-1", "conv-chan", "user-42");
+    defer routed_key.deinit(allocator);
+    try std.testing.expectEqualStrings("agent:teams-channel-agent:teams:channel:conv-chan", routed_key.key);
 }
 
 fn buildTeamsWebhookRequest(

--- a/src/main.zig
+++ b/src/main.zig
@@ -5394,7 +5394,7 @@ fn runAuth(allocator: std.mem.Allocator, sub_args: []const []const u8) !void {
         std.debug.print("Unknown auth provider: {s}\n\n", .{provider_name});
         std.debug.print("Available providers:\n", .{});
         std.debug.print("  openai-codex    ChatGPT Plus/Pro subscription (OAuth)\n", .{});
-        std.debug.print("  weixin          WeChat personal account (QR code scan)\n", .{});
+        std.debug.print("  weixin          WeChat iLink Bot (QR code scan)\n", .{});
         std_compat.process.exit(1);
     }
 
@@ -5489,7 +5489,7 @@ fn printAuthUsage() void {
         \\
         \\Providers:
         \\  openai-codex    ChatGPT Plus/Pro subscription (OAuth)
-        \\  weixin          WeChat personal account (QR code scan)
+        \\  weixin          WeChat iLink Bot (QR code scan)
         \\
         \\Weixin options:
         \\  --base-url <url>    iLink API base URL (default: https://ilinkai.weixin.qq.com/)
@@ -5504,13 +5504,236 @@ fn printAuthUsage() void {
         \\  nullclaw auth status openai-codex
         \\  nullclaw auth status weixin
         \\  nullclaw auth logout openai-codex
+        \\  nullclaw auth logout weixin
         \\
     , .{AUTH_SUBCOMMANDS}), .{});
 }
 
+const DEFAULT_WEIXIN_BASE_URL = yc.config.config_types.WeixinConfig.DEFAULT_BASE_URL;
+
+fn parseWeixinTimeoutNs(raw: []const u8) !u64 {
+    const seconds = try std.fmt.parseInt(u64, raw, 10);
+    if (seconds == 0) return error.InvalidTimeout;
+    return std.math.mul(u64, seconds, @as(u64, std.time.ns_per_s));
+}
+
+const WeixinCredentialMutation = union(enum) {
+    login: struct {
+        token: []const u8,
+        base_url: []const u8,
+        proxy: ?[]const u8,
+    },
+    logout,
+};
+
+const SelectedWeixinConfig = struct {
+    channel: *std.json.ObjectMap,
+    account: *std.json.ObjectMap,
+    wrapped: bool,
+};
+
+fn clearWeixinCredentialFields(object: *std.json.ObjectMap) void {
+    _ = object.swapRemove("token");
+    _ = object.swapRemove("base_url");
+    _ = object.swapRemove("proxy");
+}
+
+fn isValidWeixinAccountJson(object: std.json.ObjectMap) bool {
+    inline for (.{ "account_id", "token", "base_url" }) |field| {
+        if (object.get(field)) |value| {
+            if (value != .string) return false;
+        }
+    }
+    if (object.get("proxy")) |proxy| {
+        if (proxy != .null and proxy != .string) return false;
+    }
+    if (object.get("allow_from")) |allow_from| {
+        if (allow_from != .array) return false;
+        for (allow_from.array.items) |entry| {
+            // Match config parsing, which also accepts integer IDs and coerces them to strings.
+            if (entry != .string and entry != .integer) return false;
+        }
+    }
+    return true;
+}
+
+fn putJsonString(
+    allocator: std.mem.Allocator,
+    object: *std.json.ObjectMap,
+    key: []const u8,
+    value: []const u8,
+) !void {
+    const owned_value = try allocator.dupe(u8, value);
+    if (object.getPtr(key)) |slot| {
+        slot.* = .{ .string = owned_value };
+        return;
+    }
+    try object.put(allocator, try allocator.dupe(u8, key), .{ .string = owned_value });
+}
+
+fn migrateLegacyWeixinAccounts(allocator: std.mem.Allocator, channel: *std.json.Value) !void {
+    if (channel.* != .array) return;
+
+    var accounts: std.json.ObjectMap = .empty;
+    for (channel.array.items, 0..) |item, index| {
+        if (item != .object) return error.InvalidWeixinConfig;
+
+        var account = item;
+        const configured_id = if (account.object.get("account_id")) |account_id|
+            if (account_id == .string and account_id.string.len > 0) account_id.string else null
+        else
+            null;
+
+        var account_id = configured_id orelse if (index == 0)
+            "default"
+        else
+            try std.fmt.allocPrint(allocator, "account-{d}", .{index + 1});
+        var suffix = index + 1;
+        while (accounts.get(account_id) != null) : (suffix += 1) {
+            account_id = try std.fmt.allocPrint(allocator, "account-{d}", .{suffix});
+        }
+
+        _ = account.object.swapRemove("account_id");
+        try accounts.put(allocator, try allocator.dupe(u8, account_id), account);
+    }
+
+    channel.* = .{ .object = .empty };
+    if (accounts.count() > 0) {
+        try channel.object.put(allocator, try allocator.dupe(u8, "accounts"), .{ .object = accounts });
+    }
+}
+
+fn selectWeixinConfig(
+    allocator: std.mem.Allocator,
+    channel: *std.json.Value,
+) !SelectedWeixinConfig {
+    try migrateLegacyWeixinAccounts(allocator, channel);
+    if (channel.* != .object) return error.InvalidWeixinConfig;
+
+    const channel_object = &channel.object;
+    const accounts_value = channel_object.getPtr("accounts") orelse return .{
+        .channel = channel_object,
+        .account = channel_object,
+        .wrapped = false,
+    };
+    if (accounts_value.* != .object) return error.InvalidWeixinConfig;
+
+    const accounts = &accounts_value.object;
+    var object_count: usize = 0;
+    var count_it = accounts.iterator();
+    while (count_it.next()) |entry| {
+        if (entry.value_ptr.* == .object) object_count += 1;
+    }
+    if (object_count == 0) {
+        // Match config parsing: an empty (or entirely malformed) accounts map
+        // falls back to the inline channel object.
+        return .{ .channel = channel_object, .account = channel_object, .wrapped = false };
+    }
+
+    if (accounts.getPtr("default")) |account| {
+        if (account.* == .object) return .{ .channel = channel_object, .account = &account.object, .wrapped = true };
+    }
+    if (accounts.getPtr("main")) |account| {
+        if (account.* == .object) return .{ .channel = channel_object, .account = &account.object, .wrapped = true };
+    }
+
+    var selected_key: ?[]const u8 = null;
+    var selected_value: ?*std.json.Value = null;
+    var it = accounts.iterator();
+    while (it.next()) |entry| {
+        if (entry.value_ptr.* != .object) continue;
+        if (selected_key == null or std.mem.order(u8, entry.key_ptr.*, selected_key.?) == .lt) {
+            selected_key = entry.key_ptr.*;
+            selected_value = entry.value_ptr;
+        }
+    }
+    const account = selected_value orelse unreachable;
+    return .{ .channel = channel_object, .account = &account.object, .wrapped = true };
+}
+
+fn updateWeixinChannelJson(
+    allocator: std.mem.Allocator,
+    current_json: ?[]const u8,
+    mutation: WeixinCredentialMutation,
+) ![]u8 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        arena_allocator,
+        current_json orelse "{}",
+        .{},
+    );
+    var channel = parsed.value;
+    const selected = try selectWeixinConfig(arena_allocator, &channel);
+
+    switch (mutation) {
+        .login => |credentials| {
+            try putJsonString(arena_allocator, selected.account, "token", credentials.token);
+            if (std.mem.eql(u8, credentials.base_url, DEFAULT_WEIXIN_BASE_URL)) {
+                _ = selected.account.swapRemove("base_url");
+            } else {
+                try putJsonString(arena_allocator, selected.account, "base_url", credentials.base_url);
+            }
+            if (credentials.proxy) |proxy| {
+                try putJsonString(arena_allocator, selected.account, "proxy", proxy);
+            }
+            if (selected.account.get("allow_from") == null) {
+                try selected.account.put(
+                    arena_allocator,
+                    try arena_allocator.dupe(u8, "allow_from"),
+                    .{ .array = std.json.Array.init(arena_allocator) },
+                );
+            }
+            if (!isValidWeixinAccountJson(selected.account.*)) return error.InvalidWeixinConfig;
+        },
+        .logout => {
+            _ = selected.account.swapRemove("token");
+        },
+    }
+
+    if (selected.wrapped) {
+        // Older login commands wrote ignored credentials beside `accounts`.
+        clearWeixinCredentialFields(selected.channel);
+    }
+
+    return std.json.Stringify.valueAlloc(allocator, channel, .{ .whitespace = .indent_2 });
+}
+
+fn mutateStoredWeixinCredentials(
+    allocator: std.mem.Allocator,
+    mutation: WeixinCredentialMutation,
+) !bool {
+    const config_mutator = yc.config_mutator;
+    const current_json = config_mutator.findPathValueJson(allocator, "channels.weixin") catch |err| switch (err) {
+        error.FileNotFound => null,
+        else => return err,
+    };
+    defer if (current_json) |json| allocator.free(json);
+
+    switch (mutation) {
+        .logout => if (current_json == null) return false,
+        .login => {},
+    }
+
+    const updated_json = try updateWeixinChannelJson(allocator, current_json, mutation);
+    defer allocator.free(updated_json);
+
+    var result = try config_mutator.mutateDefaultConfig(
+        allocator,
+        .set,
+        "channels.weixin",
+        updated_json,
+        .{ .apply = true },
+    );
+    defer config_mutator.freeMutationResult(allocator, &result);
+    return result.changed;
+}
+
 fn runAuthWeixin(allocator: std.mem.Allocator, subcmd: []const u8, args: []const []const u8) void {
     const weixin_mod = yc.channels.weixin;
-    const config_mutator = yc.config_mutator;
 
     if (std.mem.eql(u8, subcmd, "login")) {
         var opts = weixin_mod.LoginOptions{};
@@ -5525,11 +5748,10 @@ fn runAuthWeixin(allocator: std.mem.Allocator, subcmd: []const u8, args: []const
                 opts.proxy = args[i];
             } else if (std.mem.eql(u8, args[i], "--timeout") and i + 1 < args.len) {
                 i += 1;
-                const secs = std.fmt.parseInt(u64, args[i], 10) catch {
+                opts.timeout_ns = parseWeixinTimeoutNs(args[i]) catch {
                     std.debug.print("Invalid timeout value: {s}\n", .{args[i]});
                     std.process.exit(1);
                 };
-                opts.timeout_ns = secs * std.time.ns_per_s;
             } else {
                 std.debug.print("Unknown option: {s}\n", .{args[i]});
                 printAuthUsage();
@@ -5537,7 +5759,18 @@ fn runAuthWeixin(allocator: std.mem.Allocator, subcmd: []const u8, args: []const
             }
         }
 
-        std.debug.print("Starting Weixin (WeChat personal) login...\n\n", .{});
+        if (!weixin_mod.isValidBaseUrl(opts.base_url)) {
+            std.debug.print("Invalid Weixin base URL: expected an HTTPS URL without a query or fragment.\n", .{});
+            std.process.exit(1);
+        }
+        if (opts.proxy) |proxy| {
+            if (!yc.config.HttpRequestConfig.isValidProxyUrl(proxy)) {
+                std.debug.print("Invalid Weixin proxy URL.\n", .{});
+                std.process.exit(1);
+            }
+        }
+
+        std.debug.print("Starting Weixin iLink Bot login...\n\n", .{});
 
         var result = weixin_mod.performLogin(allocator, opts) catch |err| {
             std.debug.print("Weixin login failed: {s}\n", .{@errorName(err)});
@@ -5551,43 +5784,21 @@ fn runAuthWeixin(allocator: std.mem.Allocator, subcmd: []const u8, args: []const
             std.debug.print("  User ID: {s}\n", .{result.user_id});
         }
 
-        // Persist token to config
-        const token_json = std.fmt.allocPrint(allocator, "\"{s}\"", .{result.bot_token}) catch {
-            std.debug.print("\nCould not format token for config. Add manually:\n", .{});
-            printManualWeixinConfig(result.bot_token, result.base_url);
-            return;
+        _ = mutateStoredWeixinCredentials(allocator, .{ .login = .{
+            .token = result.bot_token,
+            .base_url = result.base_url,
+            .proxy = opts.proxy,
+        } }) catch {
+            // Never print the bot token: fix the config error and repeat login instead.
+            std.debug.print("\nCould not auto-save Weixin credentials. Fix the config and repeat login.\n", .{});
+            // NOTE: This process-exit path is not unit-tested because it would terminate the test runner.
+            std.process.exit(1);
         };
-        defer allocator.free(token_json);
-
-        _ = config_mutator.mutateDefaultConfig(
-            allocator,
-            .set,
-            "channels.weixin.token",
-            token_json,
-            .{ .apply = true },
-        ) catch {
-            std.debug.print("\nCould not auto-save config. Add manually:\n", .{});
-            printManualWeixinConfig(result.bot_token, result.base_url);
-            return;
-        };
-
-        // Save base_url if it differs from default
-        if (!std.mem.eql(u8, result.base_url, "https://ilinkai.weixin.qq.com/")) {
-            const base_url_json = std.fmt.allocPrint(allocator, "\"{s}\"", .{result.base_url}) catch return;
-            defer allocator.free(base_url_json);
-            _ = config_mutator.mutateDefaultConfig(
-                allocator,
-                .set,
-                "channels.weixin.base_url",
-                base_url_json,
-                .{ .apply = true },
-            ) catch {};
-        }
 
         std.debug.print("\nConfig updated. Start the gateway with:\n", .{});
         std.debug.print("  nullclaw gateway\n\n", .{});
-        std.debug.print("To restrict which WeChat users can send messages, add their user IDs\n", .{});
-        std.debug.print("to channels.weixin.allow_from in your config.\n", .{});
+        std.debug.print("No inbound messages are accepted until allow_from on the updated\n", .{});
+        std.debug.print("Weixin account lists trusted user IDs (or an intentional \"*\").\n", .{});
     } else if (std.mem.eql(u8, subcmd, "status")) {
         var arena = std.heap.ArenaAllocator.init(allocator);
         defer arena.deinit();
@@ -5599,14 +5810,11 @@ fn runAuthWeixin(allocator: std.mem.Allocator, subcmd: []const u8, args: []const
 
         if (cfg.channels.weixinPrimary()) |weixin_cfg| {
             if (weixin_cfg.token.len > 0) {
-                std.debug.print("weixin: authenticated\n", .{});
-                std.debug.print("  Token: {s}...{s}\n", .{
-                    weixin_cfg.token[0..@min(8, weixin_cfg.token.len)],
-                    if (weixin_cfg.token.len > 8) weixin_cfg.token[weixin_cfg.token.len - 4 ..] else "",
-                });
+                std.debug.print("weixin: token configured\n", .{});
+                // Do not print token material; status reports configuration, not remote validity.
                 std.debug.print("  Base URL: {s}\n", .{weixin_cfg.base_url});
             } else {
-                std.debug.print("weixin: not authenticated (token empty)\n", .{});
+                std.debug.print("weixin: not configured (token empty)\n", .{});
                 std.debug.print("  Run `nullclaw auth login weixin` to authenticate.\n", .{});
             }
         } else {
@@ -5614,33 +5822,20 @@ fn runAuthWeixin(allocator: std.mem.Allocator, subcmd: []const u8, args: []const
             std.debug.print("  Run `nullclaw auth login weixin` to authenticate.\n", .{});
         }
     } else if (std.mem.eql(u8, subcmd, "logout")) {
-        _ = config_mutator.mutateDefaultConfig(
-            allocator,
-            .unset,
-            "channels.weixin.token",
-            null,
-            .{ .apply = true },
-        ) catch |err| {
+        const changed = mutateStoredWeixinCredentials(allocator, .logout) catch |err| {
             std.debug.print("Failed to remove weixin credentials: {s}\n", .{@errorName(err)});
             return;
         };
-        std.debug.print("weixin: credentials removed.\n", .{});
+        if (changed) {
+            std.debug.print("weixin: credentials removed.\n", .{});
+        } else {
+            std.debug.print("weixin: no configured credentials to remove.\n", .{});
+        }
     } else {
         std.debug.print("Unknown auth command: {s}\n\n", .{subcmd});
         printAuthUsage();
         std.process.exit(1);
     }
-}
-
-fn printManualWeixinConfig(token: []const u8, base_url: []const u8) void {
-    std.debug.print("\nAdd the following to the channels section of your nullclaw config:\n\n", .{});
-    std.debug.print("  \"weixin\": [{{\n", .{});
-    std.debug.print("    \"token\": \"{s}\",\n", .{token});
-    if (!std.mem.eql(u8, base_url, "https://ilinkai.weixin.qq.com/")) {
-        std.debug.print("    \"base_url\": \"{s}\",\n", .{base_url});
-    }
-    std.debug.print("    \"allow_from\": []\n", .{});
-    std.debug.print("  }}]\n", .{});
 }
 
 fn runAuthDeviceCodeLogin(
@@ -6209,6 +6404,266 @@ test "writeJsonString wraps and escapes special characters" {
     try writeJsonString(&aw.writer, "line \"one\"\nline two\\");
     const written = aw.writer.buffer[0..aw.writer.end];
     try std.testing.expectEqualStrings("\"line \\\"one\\\"\\nline two\\\\\"", written);
+}
+
+test "weixin timeout parsing rejects zero and overflow" {
+    try std.testing.expectEqual(@as(u64, 5 * std.time.ns_per_s), try parseWeixinTimeoutNs("5"));
+    try std.testing.expectError(error.InvalidTimeout, parseWeixinTimeoutNs("0"));
+    try std.testing.expectError(error.Overflow, parseWeixinTimeoutNs("18446744073709551615"));
+}
+
+test "weixin credential update round trips escaped credentials" {
+    const channel_json = try updateWeixinChannelJson(std.testing.allocator, null, .{ .login = .{
+        .token = "token-\"line\nnext",
+        .base_url = "https://region.example.com/",
+        .proxy = "http://127.0.0.1:7890",
+    } });
+    defer std.testing.allocator.free(channel_json);
+    const rendered = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"channels\":{{\"weixin\":{s}}}}}",
+        .{channel_json},
+    );
+    defer std.testing.allocator.free(rendered);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var cfg = yc.config.Config{
+        .workspace_dir = "/tmp/nullclaw-test",
+        .config_path = "/tmp/nullclaw-test/config.json",
+        .allocator = arena.allocator(),
+    };
+    try cfg.parseJson(rendered);
+
+    try std.testing.expectEqual(@as(usize, 1), cfg.channels.weixin.len);
+    const weixin = cfg.channels.weixin[0];
+    try std.testing.expectEqualStrings("token-\"line\nnext", weixin.token);
+    try std.testing.expectEqualStrings("https://region.example.com/", weixin.base_url);
+    try std.testing.expectEqualStrings("http://127.0.0.1:7890", weixin.proxy.?);
+    try std.testing.expectEqual(@as(usize, 0), weixin.allow_from.len);
+}
+
+test "weixin credential update preserves primary account settings" {
+    const current =
+        \\{
+        \\  "accounts": {
+        \\    "backup": {"token":"keep","allow_from":["backup-user"]},
+        \\    "default": {"token":"old","base_url":"https://stale.example.com/","proxy":"http://127.0.0.1:7890","allow_from":["primary-user"]}
+        \\  },
+        \\  "token": "ignored-legacy-token",
+        \\  "base_url": "https://ignored.example.com/"
+        \\}
+    ;
+    const updated = try updateWeixinChannelJson(std.testing.allocator, current, .{ .login = .{
+        .token = "new-token",
+        .base_url = DEFAULT_WEIXIN_BASE_URL,
+        .proxy = null,
+    } });
+    defer std.testing.allocator.free(updated);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, updated, .{});
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value.object.get("token") == null);
+    try std.testing.expect(parsed.value.object.get("base_url") == null);
+
+    const accounts = parsed.value.object.get("accounts").?.object;
+    const primary = accounts.get("default").?.object;
+    try std.testing.expectEqualStrings("new-token", primary.get("token").?.string);
+    try std.testing.expect(primary.get("base_url") == null);
+    try std.testing.expectEqualStrings("http://127.0.0.1:7890", primary.get("proxy").?.string);
+    try std.testing.expectEqualStrings("primary-user", primary.get("allow_from").?.array.items[0].string);
+    try std.testing.expectEqualStrings("keep", accounts.get("backup").?.object.get("token").?.string);
+
+    const rendered = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"channels\":{{\"weixin\":{s}}}}}",
+        .{updated},
+    );
+    defer std.testing.allocator.free(rendered);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var cfg = yc.config.Config{
+        .workspace_dir = "/tmp/nullclaw-test",
+        .config_path = "/tmp/nullclaw-test/config.json",
+        .allocator = arena.allocator(),
+    };
+    try cfg.parseJson(rendered);
+    try std.testing.expectEqualStrings("new-token", cfg.channels.weixinPrimary().?.token);
+}
+
+test "weixin credential update selects lexical account and overwrites proxy" {
+    const current =
+        \\{"accounts":{"zeta":{"token":"keep"},"alpha":{"token":"old","proxy":"http://127.0.0.1:7000"}}}
+    ;
+    const updated = try updateWeixinChannelJson(std.testing.allocator, current, .{ .login = .{
+        .token = "new-token",
+        .base_url = "https://region.example.com/",
+        .proxy = "socks5://127.0.0.1:1080",
+    } });
+    defer std.testing.allocator.free(updated);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, updated, .{});
+    defer parsed.deinit();
+    const accounts = parsed.value.object.get("accounts").?.object;
+    const selected = accounts.get("alpha").?.object;
+    try std.testing.expectEqualStrings("new-token", selected.get("token").?.string);
+    try std.testing.expectEqualStrings("https://region.example.com/", selected.get("base_url").?.string);
+    try std.testing.expectEqualStrings("socks5://127.0.0.1:1080", selected.get("proxy").?.string);
+    try std.testing.expectEqualStrings("keep", accounts.get("zeta").?.object.get("token").?.string);
+}
+
+test "weixin credential update migrates legacy arrays without dropping accounts" {
+    const current =
+        \\[
+        \\  {"account_id":"main","token":"old","allow_from":["main-user"]},
+        \\  {"account_id":"backup","token":"keep","allow_from":["backup-user"]}
+        \\]
+    ;
+    const updated = try updateWeixinChannelJson(std.testing.allocator, current, .{ .login = .{
+        .token = "new-token",
+        .base_url = DEFAULT_WEIXIN_BASE_URL,
+        .proxy = null,
+    } });
+    defer std.testing.allocator.free(updated);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, updated, .{});
+    defer parsed.deinit();
+    const accounts = parsed.value.object.get("accounts").?.object;
+    try std.testing.expectEqual(@as(usize, 2), accounts.count());
+    try std.testing.expectEqualStrings("new-token", accounts.get("main").?.object.get("token").?.string);
+    try std.testing.expectEqualStrings("main-user", accounts.get("main").?.object.get("allow_from").?.array.items[0].string);
+    try std.testing.expectEqualStrings("keep", accounts.get("backup").?.object.get("token").?.string);
+    try std.testing.expectEqualStrings("backup-user", accounts.get("backup").?.object.get("allow_from").?.array.items[0].string);
+}
+
+test "weixin login preserves inline settings beside empty accounts" {
+    const current =
+        \\{"accounts":{},"token":"old","base_url":"https://old.example.com/","proxy":"http://127.0.0.1:7890","allow_from":["trusted-user"]}
+    ;
+    const updated = try updateWeixinChannelJson(std.testing.allocator, current, .{ .login = .{
+        .token = "new-token",
+        .base_url = DEFAULT_WEIXIN_BASE_URL,
+        .proxy = null,
+    } });
+    defer std.testing.allocator.free(updated);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, updated, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 0), parsed.value.object.get("accounts").?.object.count());
+    try std.testing.expectEqualStrings("new-token", parsed.value.object.get("token").?.string);
+    try std.testing.expect(parsed.value.object.get("base_url") == null);
+    try std.testing.expectEqualStrings("http://127.0.0.1:7890", parsed.value.object.get("proxy").?.string);
+    try std.testing.expectEqualStrings("trusted-user", parsed.value.object.get("allow_from").?.array.items[0].string);
+
+    const rendered = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"channels\":{{\"weixin\":{s}}}}}",
+        .{updated},
+    );
+    defer std.testing.allocator.free(rendered);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var cfg = yc.config.Config{
+        .workspace_dir = "/tmp/nullclaw-test",
+        .config_path = "/tmp/nullclaw-test/config.json",
+        .allocator = arena.allocator(),
+    };
+    try cfg.parseJson(rendered);
+    const weixin = cfg.channels.weixinPrimary().?;
+    try std.testing.expectEqualStrings("new-token", weixin.token);
+    try std.testing.expectEqualStrings("http://127.0.0.1:7890", weixin.proxy.?);
+    try std.testing.expectEqualStrings("trusted-user", weixin.allow_from[0]);
+}
+
+test "weixin logout removes only preferred account credentials" {
+    const current =
+        \\{"accounts":{"default":{"token":"remove","allow_from":["primary-user"]},"backup":{"token":"keep"}},"token":"ignored"}
+    ;
+    const updated = try updateWeixinChannelJson(std.testing.allocator, current, .logout);
+    defer std.testing.allocator.free(updated);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, updated, .{});
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value.object.get("token") == null);
+    const accounts = parsed.value.object.get("accounts").?.object;
+    try std.testing.expect(accounts.get("default").?.object.get("token") == null);
+    try std.testing.expectEqualStrings("primary-user", accounts.get("default").?.object.get("allow_from").?.array.items[0].string);
+    try std.testing.expectEqualStrings("keep", accounts.get("backup").?.object.get("token").?.string);
+}
+
+test "weixin logout does not create a missing account" {
+    const updated = try updateWeixinChannelJson(
+        std.testing.allocator,
+        "{\"accounts\":{},\"token\":\"active-token\",\"base_url\":\"https://stale.example.com/\",\"proxy\":\"http://127.0.0.1:7890\"}",
+        .logout,
+    );
+    defer std.testing.allocator.free(updated);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, updated, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 0), parsed.value.object.get("accounts").?.object.count());
+    try std.testing.expect(parsed.value.object.get("token") == null);
+    try std.testing.expectEqualStrings("https://stale.example.com/", parsed.value.object.get("base_url").?.string);
+    try std.testing.expectEqualStrings("http://127.0.0.1:7890", parsed.value.object.get("proxy").?.string);
+
+    const rendered = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"channels\":{{\"weixin\":{s}}}}}",
+        .{updated},
+    );
+    defer std.testing.allocator.free(rendered);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var cfg = yc.config.Config{
+        .workspace_dir = "/tmp/nullclaw-test",
+        .config_path = "/tmp/nullclaw-test/config.json",
+        .allocator = arena.allocator(),
+    };
+    try cfg.parseJson(rendered);
+    try std.testing.expectEqual(@as(usize, 0), cfg.channels.weixinPrimary().?.token.len);
+}
+
+test "weixin credential update rejects invalid accounts shape" {
+    try std.testing.expectError(
+        error.InvalidWeixinConfig,
+        updateWeixinChannelJson(std.testing.allocator, "{\"accounts\":[]}", .logout),
+    );
+}
+
+test "weixin login rejects malformed selected account" {
+    try std.testing.expectError(
+        error.InvalidWeixinConfig,
+        updateWeixinChannelJson(
+            std.testing.allocator,
+            "{\"accounts\":{\"default\":{\"allow_from\":\"alice\"},\"backup\":{\"token\":\"keep\"}}}",
+            .{ .login = .{
+                .token = "new-token",
+                .base_url = DEFAULT_WEIXIN_BASE_URL,
+                .proxy = null,
+            } },
+        ),
+    );
+}
+
+test "weixin login ignores malformed account entries like config parsing" {
+    const updated = try updateWeixinChannelJson(
+        std.testing.allocator,
+        "{\"accounts\":{\"default\":false,\"backup\":{\"token\":\"old\"}}}",
+        .{ .login = .{
+            .token = "new-token",
+            .base_url = DEFAULT_WEIXIN_BASE_URL,
+            .proxy = null,
+        } },
+    );
+    defer std.testing.allocator.free(updated);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, updated, .{});
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value.object.get("accounts").?.object.get("default").? == .bool);
+    try std.testing.expectEqualStrings(
+        "new-token",
+        parsed.value.object.get("accounts").?.object.get("backup").?.object.get("token").?.string,
+    );
 }
 
 test "skillSource distinguishes workspace and community skills" {


### PR DESCRIPTION
## Summary

Documents the Weixin iLink Bot QR authorization flow in the English and Chinese channel guides, and hardens the existing implementation uncovered during review.

Ref: #817 | Closes #817

## What changed

- Clarifies that `weixin` is the iLink Bot transport and is distinct from the signed-webhook `wechat` Official Account channel and WeCom.
- Makes `nullclaw auth login/status/logout weixin` preserve inline, multi-account, and legacy-array configs without exposing token material.
- Persists proxy and redirected base URL settings, validates credential-bearing HTTPS/proxy URLs, and exits non-zero when credentials cannot be saved.
- Makes empty inbound allowlists fail closed across the affected channel paths; Tencent sender IDs use exact case-sensitive matching.
- Fixes partial-allocation/OOM cleanup in Weixin parsing and login responses.
- Fixes leaked routed gateway session keys across webhook channel handlers.
- Converts stale WeChat/Max/Teams config examples to canonical `accounts` paths and corrects stale IRC `channel` examples.
- Keeps the intentional, documented MaixCam empty-allowlist exception unchanged.

## Validation

- `zig build test --summary all` — 7,402 passed, 9 skipped, zero leaks
- `zig build -Doptimize=ReleaseSmall`
- GitHub CI: Linux x86_64, macOS aarch64, and Windows x86_64 all passed

## Compatibility note

For the affected allowlist-based channels, an empty `allow_from` now denies inbound messages. Use explicit sender IDs, or `"*"` only for an intentionally open bot.