### PR TITLE
Enable native API-level tool calls during streaming

### DIFF
--- a/src/agent/cli.zig
+++ b/src/agent/cli.zig
@@ -65,8 +65,8 @@ const CliProviderContext = struct {
     }
 };
 
-fn shouldPrintTurnResponse(supports_streaming: bool, emitted_text: bool) bool {
-    return !supports_streaming or !emitted_text;
+fn shouldPrintTurnResponse(emitted_text: bool) bool {
+    return !emitted_text;
 }
 
 fn shouldSuppressLiveForRedaction(redactor: ?*redaction.Redactor, content: []const u8) bool {
@@ -74,10 +74,15 @@ fn shouldSuppressLiveForRedaction(redactor: ?*redaction.Redactor, content: []con
     return r.wouldRehydrate() or (r.config.record_originals and r.wouldRedact(content));
 }
 
-fn shouldPrintSeparateUsage(supports_streaming: bool, emitted_text: bool) bool {
+fn shouldPrintSeparateUsage(emitted_text: bool) bool {
     // Agent.turn already embeds usage in the returned final text. The CLI only
     // needs a separate usage line when streaming printed that final text live.
-    return supports_streaming and emitted_text;
+    return emitted_text;
+}
+
+fn attachCliStream(agent: *Agent, stream_ctx: *CliStreamCtx) void {
+    agent.stream_callback = cliStreamCallback;
+    agent.stream_ctx = @ptrCast(stream_ctx);
 }
 
 fn maybePrintUsage(w: anytype, agent: *const Agent) !void {
@@ -646,7 +651,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         }
         defer agent.deinit();
 
-        // Enable streaming if provider supports it.
+        // Attach the streaming sink; Agent.turn gates it per selected model.
         // When reasoning_mode == .stream, use ThinkPassthroughFilter so that
         // <think> content is printed live instead of being silently stripped.
         var stream_ctx = CliStreamCtx{
@@ -662,10 +667,9 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         } else {
             stream_ctx.sink = makeCliStreamSink(raw_stream_sink, &stream_ctx.filter);
         }
-        if (supports_streaming) {
-            agent.stream_callback = cliStreamCallback;
-            agent.stream_ctx = @ptrCast(&stream_ctx);
-        }
+        // Always attach the sink. Agent.turn decides per selected turn model
+        // whether streaming is supported (important for router/model overrides).
+        attachCliStream(&agent, &stream_ctx);
 
         stream_ctx.emitted_text = false;
         const response = agent.turn(message) catch |err| {
@@ -692,7 +696,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
 
         persistCliTurn(&agent, message, response);
 
-        if (shouldPrintTurnResponse(supports_streaming, stream_ctx.emitted_text)) {
+        if (shouldPrintTurnResponse(stream_ctx.emitted_text)) {
             // unredact() always returns a fresh allocation when the redactor
             // is on. Use an optional so cleanup logic doesn't depend on
             // pointer identity.
@@ -706,7 +710,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         } else {
             try w.print("\n", .{});
         }
-        if (shouldPrintSeparateUsage(supports_streaming, stream_ctx.emitted_text)) {
+        if (shouldPrintSeparateUsage(stream_ctx.emitted_text)) {
             try maybePrintUsage(w, &agent);
         }
         try w.flush();
@@ -785,7 +789,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
     }
     defer agent.deinit();
 
-    // Enable streaming if provider supports it.
+    // Attach the streaming sink; Agent.turn gates it per selected model.
     // When reasoning_mode == .stream, use ThinkPassthroughFilter so that
     // <think> content is printed live instead of being silently stripped.
     var stream_ctx = CliStreamCtx{
@@ -801,10 +805,9 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
     } else {
         stream_ctx.sink = makeCliStreamSink(raw_stream_sink, &stream_ctx.filter);
     }
-    if (supports_streaming) {
-        agent.stream_callback = cliStreamCallback;
-        agent.stream_ctx = @ptrCast(&stream_ctx);
-    }
+    // Always attach the sink. Agent.turn decides per selected turn model
+    // whether streaming is supported (including models selected via /model).
+    attachCliStream(&agent, &stream_ctx);
 
     const stdin = std_compat.fs.File.stdin();
     var line_buf: [4096]u8 = undefined;
@@ -886,7 +889,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
 
         persistCliTurn(&agent, debounced_input.current, response);
 
-        if (shouldPrintTurnResponse(supports_streaming, stream_ctx.emitted_text)) {
+        if (shouldPrintTurnResponse(stream_ctx.emitted_text)) {
             const unredacted: ?[]u8 = if (agent.redactor) |r|
                 (if (r.wouldRehydrate()) try r.unredact(allocator, response) else null)
             else
@@ -897,7 +900,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         } else {
             try w.print("\n\n", .{});
         }
-        if (shouldPrintSeparateUsage(supports_streaming, stream_ctx.emitted_text)) {
+        if (shouldPrintSeparateUsage(stream_ctx.emitted_text)) {
             try maybePrintUsage(w, &agent);
         }
         try w.flush();
@@ -1110,7 +1113,7 @@ test "cliStreamCallback keeps emitted_text false for filtered tool_call-only chu
     cliStreamCallback(@ptrCast(&ctx), providers.StreamChunk.finalChunk());
 
     try std.testing.expect(!ctx.emitted_text);
-    try std.testing.expect(shouldPrintTurnResponse(true, ctx.emitted_text));
+    try std.testing.expect(shouldPrintTurnResponse(ctx.emitted_text));
 }
 
 test "parseAgentArgs parses provider and model overrides" {
@@ -1171,12 +1174,27 @@ test "activeCliProvider uses returned holder storage for named agents" {
 }
 
 test "shouldPrintTurnResponse prints fallback when streaming emits no text" {
-    try std.testing.expect(shouldPrintTurnResponse(true, false));
-    try std.testing.expect(shouldPrintTurnResponse(false, false));
+    try std.testing.expect(shouldPrintTurnResponse(false));
 }
 
 test "shouldPrintTurnResponse suppresses duplicate output after streamed text" {
-    try std.testing.expect(!shouldPrintTurnResponse(true, true));
+    // Regression: the provider-wide capability may be false even when a
+    // dynamically routed turn streams. Observed output is authoritative.
+    try std.testing.expect(!shouldPrintTurnResponse(true));
+}
+
+test "attachCliStream does not pre-gate dynamically routed models" {
+    // Regression: Provider.supportsStreaming() may describe a non-streaming
+    // default route while the selected turn model supports streaming.
+    var agent: Agent = undefined;
+    var stream_ctx = CliStreamCtx{ .sink = undefined };
+    attachCliStream(&agent, &stream_ctx);
+
+    try std.testing.expect(agent.stream_callback != null);
+    try std.testing.expectEqual(
+        @intFromPtr(&stream_ctx),
+        @intFromPtr(agent.stream_ctx.?),
+    );
 }
 
 test "persistCliTurn redacts PII before session persistence" {
@@ -1372,9 +1390,8 @@ test "providerFailureLooksQuotaConstrained detects rate and quota detail" {
 test "shouldPrintSeparateUsage only for streaming text already emitted" {
     // Regression: non-streaming CLI responses already include composeFinalReply
     // usage details, so a second CLI usage line would duplicate the same turn.
-    try std.testing.expect(!shouldPrintSeparateUsage(false, false));
-    try std.testing.expect(!shouldPrintSeparateUsage(true, false));
-    try std.testing.expect(shouldPrintSeparateUsage(true, true));
+    try std.testing.expect(!shouldPrintSeparateUsage(false));
+    try std.testing.expect(shouldPrintSeparateUsage(true));
 }
 
 test "writeRateLimitHint mentions reliability knobs and logs" {

--- a/src/agent/dispatcher.zig
+++ b/src/agent/dispatcher.zig
@@ -379,10 +379,17 @@ pub fn parseStructuredToolCalls(
     for (tool_calls) |tc| {
         if (tc.name.len == 0) continue;
 
+        const name = try allocator.dupe(u8, tc.name);
+        errdefer allocator.free(name);
+        const arguments_json = try allocator.dupe(u8, tc.arguments);
+        errdefer allocator.free(arguments_json);
+        const tool_call_id = if (tc.id.len > 0) try allocator.dupe(u8, tc.id) else null;
+        errdefer if (tool_call_id) |id| allocator.free(id);
+
         try calls.append(allocator, .{
-            .name = try allocator.dupe(u8, tc.name),
-            .arguments_json = try allocator.dupe(u8, tc.arguments),
-            .tool_call_id = if (tc.id.len > 0) try allocator.dupe(u8, tc.id) else null,
+            .name = name,
+            .arguments_json = arguments_json,
+            .tool_call_id = tool_call_id,
         });
     }
 
@@ -2562,6 +2569,32 @@ test "parseStructuredToolCalls empty id becomes null" {
 
     try std.testing.expectEqual(@as(usize, 1), result.len);
     try std.testing.expect(result[0].tool_call_id == null);
+}
+
+fn parseStructuredToolCallsAllocationTest(allocator: std.mem.Allocator) !void {
+    const tool_calls = [_]providers.ToolCall{
+        .{ .id = "call_1", .name = "shell", .arguments = "{\"command\":\"pwd\"}" },
+        .{ .id = "call_2", .name = "file_read", .arguments = "{\"path\":\"README.md\"}" },
+    };
+    const result = try parseStructuredToolCalls(allocator, &tool_calls);
+    defer {
+        for (result) |call| {
+            allocator.free(call.name);
+            allocator.free(call.arguments_json);
+            if (call.tool_call_id) |id| allocator.free(id);
+        }
+        allocator.free(result);
+    }
+}
+
+test "parseStructuredToolCalls allocation failures do not leak" {
+    // Regression: native streaming tool calls exercise every intermediate
+    // allocation before the ParsedToolCall is owned by the result list.
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        parseStructuredToolCallsAllocationTest,
+        .{},
+    );
 }
 
 // ── extractJsonObject with arrays ───────────────────────────────

--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -2021,8 +2021,7 @@ pub const Agent = struct {
             var prompt_tools_arena = std.heap.ArenaAllocator.init(self.allocator);
             defer prompt_tools_arena.deinit();
             const prompt_tools = try self.filterToolsForPromptText(prompt_tools_arena.allocator());
-            const prompt_is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
-            const prompt_native_tools_enabled = !prompt_is_streaming and self.provider.supportsNativeTools();
+            const prompt_native_tools_enabled = self.provider.supportsNativeTools();
 
             const capabilities_section = capabilities_mod.buildPromptSection(
                 self.allocator,
@@ -2200,7 +2199,7 @@ pub const Agent = struct {
 
             const timer_start = std_compat.time.milliTimestamp();
             const is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
-            const native_tools_enabled = !is_streaming and self.provider.supportsNativeTools();
+            const native_tools_enabled = self.provider.supportsNativeTools();
             const include_reasoning = self.reasoning_mode != .off;
 
             // Filter tool specs for this turn (arena-owned; may be self.tool_specs directly if no groups).
@@ -2216,7 +2215,7 @@ pub const Agent = struct {
                 turn_max_tokens,
             );
 
-            // Call provider: streaming (no retries, no native tools) or blocking with retry
+            // Call provider: streaming (native tools if supported) or blocking with retry
             var response: ChatResponse = undefined;
             var response_attempt: u32 = 1;
             providers.clearLastApiErrorDetail();
@@ -2231,7 +2230,7 @@ pub const Agent = struct {
                         .model = turn_model_name,
                         .temperature = self.temperature,
                         .max_tokens = request_max_tokens,
-                        .tools = null,
+                        .tools = if (native_tools_enabled) turn_tool_specs else null,
                         .timeout_secs = self.message_timeout_secs,
                         .reasoning_effort = self.reasoning_effort,
                         .include_reasoning = include_reasoning,
@@ -2268,7 +2267,7 @@ pub const Agent = struct {
                                 .model = turn_model_name,
                                 .temperature = self.temperature,
                                 .max_tokens = retry_max_tokens,
-                                .tools = null,
+                                .tools = if (native_tools_enabled) turn_tool_specs else null,
                                 .timeout_secs = self.message_timeout_secs,
                                 .reasoning_effort = self.reasoning_effort,
                                 .include_reasoning = include_reasoning,
@@ -10785,9 +10784,9 @@ test "filterToolsForPromptText empty group excludes MCP tools" {
     try std.testing.expectEqualStrings("shell", result[0].name());
 }
 
-test "Agent system prompt keeps parameters when streaming disables native tool schemas" {
-    // Regression: streaming turns send tools=null, so the text prompt must keep
-    // Parameters even if the provider supports native tools.
+test "Agent system prompt excludes tool schemas when streaming and native tools are compatible" {
+    // Regression: streaming with native_tools provider should pass API-level tools[]
+    // and exclude text-embedded tool schemas from the system prompt.
     const StreamingPromptCapture = struct {
         captured_system: ?[]u8 = null,
         capture_alloc: std.mem.Allocator,
@@ -10817,7 +10816,7 @@ test "Agent system prompt keeps parameters when streaming disables native tool s
             callback: providers.StreamCallback,
             callback_ctx: *anyopaque,
         ) anyerror!providers.StreamChatResult {
-            try std.testing.expect(request.tools == null);
+            try std.testing.expect(request.tools != null);
             const self: *@This() = @ptrCast(@alignCast(ptr));
             for (request.messages) |msg| {
                 if (msg.role == .system) {
@@ -10887,7 +10886,7 @@ test "Agent system prompt keeps parameters when streaming disables native tool s
     try std.testing.expect(provider_state.captured_system != null);
     const captured = provider_state.captured_system.?;
     try std.testing.expect(std.mem.indexOf(u8, captured, "**shell**: shell") != null);
-    try std.testing.expect(std.mem.indexOf(u8, captured, "Parameters: `{}`") != null);
+    try std.testing.expect(std.mem.indexOf(u8, captured, "Parameters: `{}`") == null);
     try std.testing.expect(std.mem.indexOf(u8, captured, "mcp_secret_lookup") == null);
 }
 

--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -412,6 +412,8 @@ pub const Agent = struct {
     workspace_prompt_fingerprint: ?u64 = null,
     /// Model name used when building the currently cached system prompt.
     system_prompt_model_name: ?[]u8 = null,
+    /// Native-tool mode used when building the currently cached system prompt.
+    system_prompt_native_tools_enabled: ?bool = null,
 
     /// Whether compaction was performed during the last turn.
     last_turn_compacted: bool = false,
@@ -1974,6 +1976,13 @@ pub const Agent = struct {
             self.model_name;
         const turn_model_name_owned = !std.mem.eql(u8, turn_model_name, self.model_name);
         defer if (turn_model_name_owned) self.allocator.free(turn_model_name);
+        const turn_is_streaming = self.stream_callback != null and
+            self.stream_ctx != null and
+            self.provider.supportsStreamingForModel(turn_model_name);
+        const turn_native_tools_enabled = if (turn_is_streaming)
+            self.provider.supportsStreamingNativeToolsForModel(turn_model_name)
+        else
+            self.provider.supportsNativeToolsForModel(turn_model_name);
 
         var cfg_for_prompt_opt: ?Config = Config.load(self.allocator) catch null;
         defer if (cfg_for_prompt_opt) |*cfg_loaded| cfg_loaded.deinit();
@@ -1996,6 +2005,11 @@ pub const Agent = struct {
                 }
             }
         }
+        if (self.has_system_prompt and
+            self.system_prompt_native_tools_enabled != turn_native_tools_enabled)
+        {
+            self.has_system_prompt = false;
+        }
 
         const turn_has_conversation_context = self.conversation_context != null;
         const turn_conversation_context_fingerprint = if (self.conversation_context) |ctx|
@@ -2010,7 +2024,6 @@ pub const Agent = struct {
             var prompt_tools_arena = std.heap.ArenaAllocator.init(self.allocator);
             defer prompt_tools_arena.deinit();
             const prompt_tools = try self.filterToolsForPromptText(prompt_tools_arena.allocator());
-            const prompt_native_tools_enabled = self.provider.supportsNativeTools();
 
             const capabilities_section = capabilities_mod.buildPromptSection(
                 self.allocator,
@@ -2029,7 +2042,7 @@ pub const Agent = struct {
                 .bootstrap_provider = self.bootstrap,
                 .identity_config = if (cfg_for_prompt_ptr) |cfg| cfg.identity else null,
                 .observer = self.observer,
-                .native_tools_enabled = prompt_native_tools_enabled,
+                .native_tools_enabled = turn_native_tools_enabled,
             });
             const active_skill_section = try commands.buildActiveSkillPromptSection(self);
             defer if (active_skill_section) |section| self.allocator.free(section);
@@ -2066,31 +2079,21 @@ pub const Agent = struct {
                 break :blk try composed.toOwnedSlice(self.allocator);
             };
 
-            // Keep exactly one canonical system prompt at history[0].
-            // This allows /model to invalidate and refresh the prompt in place.
-            if (self.history.items.len > 0 and self.history.items[0].role == .system) {
-                self.history.items[0].deinit(self.allocator);
-                self.history.items[0] = .{
-                    .role = .system,
-                    .content = final_system,
-                };
-            } else if (self.history.items.len > 0) {
-                try self.history.insert(self.allocator, 0, .{
-                    .role = .system,
-                    .content = final_system,
-                });
-            } else {
-                try self.history.append(self.allocator, .{
-                    .role = .system,
-                    .content = final_system,
-                });
-            }
+            // Keep exactly one canonical system prompt at history[0]. The
+            // helper atomically transfers both owned allocations only after
+            // every fallible step succeeds.
+            try installCachedSystemPromptOwned(
+                self.allocator,
+                &self.history,
+                &self.system_prompt_model_name,
+                final_system,
+                turn_model_name,
+            );
             self.has_system_prompt = true;
             self.system_prompt_has_conversation_context = turn_has_conversation_context;
             self.system_prompt_conversation_context_fingerprint = turn_conversation_context_fingerprint;
             self.workspace_prompt_fingerprint = workspace_fp;
-            if (self.system_prompt_model_name) |cached_model| self.allocator.free(cached_model);
-            self.system_prompt_model_name = try self.allocator.dupe(u8, turn_model_name);
+            self.system_prompt_native_tools_enabled = turn_native_tools_enabled;
         }
 
         // Auto-save user message to memory (nanoTimestamp key to avoid collisions within the same second)
@@ -2187,8 +2190,8 @@ pub const Agent = struct {
             const arena = iter_arena.allocator();
 
             const timer_start = std_compat.time.milliTimestamp();
-            const is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
-            const native_tools_enabled = self.provider.supportsNativeTools();
+            const is_streaming = turn_is_streaming;
+            const native_tools_enabled = turn_native_tools_enabled;
             const include_reasoning = self.reasoning_mode != .off;
 
             // Filter tool specs for this turn (arena-owned; may be self.tool_specs directly if no groups).
@@ -2279,7 +2282,7 @@ pub const Agent = struct {
                 response = ChatResponse{
                     .content = stream_result.content,
                     .reasoning_content = stream_result.reasoning_content,
-                    .tool_calls = &.{},
+                    .tool_calls = stream_result.tool_calls,
                     .usage = stream_result.usage,
                     .model = stream_result.model,
                 };
@@ -2451,6 +2454,10 @@ pub const Agent = struct {
                     };
                 };
             }
+            // Provider response fields are owned for the rest of this
+            // iteration. Explicit success/continue paths consume and reset
+            // them; this closes every fallible post-processing exit.
+            errdefer self.freeResponseFields(&response);
             self.logLlmResponse(iteration + 1, response_attempt, &response);
 
             const duration_ms: u64 = @as(u64, @intCast(@max(0, std_compat.time.milliTimestamp() - timer_start)));
@@ -3841,6 +3848,7 @@ pub const Agent = struct {
         self.system_prompt_has_conversation_context = false;
         self.system_prompt_conversation_context_fingerprint = null;
         self.workspace_prompt_fingerprint = null;
+        self.system_prompt_native_tools_enabled = null;
         if (self.redactor) |r| r.reset();
     }
 
@@ -3892,6 +3900,31 @@ pub const Agent = struct {
     }
 };
 
+fn installCachedSystemPromptOwned(
+    allocator: std.mem.Allocator,
+    history: *std.ArrayListUnmanaged(Agent.OwnedMessage),
+    cached_model_name: *?[]u8,
+    final_system: []const u8,
+    model_name: []const u8,
+) !void {
+    // Ownership of final_system transfers to this helper immediately.
+    errdefer allocator.free(final_system);
+    const new_model_name = try allocator.dupe(u8, model_name);
+    errdefer allocator.free(new_model_name);
+
+    if (history.items.len > 0 and history.items[0].role == .system) {
+        history.items[0].deinit(allocator);
+        history.items[0] = .{ .role = .system, .content = final_system };
+    } else if (history.items.len > 0) {
+        try history.insert(allocator, 0, .{ .role = .system, .content = final_system });
+    } else {
+        try history.append(allocator, .{ .role = .system, .content = final_system });
+    }
+
+    if (cached_model_name.*) |old_model_name| allocator.free(old_model_name);
+    cached_model_name.* = new_model_name;
+}
+
 pub const cli = @import("cli.zig");
 
 /// CLI entry point — re-exported for backward compatibility.
@@ -3909,6 +3942,46 @@ test "Agent.OwnedMessage toChatMessage" {
     const chat = msg.toChatMessage();
     try std.testing.expect(chat.role == .user);
     try std.testing.expectEqualStrings("hello", chat.content);
+}
+
+fn installCachedSystemPromptAllocationTest(allocator: std.mem.Allocator) !void {
+    var history: std.ArrayListUnmanaged(Agent.OwnedMessage) = .empty;
+    defer {
+        for (history.items) |*message| message.deinit(allocator);
+        history.deinit(allocator);
+    }
+    var cached_model_name: ?[]u8 = null;
+    defer if (cached_model_name) |model_name| allocator.free(model_name);
+
+    const first_prompt = try allocator.dupe(u8, "first system prompt");
+    try installCachedSystemPromptOwned(
+        allocator,
+        &history,
+        &cached_model_name,
+        first_prompt,
+        "first-model",
+    );
+
+    const replacement_prompt = try allocator.dupe(u8, "replacement system prompt");
+    try installCachedSystemPromptOwned(
+        allocator,
+        &history,
+        &cached_model_name,
+        replacement_prompt,
+        "replacement-model",
+    );
+    try std.testing.expectEqualStrings("replacement system prompt", history.items[0].content);
+    try std.testing.expectEqualStrings("replacement-model", cached_model_name.?);
+}
+
+test "system prompt cache replacement is allocation failure safe" {
+    // Regression: rebuilding for a different streaming/native-tools mode must
+    // preserve the old cache and free the candidate prompt on any OOM.
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        installCachedSystemPromptAllocationTest,
+        .{},
+    );
 }
 
 test "Agent trim history preserves system prompt" {
@@ -10818,22 +10891,44 @@ test "Agent system prompt excludes tool schemas when streaming and native tools 
     // and exclude text-embedded tool schemas from the system prompt.
     const StreamingPromptCapture = struct {
         captured_system: ?[]u8 = null,
+        captured_blocking_system: ?[]u8 = null,
         capture_alloc: std.mem.Allocator,
 
         fn chatWithSystem(_: *anyopaque, allocator_: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
             return allocator_.dupe(u8, "ok");
         }
 
-        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
-            return error.ShouldNotUseBlockingChat;
+        fn chat(ptr: *anyopaque, allocator_: std.mem.Allocator, request: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            for (request.messages) |msg| {
+                if (msg.role == .system) {
+                    if (self.captured_blocking_system) |old| self.capture_alloc.free(old);
+                    self.captured_blocking_system = try self.capture_alloc.dupe(u8, msg.content);
+                    break;
+                }
+            }
+            return .{ .content = try allocator_.dupe(u8, "ok blocking") };
         }
 
         fn supportsNativeTools(_: *anyopaque) bool {
-            return true;
+            return false;
+        }
+
+        fn supportsNativeToolsForModel(_: *anyopaque, model: []const u8) bool {
+            _ = model;
+            return false;
+        }
+
+        fn supportsStreamingNativeToolsForModel(_: *anyopaque, model: []const u8) bool {
+            return std.mem.eql(u8, model, "openai/gpt-4.1-mini");
         }
 
         fn supportsStreaming(_: *anyopaque) bool {
-            return true;
+            return false;
+        }
+
+        fn supportsStreamingForModel(_: *anyopaque, model: []const u8) bool {
+            return std.mem.eql(u8, model, "openai/gpt-4.1-mini");
         }
 
         fn streamChat(
@@ -10872,13 +10967,17 @@ test "Agent system prompt excludes tool schemas when streaming and native tools 
     const allocator = std.testing.allocator;
     var provider_state = StreamingPromptCapture{ .capture_alloc = allocator };
     defer if (provider_state.captured_system) |captured| allocator.free(captured);
+    defer if (provider_state.captured_blocking_system) |captured| allocator.free(captured);
     const provider_vtable = Provider.VTable{
         .chatWithSystem = StreamingPromptCapture.chatWithSystem,
         .chat = StreamingPromptCapture.chat,
         .supportsNativeTools = StreamingPromptCapture.supportsNativeTools,
+        .supportsNativeToolsForModel = StreamingPromptCapture.supportsNativeToolsForModel,
+        .supportsStreamingNativeToolsForModel = StreamingPromptCapture.supportsStreamingNativeToolsForModel,
         .getName = StreamingPromptCapture.getName,
         .deinit = StreamingPromptCapture.deinitFn,
         .supports_streaming = StreamingPromptCapture.supportsStreaming,
+        .supportsStreamingForModel = StreamingPromptCapture.supportsStreamingForModel,
         .stream_chat = StreamingPromptCapture.streamChat,
     };
     const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &provider_vtable };
@@ -10917,6 +11016,247 @@ test "Agent system prompt excludes tool schemas when streaming and native tools 
     try std.testing.expect(std.mem.indexOf(u8, captured, "**shell**: shell") != null);
     try std.testing.expect(std.mem.indexOf(u8, captured, "Parameters: `{}`") == null);
     try std.testing.expect(std.mem.indexOf(u8, captured, "mcp_secret_lookup") == null);
+
+    // SessionManager can toggle streaming on the same Agent between turns.
+    // The cached system prompt must be rebuilt for the new native-tool mode.
+    agent.stream_callback = null;
+    agent.stream_ctx = null;
+    const blocking_response = try agent.turn("hello again");
+    defer allocator.free(blocking_response);
+    try std.testing.expectEqualStrings("ok blocking", blocking_response);
+    try std.testing.expect(provider_state.captured_blocking_system != null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, provider_state.captured_blocking_system.?, "Parameters: `{}`") != null,
+    );
+}
+
+test "Agent executes native tool call returned by streaming provider" {
+    // Regression: sending API-level tools during streaming is only safe when
+    // the structured call survives StreamChatResult and reaches the tool loop.
+    const StreamingToolProvider = struct {
+        call_count: usize = 0,
+        saw_tools: bool = false,
+        saw_tool_result: bool = false,
+
+        fn chatWithSystem(_: *anyopaque, allocator_: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator_.dupe(u8, "unused");
+        }
+
+        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            return error.ShouldNotUseBlockingChat;
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return false;
+        }
+
+        fn supportsNativeToolsForModel(_: *anyopaque, model: []const u8) bool {
+            _ = model;
+            return false;
+        }
+
+        fn supportsStreamingNativeToolsForModel(_: *anyopaque, model: []const u8) bool {
+            return std.mem.eql(u8, model, "openai/gpt-4.1-mini");
+        }
+
+        fn supportsStreaming(_: *anyopaque) bool {
+            return false;
+        }
+
+        fn supportsStreamingForModel(_: *anyopaque, model: []const u8) bool {
+            return std.mem.eql(u8, model, "openai/gpt-4.1-mini");
+        }
+
+        fn streamChat(
+            ptr: *anyopaque,
+            allocator_: std.mem.Allocator,
+            request: providers.ChatRequest,
+            model: []const u8,
+            _: f64,
+            callback: providers.StreamCallback,
+            callback_ctx: *anyopaque,
+        ) anyerror!providers.StreamChatResult {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.call_count += 1;
+            self.saw_tools = self.saw_tools or (request.tools != null and request.tools.?.len == 1);
+
+            if (self.call_count == 1) {
+                const tool_calls = try allocator_.alloc(providers.ToolCall, 1);
+                errdefer allocator_.free(tool_calls);
+                const id = try allocator_.dupe(u8, "call_stream_1");
+                errdefer allocator_.free(id);
+                const name = try allocator_.dupe(u8, "shell");
+                errdefer allocator_.free(name);
+                const arguments = try allocator_.dupe(u8, "{}");
+                errdefer allocator_.free(arguments);
+                tool_calls[0] = .{
+                    .id = id,
+                    .name = name,
+                    .arguments = arguments,
+                };
+                callback(callback_ctx, providers.StreamChunk.finalChunk());
+                return .{
+                    .tool_calls = tool_calls,
+                    .model = try allocator_.dupe(u8, model),
+                };
+            }
+
+            for (request.messages) |message| {
+                if (message.role == .user and
+                    std.mem.indexOf(u8, message.content, "<tool_result name=\"shell\" status=\"ok\">") != null)
+                {
+                    self.saw_tool_result = true;
+                    break;
+                }
+            }
+            callback(callback_ctx, providers.StreamChunk.textDelta("done"));
+            callback(callback_ctx, providers.StreamChunk.finalChunk());
+            return .{
+                .content = try allocator_.dupe(u8, "done"),
+                .model = try allocator_.dupe(u8, model),
+            };
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "streaming-native-tool";
+        }
+
+        fn deinitFn(_: *anyopaque) void {}
+    };
+
+    const allocator = std.testing.allocator;
+    var provider_state = StreamingToolProvider{};
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = StreamingToolProvider.chatWithSystem,
+        .chat = StreamingToolProvider.chat,
+        .supportsNativeTools = StreamingToolProvider.supportsNativeTools,
+        .supportsNativeToolsForModel = StreamingToolProvider.supportsNativeToolsForModel,
+        .supportsStreamingNativeToolsForModel = StreamingToolProvider.supportsStreamingNativeToolsForModel,
+        .getName = StreamingToolProvider.getName,
+        .deinit = StreamingToolProvider.deinitFn,
+        .supports_streaming = StreamingToolProvider.supportsStreaming,
+        .supportsStreamingForModel = StreamingToolProvider.supportsStreamingForModel,
+        .stream_chat = StreamingToolProvider.streamChat,
+    };
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &provider_vtable };
+
+    const runtime_tools = [_]Tool{try makeMockFilterTool(allocator, "shell")};
+    defer freeMockFilterTool(runtime_tools[0], allocator);
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .default_model = "openai/gpt-4.1-mini",
+        .allocator = allocator,
+    };
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, provider, &runtime_tools, null, noop.observer());
+    defer agent.deinit();
+
+    const StreamSink = struct {
+        fn onChunk(_: *anyopaque, _: providers.StreamChunk) void {}
+    };
+    var stream_ctx: u8 = 0;
+    agent.stream_callback = StreamSink.onChunk;
+    agent.stream_ctx = @ptrCast(&stream_ctx);
+
+    const response = try agent.turn("use shell");
+    defer allocator.free(response);
+    try std.testing.expectEqualStrings("done", response);
+    try std.testing.expectEqual(@as(usize, 2), provider_state.call_count);
+    try std.testing.expect(provider_state.saw_tools);
+    try std.testing.expect(provider_state.saw_tool_result);
+}
+
+test "Agent frees streamed native response on post-processing allocation failure" {
+    // Regression: once streamChat returns owned tool calls, any later OOM must
+    // release the entire response before Agent.turn propagates the error.
+    const OomAfterStreamProvider = struct {
+        failing: *std.testing.FailingAllocator,
+
+        fn chatWithSystem(_: *anyopaque, allocator_: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator_.dupe(u8, "unused");
+        }
+
+        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            return error.ShouldNotUseBlockingChat;
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn supportsStreaming(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn streamChat(
+            ptr: *anyopaque,
+            allocator_: std.mem.Allocator,
+            _: providers.ChatRequest,
+            model: []const u8,
+            _: f64,
+            callback: providers.StreamCallback,
+            callback_ctx: *anyopaque,
+        ) anyerror!providers.StreamChatResult {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            var result: providers.StreamChatResult = .{};
+            errdefer result.deinit(allocator_);
+
+            const tool_calls = try allocator_.alloc(providers.ToolCall, 1);
+            tool_calls[0] = .{ .id = "", .name = "", .arguments = "" };
+            result.tool_calls = tool_calls;
+            tool_calls[0].id = try allocator_.dupe(u8, "call_oom");
+            tool_calls[0].name = try allocator_.dupe(u8, "shell");
+            tool_calls[0].arguments = try allocator_.dupe(u8, "{}");
+            result.model = try allocator_.dupe(u8, model);
+            callback(callback_ctx, providers.StreamChunk.finalChunk());
+
+            // Fail the first allocation in Agent's structured-call conversion.
+            self.failing.fail_index = self.failing.alloc_index;
+            return result;
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "streaming-oom";
+        }
+
+        fn deinitFn(_: *anyopaque) void {}
+    };
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const allocator = failing.allocator();
+    var provider_state = OomAfterStreamProvider{ .failing = &failing };
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = OomAfterStreamProvider.chatWithSystem,
+        .chat = OomAfterStreamProvider.chat,
+        .supportsNativeTools = OomAfterStreamProvider.supportsNativeTools,
+        .getName = OomAfterStreamProvider.getName,
+        .deinit = OomAfterStreamProvider.deinitFn,
+        .supports_streaming = OomAfterStreamProvider.supportsStreaming,
+        .stream_chat = OomAfterStreamProvider.streamChat,
+    };
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &provider_vtable };
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .default_model = "test-model",
+        .allocator = allocator,
+    };
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, provider, &.{}, null, noop.observer());
+    defer {
+        failing.fail_index = std.math.maxInt(usize);
+        agent.deinit();
+    }
+
+    const StreamSink = struct {
+        fn onChunk(_: *anyopaque, _: providers.StreamChunk) void {}
+    };
+    var stream_ctx: u8 = 0;
+    agent.stream_callback = StreamSink.onChunk;
+    agent.stream_ctx = @ptrCast(&stream_ctx);
+
+    try std.testing.expectError(error.OutOfMemory, agent.turn("use shell"));
 }
 
 test "buildProviderMessagesForTurn adds priority hint without mutating history" {
@@ -12111,8 +12451,8 @@ test "Agent: redactor scrubs PII before provider.streamChat" {
     var agent = try Agent.fromConfigWithProfile(allocator, &cfg, provider, &.{}, null, noop.observer(), profile);
     defer agent.deinit();
 
-    // Activate streaming path: both callback and ctx must be non-null AND provider
-    // must report supportsStreaming() true.
+    // Activate streaming path: both callback and ctx must be non-null, and the
+    // provider must report supportsStreamingForModel(turn model) true.
     const StreamSink = struct {
         fn onChunk(_: *anyopaque, _: providers.StreamChunk) void {}
     };

--- a/src/providers/anthropic.zig
+++ b/src/providers/anthropic.zig
@@ -24,6 +24,7 @@ pub const AnthropicProvider = struct {
     credential: ?[]const u8,
     base_url: []const u8,
     allocator: std.mem.Allocator,
+    native_tools: bool = true,
 
     const DEFAULT_BASE_URL = "https://api.anthropic.com";
     const API_VERSION = "2023-06-01";
@@ -353,8 +354,9 @@ pub const AnthropicProvider = struct {
         return parseNativeResponse(allocator, resp_body);
     }
 
-    fn supportsNativeToolsImpl(_: *anyopaque) bool {
-        return true;
+    fn supportsNativeToolsImpl(ptr: *anyopaque) bool {
+        const self: *AnthropicProvider = @ptrCast(@alignCast(ptr));
+        return self.native_tools;
     }
 
     fn supportsVisionImpl(_: *anyopaque) bool {
@@ -412,7 +414,7 @@ pub const AnthropicProvider = struct {
             hdr_count += 1;
         }
 
-        return sse.curlStreamAnthropic(allocator, url, body, headers_buf[0..hdr_count], callback, callback_ctx) catch |err| {
+        return sse.curlStreamAnthropicTimed(allocator, url, body, headers_buf[0..hdr_count], request.timeout_secs, callback, callback_ctx) catch |err| {
             if (err == error.CurlWaitError or err == error.CurlFailed) {
                 log.warn("Anthropic streaming failed with {}; falling back to non-streaming response", .{err});
                 var fallback = try chatImpl(ptr, allocator, request, model, temperature);
@@ -770,10 +772,12 @@ test "parseNativeResponse with text and tool_use" {
     try std.testing.expect(response.usage.total_tokens == 30);
 }
 
-test "supportsNativeTools returns true" {
+test "supportsNativeTools honors provider opt-out" {
     var p = AnthropicProvider.init(std.testing.allocator, "key", null);
     const prov = p.provider();
     try std.testing.expect(prov.supportsNativeTools());
+    p.native_tools = false;
+    try std.testing.expect(!prov.supportsNativeTools());
 }
 
 test "parseTextResponse multiple blocks returns first text" {

--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -1181,6 +1181,32 @@ pub const OpenAiCompatibleProvider = struct {
         allocator.free(messages);
     }
 
+    fn normalizeStreamingResult(allocator: std.mem.Allocator, result: *root.StreamChatResult) !void {
+        if (result.content) |raw| {
+            const cleaned = try stripThinkBlocks(allocator, raw);
+            allocator.free(raw);
+            if (cleaned.len == 0) {
+                allocator.free(cleaned);
+                result.content = null;
+                result.usage.completion_tokens = 0;
+            } else {
+                result.content = cleaned;
+                // Only fall back to byte-count estimate when the API did not
+                // supply a real token count (e.g. provider that ignores
+                // include_usage). Preserving the real count matters for /cost.
+                if (result.usage.completion_tokens == 0) {
+                    result.usage.completion_tokens = @intCast((cleaned.len + 3) / 4);
+                }
+            }
+        }
+        // Recompute total in case only prompt or only completion was received.
+        if (result.usage.total_tokens == 0 and
+            (result.usage.prompt_tokens > 0 or result.usage.completion_tokens > 0))
+        {
+            result.usage.total_tokens = result.usage.prompt_tokens +| result.usage.completion_tokens;
+        }
+    }
+
     fn streamChatImpl(
         ptr: *anyopaque,
         allocator: std.mem.Allocator,
@@ -1271,29 +1297,8 @@ pub const OpenAiCompatibleProvider = struct {
             }
             return err;
         };
-
-        if (result.content) |raw| {
-            const cleaned = try stripThinkBlocks(allocator, raw);
-            allocator.free(raw);
-            if (cleaned.len == 0) {
-                result.content = null;
-                result.usage.completion_tokens = 0;
-            } else {
-                result.content = cleaned;
-                // Only fall back to byte-count estimate when the API did not
-                // supply a real token count (e.g. provider that ignores
-                // include_usage). Preserving the real count matters for /cost.
-                if (result.usage.completion_tokens == 0) {
-                    result.usage.completion_tokens = @intCast((cleaned.len + 3) / 4);
-                }
-            }
-        }
-        // Recompute total in case only prompt or only completion was received.
-        if (result.usage.total_tokens == 0 and
-            (result.usage.prompt_tokens > 0 or result.usage.completion_tokens > 0))
-        {
-            result.usage.total_tokens = result.usage.prompt_tokens +| result.usage.completion_tokens;
-        }
+        errdefer result.deinit(allocator);
+        try normalizeStreamingResult(allocator, &result);
 
         return result;
     }
@@ -3168,6 +3173,36 @@ test "max_streaming_prompt_bytes set applies threshold" {
 
 test "DEFAULT_MAX_STREAMING_PROMPT_BYTES legacy value is 32 KiB" {
     try std.testing.expectEqual(@as(usize, 32 * 1024), DEFAULT_MAX_STREAMING_PROMPT_BYTES);
+}
+
+fn normalizeStreamingResultAllocationTest(allocator: std.mem.Allocator) !void {
+    var result: root.StreamChatResult = .{};
+    defer result.deinit(allocator);
+
+    result.content = try allocator.dupe(u8, "<think>hidden</think>visible");
+    result.reasoning_content = try allocator.dupe(u8, "reasoning");
+    result.model = try allocator.dupe(u8, "test-model");
+
+    const tool_calls = try allocator.alloc(root.ToolCall, 1);
+    tool_calls[0] = .{ .id = "", .name = "", .arguments = "" };
+    result.tool_calls = tool_calls;
+    tool_calls[0].id = try allocator.dupe(u8, "call_1");
+    tool_calls[0].name = try allocator.dupe(u8, "shell");
+    tool_calls[0].arguments = try allocator.dupe(u8, "{}");
+
+    try OpenAiCompatibleProvider.normalizeStreamingResult(allocator, &result);
+    try std.testing.expectEqualStrings("visible", result.content.?);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.len);
+}
+
+test "normalizeStreamingResult frees owned stream fields on allocation failure" {
+    // Regression: think-block post-processing must not leak content or native
+    // tool-call fields when its replacement allocation fails.
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        normalizeStreamingResultAllocationTest,
+        .{},
+    );
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/providers/factory.zig
+++ b/src/providers/factory.zig
@@ -350,6 +350,17 @@ pub const ProviderHolder = union(enum) {
         self.provider().deinit();
     }
 
+    fn openRouterHolder(
+        allocator: std.mem.Allocator,
+        api_key: ?[]const u8,
+        extra_body_params: ?[]const u8,
+        native_tools: bool,
+    ) ProviderHolder {
+        var prov = openrouter.OpenRouterProvider.init(allocator, api_key, extra_body_params);
+        prov.native_tools = native_tools;
+        return .{ .openrouter = prov };
+    }
+
     /// Create a ProviderHolder from a provider name string and optional API key.
     /// Uses `classifyProvider` to route to the correct concrete provider.
     pub fn fromConfig(
@@ -391,18 +402,26 @@ pub const ProviderHolder = union(enum) {
     ) ProviderHolder {
         const kind = classifyProvider(provider_name);
         return switch (kind) {
-            .anthropic_provider => .{ .anthropic = anthropic.AnthropicProvider.init(
-                allocator,
-                api_key,
-                if (std.mem.startsWith(u8, provider_name, "anthropic-custom:"))
-                    if (config_types.ProviderEntry.isValidBaseUrl(provider_name["anthropic-custom:".len..]))
-                        provider_name["anthropic-custom:".len..]
+            .anthropic_provider => blk: {
+                var prov = anthropic.AnthropicProvider.init(
+                    allocator,
+                    api_key,
+                    if (std.mem.startsWith(u8, provider_name, "anthropic-custom:"))
+                        if (config_types.ProviderEntry.isValidBaseUrl(provider_name["anthropic-custom:".len..]))
+                            provider_name["anthropic-custom:".len..]
+                        else
+                            validatedBaseUrl(base_url)
                     else
-                        validatedBaseUrl(base_url)
-                else
-                    validatedBaseUrl(base_url),
-            ) },
-            .openai_provider => .{ .openai = openai.OpenAiProvider.init(allocator, api_key, user_agent, extra_body_params) },
+                        validatedBaseUrl(base_url),
+                );
+                prov.native_tools = native_tools;
+                break :blk .{ .anthropic = prov };
+            },
+            .openai_provider => blk: {
+                var prov = openai.OpenAiProvider.init(allocator, api_key, user_agent, extra_body_params);
+                prov.native_tools = native_tools;
+                break :blk .{ .openai = prov };
+            },
             .azure_openai_provider => blk: {
                 const azure_url = normalizeAzureBaseUrlOwned(allocator, validatedBaseUrl(base_url)) catch null;
                 var prov = compatible.OpenAiCompatibleProvider.init(
@@ -431,7 +450,7 @@ pub const ProviderHolder = union(enum) {
                 prov.native_tools = native_tools;
                 break :blk .{ .ollama = prov };
             },
-            .openrouter_provider => .{ .openrouter = openrouter.OpenRouterProvider.init(allocator, api_key, extra_body_params) },
+            .openrouter_provider => openRouterHolder(allocator, api_key, extra_body_params, native_tools),
             .compatible_provider => blk: {
                 // Config base_url overrides built-in URL table and custom: prefix
                 const url = validatedBaseUrl(base_url) orelse
@@ -481,15 +500,15 @@ pub const ProviderHolder = union(enum) {
             .claude_cli_provider => if (claude_cli.ClaudeCliProvider.init(allocator, null)) |p|
                 .{ .claude_cli = p }
             else |_|
-                .{ .openrouter = openrouter.OpenRouterProvider.init(allocator, api_key, null) },
+                openRouterHolder(allocator, api_key, null, native_tools),
             .codex_cli_provider => if (codex_cli.CodexCliProvider.init(allocator, null)) |p|
                 .{ .codex_cli = p }
             else |_|
-                .{ .openrouter = openrouter.OpenRouterProvider.init(allocator, api_key, null) },
+                openRouterHolder(allocator, api_key, null, native_tools),
             .gemini_cli_provider => if (gemini_cli.GeminiCliProvider.init(allocator, null)) |p|
                 .{ .gemini_cli = p }
             else |_|
-                .{ .openrouter = openrouter.OpenRouterProvider.init(allocator, api_key, null) },
+                openRouterHolder(allocator, api_key, null, native_tools),
             .openai_codex_provider => .{ .openai_codex = openai_codex.OpenAiCodexProvider.init(allocator, null) },
             // Unknown provider: if base_url is configured, treat as OpenAI-compatible;
             // otherwise fall back to OpenRouter.
@@ -511,7 +530,7 @@ pub const ProviderHolder = union(enum) {
                 if (chat_template_enable_thinking_param) prov.chat_template_enable_thinking_param = true;
                 prov.extra_body_params = extra_body_params;
                 break :blk .{ .compatible = prov };
-            } else .{ .openrouter = openrouter.OpenRouterProvider.init(allocator, api_key, null) },
+            } else openRouterHolder(allocator, api_key, null, native_tools),
         };
     }
 };
@@ -1051,6 +1070,27 @@ test "fromConfig applies native_tools override for ollama" {
     defer h.deinit();
     try std.testing.expect(h == .ollama);
     try std.testing.expect(!h.provider().supportsNativeTools());
+}
+
+test "fromConfig applies native_tools opt-out to dedicated and fallback providers" {
+    // Regression: the shared ProviderEntry flag must not be ignored by the
+    // dedicated implementations or by the default OpenRouter fallback.
+    const configurable_provider_names = [_][]const u8{ "openai", "openrouter", "anthropic", "unlisted-provider" };
+    for (configurable_provider_names) |provider_name| {
+        var holder = ProviderHolder.fromConfig(
+            std.testing.allocator,
+            provider_name,
+            "test-key",
+            null,
+            false,
+            null,
+            null,
+            false,
+            null,
+        );
+        defer holder.deinit();
+        try std.testing.expect(!holder.provider().supportsNativeTools());
+    }
 }
 
 test "fromConfig passes api_key through to ollama" {

--- a/src/providers/openai.zig
+++ b/src/providers/openai.zig
@@ -19,6 +19,7 @@ const TokenUsage = root.TokenUsage;
 pub const OpenAiProvider = struct {
     api_key: ?[]const u8,
     allocator: std.mem.Allocator,
+    native_tools: bool = true,
     /// Optional User-Agent header for HTTP requests.
     user_agent: ?[]const u8 = null,
     /// Optional compact JSON string of additional key-value pairs to merge into
@@ -347,8 +348,9 @@ pub const OpenAiProvider = struct {
         return parseNativeResponse(allocator, resp_body);
     }
 
-    fn supportsNativeToolsImpl(_: *anyopaque) bool {
-        return true;
+    fn supportsNativeToolsImpl(ptr: *anyopaque) bool {
+        const self: *OpenAiProvider = @ptrCast(@alignCast(ptr));
+        return self.native_tools;
     }
 
     fn supportsVisionImpl(_: *anyopaque) bool {
@@ -524,10 +526,12 @@ test "parseNativeResponse with tool calls" {
     try std.testing.expect(response.usage.total_tokens == 15);
 }
 
-test "supportsNativeTools returns true" {
+test "supportsNativeTools honors provider opt-out" {
     var p = OpenAiProvider.init(std.testing.allocator, "key", null, null);
     const prov = p.provider();
     try std.testing.expect(prov.supportsNativeTools());
+    p.native_tools = false;
+    try std.testing.expect(!prov.supportsNativeTools());
 }
 
 test "parseTextResponse multiple choices returns first" {

--- a/src/providers/openrouter.zig
+++ b/src/providers/openrouter.zig
@@ -22,6 +22,7 @@ const TokenUsage = root.TokenUsage;
 pub const OpenRouterProvider = struct {
     api_key: ?[]const u8,
     allocator: std.mem.Allocator,
+    native_tools: bool = true,
     extra_body_params: ?[]const u8 = null,
 
     const BASE_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -422,8 +423,9 @@ pub const OpenRouterProvider = struct {
         return parseNativeResponse(allocator, resp_body);
     }
 
-    fn supportsNativeToolsImpl(_: *anyopaque) bool {
-        return true;
+    fn supportsNativeToolsImpl(ptr: *anyopaque) bool {
+        const self: *OpenRouterProvider = @ptrCast(@alignCast(ptr));
+        return self.native_tools;
     }
 
     fn supportsVisionImpl(_: *anyopaque) bool {
@@ -678,10 +680,12 @@ test "parseTextResponse classifies context errors" {
     try std.testing.expectError(error.ContextLengthExceeded, OpenRouterProvider.parseTextResponse(std.testing.allocator, body));
 }
 
-test "supportsNativeTools returns true" {
+test "supportsNativeTools honors provider opt-out" {
     var p = OpenRouterProvider.init(std.testing.allocator, "key", null);
     const prov = p.provider();
     try std.testing.expect(prov.supportsNativeTools());
+    p.native_tools = false;
+    try std.testing.expect(!prov.supportsNativeTools());
 }
 
 test "convertMessages produces valid JSON with system, user, assistant" {

--- a/src/providers/reliable.zig
+++ b/src/providers/reliable.zig
@@ -366,9 +366,12 @@ pub const ReliableProvider = struct {
         .chatWithSystem = chatWithSystemImpl,
         .chat = chatImpl,
         .supportsNativeTools = supportsNativeToolsImpl,
+        .supportsNativeToolsForModel = supportsNativeToolsForModelImpl,
+        .supportsStreamingNativeToolsForModel = supportsStreamingNativeToolsForModelImpl,
         .supports_vision = supportsVisionImpl,
         .supports_vision_for_model = supportsVisionForModelImpl,
         .supports_streaming = supportsStreamingImpl,
+        .supportsStreamingForModel = supportsStreamingForModelImpl,
         .stream_chat = streamChatImpl,
         .getName = getNameImpl,
         .deinit = deinitImpl,
@@ -606,6 +609,17 @@ pub const ReliableProvider = struct {
         return false;
     }
 
+    fn supportsStreamingForModelImpl(ptr: *anyopaque, model: []const u8) bool {
+        const self: *ReliableProvider = @ptrCast(@alignCast(ptr));
+        const target = self.resolveProviderTarget(model);
+        if (target.explicit) return target.provider.supportsStreamingForModel(target.model);
+
+        // Agent error recovery differs between blocking and streaming calls.
+        // An unrelated streaming extra must not move ordinary primary traffic
+        // onto the streaming path and bypass Agent-level recovery.
+        return self.inner.supportsStreamingForModel(model);
+    }
+
     fn streamChatImpl(
         ptr: *anyopaque,
         allocator: std.mem.Allocator,
@@ -625,7 +639,7 @@ pub const ReliableProvider = struct {
             }
             var resolved_request = request;
             resolved_request.model = target.model;
-            return target.provider.streamChat(allocator, resolved_request, target.model, temperature, callback, callback_ctx);
+            return streamSelectedProvider(target.provider, allocator, resolved_request, target.model, temperature, callback, callback_ctx);
         }
 
         // Streaming cannot recover mid-stream (doing so would require buffering the
@@ -634,14 +648,35 @@ pub const ReliableProvider = struct {
         // Note: model-chain fallback is not supported in the streaming path — this is
         // a pre-existing limitation and is not regressed by this change.
         if (!needs_vision or self.inner.supportsVisionForModel(model)) {
-            return self.inner.streamChat(allocator, request, model, temperature, callback, callback_ctx);
+            return streamSelectedProvider(self.inner, allocator, request, model, temperature, callback, callback_ctx);
         }
         for (self.extras) |entry| {
             if (entry.provider.supportsVisionForModel(model)) {
-                return entry.provider.streamChat(allocator, request, model, temperature, callback, callback_ctx);
+                return streamSelectedProvider(entry.provider, allocator, request, model, temperature, callback, callback_ctx);
             }
         }
         return error.ProviderDoesNotSupportVision;
+    }
+
+    fn streamSelectedProvider(
+        selected_provider: Provider,
+        allocator: std.mem.Allocator,
+        request: root.ChatRequest,
+        model: []const u8,
+        temperature: f64,
+        callback: root.StreamCallback,
+        callback_ctx: *anyopaque,
+    ) !root.StreamChatResult {
+        if (selected_provider.supportsStreamingForModel(model)) {
+            return selected_provider.streamChat(allocator, request, model, temperature, callback, callback_ctx);
+        }
+
+        // Selection can change after Agent's capability check (for example an
+        // image request routed to a vision-only fallback). Honor that target's
+        // streaming opt-out and bridge its blocking response into the stream.
+        var response = try selected_provider.chat(allocator, request, model, temperature);
+        defer response.deinit(allocator);
+        return root.emitChatResponseAsStream(allocator, &response, callback, callback_ctx);
     }
 
     fn supportsNativeToolsImpl(ptr: *anyopaque) bool {
@@ -651,6 +686,60 @@ pub const ReliableProvider = struct {
             if (entry.provider.supportsNativeTools()) return true;
         }
         return false;
+    }
+
+    fn modelRefSupportsNativeTools(self: *const ReliableProvider, model_ref: []const u8) bool {
+        const target = self.resolveProviderTarget(model_ref);
+        if (target.explicit) return target.provider.supportsNativeToolsForModel(target.model);
+
+        if (!self.inner.supportsNativeToolsForModel(model_ref)) return false;
+        for (self.extras) |entry| {
+            if (!entry.provider.supportsNativeToolsForModel(model_ref)) return false;
+        }
+        return true;
+    }
+
+    fn supportsNativeToolsForModelImpl(ptr: *anyopaque, model: []const u8) bool {
+        const self: *ReliableProvider = @ptrCast(@alignCast(ptr));
+        // Blocking chat can fail over across both providers and configured
+        // model refs after the system prompt is built. Native schemas are safe
+        // to omit only when every possible target accepts them.
+        if (!self.modelRefSupportsNativeTools(model)) return false;
+        for (self.model_fallbacks) |entry| {
+            if (!std.mem.eql(u8, entry.model, model)) continue;
+            for (entry.fallbacks) |fallback| {
+                if (!self.modelRefSupportsNativeTools(fallback)) return false;
+            }
+            break;
+        }
+        return true;
+    }
+
+    fn supportsStreamingNativeToolsForModelImpl(ptr: *anyopaque, model: []const u8) bool {
+        const self: *ReliableProvider = @ptrCast(@alignCast(ptr));
+        const target = self.resolveProviderTarget(model);
+        if (target.explicit) {
+            return target.provider.supportsStreamingNativeToolsForModel(target.model);
+        }
+
+        // If the primary cannot stream, streamChatImpl bridges the normal
+        // retry/failover path, so the blocking capability remains authoritative.
+        if (!self.inner.supportsStreamingForModel(model)) {
+            return supportsNativeToolsForModelImpl(ptr, model);
+        }
+        if (!self.inner.supportsStreamingNativeToolsForModel(model)) return false;
+
+        // Image content may select a vision extra after this model-level check.
+        // If the primary itself handles vision, it remains the selected target.
+        if (self.inner.supportsVisionForModel(model)) return true;
+        for (self.extras) |entry| {
+            if (entry.provider.supportsVisionForModel(model) and
+                !entry.provider.supportsStreamingNativeToolsForModel(model))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     fn supportsVisionImpl(ptr: *anyopaque) bool {
@@ -852,6 +941,7 @@ const MockInnerProvider = struct {
     fail_error: anyerror = error.ProviderError,
     supports_tools: bool,
     supports_vision: bool = true,
+    supports_streaming: bool = false,
     warmed_up: bool = false,
     name: []const u8 = "MockProvider",
 
@@ -859,6 +949,7 @@ const MockInnerProvider = struct {
         .chatWithSystem = mockChatWithSystem,
         .chat = mockChat,
         .supportsNativeTools = mockSupportsNativeTools,
+        .supports_streaming = mockSupportsStreaming,
         .supports_vision = mockSupportsVision,
         .getName = mockGetName,
         .deinit = mockDeinit,
@@ -908,6 +999,11 @@ const MockInnerProvider = struct {
     fn mockSupportsVision(ptr: *anyopaque) bool {
         const self: *MockInnerProvider = @ptrCast(@alignCast(ptr));
         return self.supports_vision;
+    }
+
+    fn mockSupportsStreaming(ptr: *anyopaque) bool {
+        const self: *MockInnerProvider = @ptrCast(@alignCast(ptr));
+        return self.supports_streaming;
     }
 
     fn mockGetName(ptr: *anyopaque) []const u8 {
@@ -1398,7 +1494,9 @@ test "model failover all models fail returns error" {
     try std.testing.expect(seen.len == 3);
 }
 
-test "supportsNativeTools returns true if any extra supports it" {
+test "supportsNativeToolsForModel is conservative across fallback providers" {
+    // Regression: the Agent builds one prompt before ReliableProvider may
+    // fail over, so schemas can be omitted only when every target is native.
     var inner_mock = MockInnerProvider{ .call_count = 0, .fail_until = 0, .supports_tools = false };
     var extra_mock = MockInnerProvider{ .call_count = 0, .fail_until = 0, .supports_tools = true };
 
@@ -1406,7 +1504,87 @@ test "supportsNativeTools returns true if any extra supports it" {
         .{ .name = "extra", .provider = extra_mock.toProvider() },
     };
     var reliable = ReliableProvider.initWithProvider(inner_mock.toProvider(), 0, 50).withExtras(&extras);
-    try std.testing.expect(reliable.provider().supportsNativeTools() == true);
+    try std.testing.expect(reliable.provider().supportsNativeTools());
+    try std.testing.expect(!reliable.provider().supportsNativeToolsForModel("model"));
+}
+
+test "model-specific capabilities follow explicit target and implicit primary" {
+    var inner_mock = MockInnerProvider{
+        .call_count = 0,
+        .fail_until = 0,
+        .supports_tools = false,
+        .supports_streaming = false,
+        .name = "inner",
+    };
+    var extra_mock = MockInnerProvider{
+        .call_count = 0,
+        .fail_until = 0,
+        .supports_tools = true,
+        .supports_streaming = true,
+        .name = "extra",
+    };
+    const extras = [_]ProviderEntry{
+        .{ .name = "extra", .provider = extra_mock.toProvider() },
+    };
+    var reliable = ReliableProvider.initWithProvider(inner_mock.toProvider(), 0, 50).withExtras(&extras);
+    const provider = reliable.provider();
+
+    try std.testing.expect(!provider.supportsNativeToolsForModel("ordinary-model"));
+    try std.testing.expect(!provider.supportsStreamingForModel("ordinary-model"));
+    try std.testing.expect(provider.supportsNativeToolsForModel("extra/tool-model"));
+    try std.testing.expect(provider.supportsStreamingForModel("extra/tool-model"));
+}
+
+test "streaming native tools use selected primary instead of blocking fallbacks" {
+    // Regression: a non-native fallback must not disable API-level tool calls
+    // when the streaming path is pinned to a native, vision-capable primary.
+    var inner_mock = MockInnerProvider{
+        .call_count = 0,
+        .fail_until = 0,
+        .supports_tools = true,
+        .supports_vision = true,
+        .supports_streaming = true,
+    };
+    var extra_mock = MockInnerProvider{
+        .call_count = 0,
+        .fail_until = 0,
+        .supports_tools = false,
+        .supports_vision = true,
+        .supports_streaming = false,
+    };
+    const extras = [_]ProviderEntry{.{ .name = "extra", .provider = extra_mock.toProvider() }};
+    var reliable = ReliableProvider.initWithProvider(inner_mock.toProvider(), 0, 50).withExtras(&extras);
+    const provider = reliable.provider();
+
+    try std.testing.expect(!provider.supportsNativeToolsForModel("model"));
+    try std.testing.expect(provider.supportsStreamingNativeToolsForModel("model"));
+}
+
+test "native tool capability includes configured model fallbacks" {
+    var inner_mock = MockInnerProvider{
+        .call_count = 0,
+        .fail_until = 0,
+        .supports_tools = true,
+        .name = "inner",
+    };
+    var extra_mock = MockInnerProvider{
+        .call_count = 0,
+        .fail_until = 0,
+        .supports_tools = false,
+        .name = "extra",
+    };
+    const extras = [_]ProviderEntry{
+        .{ .name = "extra", .provider = extra_mock.toProvider() },
+    };
+    const fallback_models = [_][]const u8{"extra/fallback-model"};
+    const model_fallbacks = [_]ModelFallbackEntry{
+        .{ .model = "inner/primary-model", .fallbacks = &fallback_models },
+    };
+    var reliable = ReliableProvider.initWithProvider(inner_mock.toProvider(), 0, 50)
+        .withExtras(&extras)
+        .withModelFallbacks(&model_fallbacks);
+
+    try std.testing.expect(!reliable.provider().supportsNativeToolsForModel("inner/primary-model"));
 }
 
 test "multi-provider chat fallback" {
@@ -1563,12 +1741,123 @@ test "streamChatImpl routes image request to vision-capable extra, skips inner" 
         fn cb(_: *anyopaque, _: root.StreamChunk) void {}
     };
     var dummy: u8 = 0;
-    const sr = try prov.streamChat(std.testing.allocator, request, "codex", 0.7, NoopCtx.cb, &dummy);
-    defer if (sr.content) |c| std.testing.allocator.free(c);
-    defer if (sr.model.len > 0) std.testing.allocator.free(sr.model);
+    var sr = try prov.streamChat(std.testing.allocator, request, "codex", 0.7, NoopCtx.cb, &dummy);
+    defer sr.deinit(std.testing.allocator);
 
     try std.testing.expect(inner.call_count == 0);
     try std.testing.expect(vision_extra.call_count == 1);
+}
+
+test "streamChatImpl honors streaming opt-out on selected vision extra" {
+    // Regression: request content can select a different target after the
+    // primary provider's streaming capability enabled the Agent stream path.
+    const VisionExtra = struct {
+        chat_calls: usize = 0,
+        stream_calls: usize = 0,
+
+        const vtable = Provider.VTable{
+            .chatWithSystem = chatWithSystem,
+            .chat = chat,
+            .supportsNativeTools = supportsNativeTools,
+            .supports_vision = supportsVision,
+            .supports_streaming = supportsStreaming,
+            .stream_chat = streamChat,
+            .getName = getName,
+            .deinit = deinit,
+        };
+
+        fn provider(self: *@This()) Provider {
+            return .{ .ptr = @ptrCast(self), .vtable = &vtable };
+        }
+
+        fn chatWithSystem(_: *anyopaque, allocator: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator.dupe(u8, "vision fallback");
+        }
+
+        fn chat(ptr: *anyopaque, allocator: std.mem.Allocator, _: ChatRequest, _: []const u8, _: f64) anyerror!ChatResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.chat_calls += 1;
+            return .{ .content = try allocator.dupe(u8, "vision fallback") };
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return false;
+        }
+
+        fn supportsVision(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn supportsStreaming(_: *anyopaque) bool {
+            return false;
+        }
+
+        fn streamChat(
+            ptr: *anyopaque,
+            _: std.mem.Allocator,
+            _: ChatRequest,
+            _: []const u8,
+            _: f64,
+            _: root.StreamCallback,
+            _: *anyopaque,
+        ) anyerror!root.StreamChatResult {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.stream_calls += 1;
+            return error.StreamingOptOutIgnored;
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "vision-extra";
+        }
+
+        fn deinit(_: *anyopaque) void {}
+    };
+
+    var inner = MockInnerProvider{
+        .call_count = 0,
+        .fail_until = 0,
+        .supports_tools = false,
+        .supports_vision = false,
+        .supports_streaming = true,
+    };
+    var vision_extra = VisionExtra{};
+    const extras = [_]ProviderEntry{.{ .name = "vision-extra", .provider = vision_extra.provider() }};
+    var reliable = ReliableProvider.initWithProvider(inner.toProvider(), 0, 50).withExtras(&extras);
+    const prov = reliable.provider();
+
+    const parts = [_]root.ContentPart{.{ .image_url = .{ .url = "https://example.com/img.png" } }};
+    const msgs = [_]root.ChatMessage{.{ .role = .user, .content = "", .content_parts = &parts }};
+    const request = ChatRequest{ .messages = &msgs };
+
+    const CallbackCtx = struct {
+        text: []const u8 = "",
+        saw_final: bool = false,
+
+        fn cb(ptr: *anyopaque, chunk: root.StreamChunk) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (chunk.is_final) {
+                self.saw_final = true;
+            } else {
+                self.text = chunk.delta;
+            }
+        }
+    };
+    var callback_ctx = CallbackCtx{};
+    var result = try prov.streamChat(
+        std.testing.allocator,
+        request,
+        "codex",
+        0.7,
+        CallbackCtx.cb,
+        @ptrCast(&callback_ctx),
+    );
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), vision_extra.chat_calls);
+    try std.testing.expectEqual(@as(usize, 0), vision_extra.stream_calls);
+    try std.testing.expectEqualStrings("vision fallback", result.content.?);
+    try std.testing.expectEqualStrings("vision fallback", callback_ctx.text);
+    try std.testing.expect(callback_ctx.saw_final);
 }
 
 test "streamChatImpl returns ProviderDoesNotSupportVision when all providers lack vision" {

--- a/src/providers/root.zig
+++ b/src/providers/root.zig
@@ -272,24 +272,40 @@ pub const StreamCallback = *const fn (ctx: *anyopaque, chunk: StreamChunk) void;
 pub const StreamChatResult = struct {
     content: ?[]const u8 = null,
     reasoning_content: ?[]const u8 = null,
+    tool_calls: []const ToolCall = &.{},
     usage: TokenUsage = .{},
     model: []const u8 = "",
+
+    pub fn deinit(self: *StreamChatResult, allocator: std.mem.Allocator) void {
+        if (self.content) |content| allocator.free(content);
+        if (self.reasoning_content) |reasoning| allocator.free(reasoning);
+        for (self.tool_calls) |tool_call| {
+            allocator.free(tool_call.id);
+            allocator.free(tool_call.name);
+            allocator.free(tool_call.arguments);
+        }
+        allocator.free(self.tool_calls);
+        if (self.model.len > 0) allocator.free(self.model);
+        self.* = .{};
+    }
 };
 
 pub fn shouldRecoverPartialStream(accumulated_len: usize, saw_done: bool) bool {
     return saw_done or accumulated_len > 0;
 }
 
+/// Release ChatResponse fields that are not part of the legacy streaming
+/// result. Retained for source compatibility with external provider adapters.
 pub fn freeStreamUnusedChatResponseFields(allocator: std.mem.Allocator, response: *ChatResponse) void {
-    for (response.tool_calls) |tc| {
-        if (tc.id.len > 0) allocator.free(tc.id);
-        if (tc.name.len > 0) allocator.free(tc.name);
-        if (tc.arguments.len > 0) allocator.free(tc.arguments);
+    for (response.tool_calls) |tool_call| {
+        if (tool_call.id.len > 0) allocator.free(tool_call.id);
+        if (tool_call.name.len > 0) allocator.free(tool_call.name);
+        if (tool_call.arguments.len > 0) allocator.free(tool_call.arguments);
     }
     if (response.tool_calls.len > 0) allocator.free(response.tool_calls);
     if (response.provider.len > 0) allocator.free(response.provider);
-    if (response.reasoning_content) |rc| {
-        if (rc.len > 0) allocator.free(rc);
+    if (response.reasoning_content) |reasoning| {
+        if (reasoning.len > 0) allocator.free(reasoning);
     }
     response.tool_calls = &.{};
     response.provider = "";
@@ -302,21 +318,27 @@ pub fn emitChatResponseAsStream(
     callback: StreamCallback,
     callback_ctx: *anyopaque,
 ) StreamChatResult {
-    const reasoning_content = response.reasoning_content;
-    response.reasoning_content = null;
     if (response.content) |content| {
         if (content.len > 0) {
             callback(callback_ctx, StreamChunk.textDelta(content));
         }
     }
     callback(callback_ctx, StreamChunk.finalChunk());
-    freeStreamUnusedChatResponseFields(allocator, response);
-    return .{
+
+    const result = StreamChatResult{
         .content = response.content,
-        .reasoning_content = reasoning_content,
+        .reasoning_content = response.reasoning_content,
+        .tool_calls = response.tool_calls,
         .usage = response.usage,
         .model = response.model,
     };
+    response.content = null;
+    response.reasoning_content = null;
+    response.tool_calls = &.{};
+    response.model = "";
+    if (response.provider.len > 0) allocator.free(response.provider);
+    response.provider = "";
+    return result;
 }
 
 /// Tool specification for function-calling APIs.
@@ -397,6 +419,13 @@ pub const Provider = struct {
         /// Whether this provider supports native tool calls.
         supportsNativeTools: *const fn (ptr: *anyopaque) bool,
 
+        /// Optional: model-specific native tool capability.
+        /// Default: falls back to supportsNativeTools.
+        supportsNativeToolsForModel: ?*const fn (ptr: *anyopaque, model: []const u8) bool = null,
+        /// Optional: native tool capability for the selected streaming path.
+        /// Default: falls back to supportsNativeToolsForModel.
+        supportsStreamingNativeToolsForModel: ?*const fn (ptr: *anyopaque, model: []const u8) bool = null,
+
         /// Provider name for diagnostics.
         getName: *const fn (ptr: *anyopaque) []const u8,
 
@@ -409,6 +438,9 @@ pub const Provider = struct {
         chat_with_tools: ?*const fn (ptr: *anyopaque, allocator: std.mem.Allocator, req: ChatRequest) anyerror!ChatResponse = null,
         /// Optional: returns true if provider supports streaming. Default: false.
         supports_streaming: ?*const fn (ptr: *anyopaque) bool = null,
+        /// Optional: model-specific streaming capability.
+        /// Default: falls back to supports_streaming.
+        supportsStreamingForModel: ?*const fn (ptr: *anyopaque, model: []const u8) bool = null,
         /// Optional: returns true if provider supports vision/image input. Default: false.
         supports_vision: ?*const fn (ptr: *anyopaque) bool = null,
         /// Optional: returns true if provider supports vision for a specific model.
@@ -451,6 +483,18 @@ pub const Provider = struct {
         return self.vtable.supportsNativeTools(self.ptr);
     }
 
+    /// Returns true if the provider supports native tools for the selected model.
+    pub fn supportsNativeToolsForModel(self: Provider, model: []const u8) bool {
+        if (self.vtable.supportsNativeToolsForModel) |f| return f(self.ptr, model);
+        return self.supportsNativeTools();
+    }
+
+    /// Returns true if the selected streaming path accepts native tool schemas.
+    pub fn supportsStreamingNativeToolsForModel(self: Provider, model: []const u8) bool {
+        if (self.vtable.supportsStreamingNativeToolsForModel) |f| return f(self.ptr, model);
+        return self.supportsNativeToolsForModel(model);
+    }
+
     pub fn getName(self: Provider) []const u8 {
         return self.vtable.getName(self.ptr);
     }
@@ -468,6 +512,12 @@ pub const Provider = struct {
     pub fn supportsStreaming(self: Provider) bool {
         if (self.vtable.supports_streaming) |f| return f(self.ptr);
         return false;
+    }
+
+    /// Returns true if the provider supports streaming for the selected model.
+    pub fn supportsStreamingForModel(self: Provider, model: []const u8) bool {
+        if (self.vtable.supportsStreamingForModel) |f| return f(self.ptr, model);
+        return self.supportsStreaming();
     }
 
     /// Returns true if provider supports vision/image input.
@@ -820,6 +870,7 @@ test "ChatResponse reasoning_content can be set" {
 test "StreamChatResult defaults" {
     const result = StreamChatResult{};
     try std.testing.expect(result.content == null);
+    try std.testing.expectEqual(@as(usize, 0), result.tool_calls.len);
     try std.testing.expect(result.usage.prompt_tokens == 0);
     try std.testing.expect(result.usage.completion_tokens == 0);
     try std.testing.expectEqualStrings("", result.model);
@@ -855,7 +906,7 @@ test "ChatResponse deinit resets owned fields" {
     try std.testing.expectEqualStrings("", response.model);
 }
 
-test "emitChatResponseAsStream frees unused chat response fields" {
+test "emitChatResponseAsStream transfers native tool calls" {
     const allocator = std.testing.allocator;
 
     var tool_calls = try allocator.alloc(ToolCall, 1);
@@ -873,6 +924,7 @@ test "emitChatResponseAsStream frees unused chat response fields" {
         .model = try allocator.dupe(u8, "test-model"),
         .reasoning_content = try allocator.dupe(u8, "private reasoning"),
     };
+    defer response.deinit(allocator);
 
     const CallbackCtx = struct {
         text_count: usize = 0,
@@ -889,19 +941,23 @@ test "emitChatResponseAsStream frees unused chat response fields" {
     };
 
     var ctx = CallbackCtx{};
-    const result = emitChatResponseAsStream(allocator, &response, CallbackCtx.onChunk, @ptrCast(&ctx));
-    defer if (result.content) |content| allocator.free(content);
-    defer if (result.reasoning_content) |reasoning| allocator.free(reasoning);
-    defer if (result.model.len > 0) allocator.free(result.model);
+    var result = emitChatResponseAsStream(allocator, &response, CallbackCtx.onChunk, @ptrCast(&ctx));
+    defer result.deinit(allocator);
 
     try std.testing.expectEqual(@as(usize, 1), ctx.text_count);
     try std.testing.expect(ctx.saw_final);
     try std.testing.expectEqual(@as(usize, 0), response.tool_calls.len);
+    try std.testing.expect(response.content == null);
     try std.testing.expectEqualStrings("", response.provider);
+    try std.testing.expectEqualStrings("", response.model);
     try std.testing.expect(response.reasoning_content == null);
     try std.testing.expectEqualStrings("hello", result.content.?);
     try std.testing.expectEqualStrings("private reasoning", result.reasoning_content.?);
     try std.testing.expectEqualStrings("test-model", result.model);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.len);
+    try std.testing.expectEqualStrings("tool-1", result.tool_calls[0].id);
+    try std.testing.expectEqualStrings("read_file", result.tool_calls[0].name);
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", result.tool_calls[0].arguments);
 }
 
 test "Provider.streamChat fallback emits single chunk and final" {
@@ -922,8 +978,13 @@ test "Provider.streamChat fallback emits single chunk and final" {
         fn chatWithSystem(_: *anyopaque, _: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
             return "";
         }
-        fn chat(_: *anyopaque, _: std.mem.Allocator, _: ChatRequest, _: []const u8, _: f64) anyerror!ChatResponse {
-            return .{ .content = "hello from fallback", .model = "test" };
+        fn chat(_: *anyopaque, allocator: std.mem.Allocator, _: ChatRequest, _: []const u8, _: f64) anyerror!ChatResponse {
+            const content = try allocator.dupe(u8, "hello from fallback");
+            errdefer allocator.free(content);
+            return .{
+                .content = content,
+                .model = try allocator.dupe(u8, "test"),
+            };
         }
         fn supNativeTools(_: *anyopaque) bool {
             return false;
@@ -947,7 +1008,8 @@ test "Provider.streamChat fallback emits single chunk and final" {
     var ctx = TestCtx{};
     const msgs = [_]ChatMessage{ChatMessage.user("test")};
     const req = ChatRequest{ .messages = &msgs, .model = "test" };
-    const result = try prov.streamChat(std.testing.allocator, req, "test", 0.7, TestCtx.onChunk, @ptrCast(&ctx));
+    var result = try prov.streamChat(std.testing.allocator, req, "test", 0.7, TestCtx.onChunk, @ptrCast(&ctx));
+    defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(ctx.got_content);
     try std.testing.expect(ctx.got_final);

--- a/src/providers/router.zig
+++ b/src/providers/router.zig
@@ -155,9 +155,12 @@ pub const RouterProvider = struct {
         .chat = chatImpl,
         .chat_with_tools = chatWithToolsImpl,
         .supportsNativeTools = supportsNativeToolsImpl,
+        .supportsNativeToolsForModel = supportsNativeToolsForModelImpl,
+        .supportsStreamingNativeToolsForModel = supportsStreamingNativeToolsForModelImpl,
         .supports_vision = supportsVisionImpl,
         .supports_vision_for_model = supportsVisionForModelImpl,
         .supports_streaming = supportsStreamingImpl,
+        .supportsStreamingForModel = supportsStreamingForModelImpl,
         .stream_chat = streamChatImpl,
         .getName = getNameImpl,
         .deinit = deinitImpl,
@@ -218,10 +221,25 @@ pub const RouterProvider = struct {
 
     fn supportsNativeToolsImpl(ptr: *anyopaque) bool {
         const self: *RouterProvider = @ptrCast(@alignCast(ptr));
-        const resolved = self.resolve(self.default_model);
+        return supportsNativeToolsForModelImpl(ptr, self.default_model);
+    }
+
+    fn supportsNativeToolsForModelImpl(ptr: *anyopaque, model: []const u8) bool {
+        const self: *RouterProvider = @ptrCast(@alignCast(ptr));
+        const resolved = self.resolve(model);
         const provider_idx = resolved[0];
+        const resolved_model = resolved[1];
         if (provider_idx >= self.providers.len) return false;
-        return self.providers[provider_idx].supportsNativeTools();
+        return self.providers[provider_idx].supportsNativeToolsForModel(resolved_model);
+    }
+
+    fn supportsStreamingNativeToolsForModelImpl(ptr: *anyopaque, model: []const u8) bool {
+        const self: *RouterProvider = @ptrCast(@alignCast(ptr));
+        const resolved = self.resolve(model);
+        const provider_idx = resolved[0];
+        const resolved_model = resolved[1];
+        if (provider_idx >= self.providers.len) return false;
+        return self.providers[provider_idx].supportsStreamingNativeToolsForModel(resolved_model);
     }
 
     fn supportsVisionImpl(ptr: *anyopaque) bool {
@@ -240,10 +258,16 @@ pub const RouterProvider = struct {
 
     fn supportsStreamingImpl(ptr: *anyopaque) bool {
         const self: *RouterProvider = @ptrCast(@alignCast(ptr));
-        const resolved = self.resolve(self.default_model);
+        return supportsStreamingForModelImpl(ptr, self.default_model);
+    }
+
+    fn supportsStreamingForModelImpl(ptr: *anyopaque, model: []const u8) bool {
+        const self: *RouterProvider = @ptrCast(@alignCast(ptr));
+        const resolved = self.resolve(model);
         const provider_idx = resolved[0];
+        const resolved_model = resolved[1];
         if (provider_idx >= self.providers.len) return false;
-        return self.providers[provider_idx].supportsStreaming();
+        return self.providers[provider_idx].supportsStreamingForModel(resolved_model);
     }
 
     fn streamChatImpl(
@@ -817,6 +841,31 @@ test "vtable supportsNativeTools follows default model route" {
     try std.testing.expect(prov.supportsNativeTools());
 }
 
+test "vtable supportsNativeToolsForModel follows selected route" {
+    // Regression: Agent may route a turn away from RouterProvider.default_model;
+    // capabilities must describe the actual provider/model pair.
+    const provider_names = [_][]const u8{ "default", "tools" };
+    var mock_default = MockProvider.init("ok", false);
+    var mock_tools = MockProvider.init("ok", true);
+    const providers = [_]Provider{ mock_default.provider(), mock_tools.provider() };
+    const routes = [_]RouterProvider.RouteEntry{
+        .{ .hint = "tools", .route = .{ .provider_name = "tools", .model = "tools-model" } },
+    };
+    var router = try RouterProvider.init(
+        std.testing.allocator,
+        &provider_names,
+        &providers,
+        &routes,
+        "default-model",
+    );
+    const prov = router.provider();
+    defer prov.deinit();
+
+    try std.testing.expect(!prov.supportsNativeTools());
+    try std.testing.expect(prov.supportsNativeToolsForModel("hint:tools"));
+    try std.testing.expect(prov.supportsStreamingNativeToolsForModel("hint:tools"));
+}
+
 test "vtable supportsVisionForModel follows hint routing" {
     const provider_names = [_][]const u8{ "default", "vision" };
     var mock_default = MockProvider.initWithVision("ok", false, false);
@@ -878,6 +927,29 @@ test "vtable supportsStreaming follows default model route" {
     try std.testing.expect(prov.supportsStreaming());
 }
 
+test "vtable supportsStreamingForModel follows selected route" {
+    const provider_names = [_][]const u8{ "default", "streaming" };
+    var mock_default = MockProvider.init("ok", false);
+    var mock_streaming = MockProvider.init("streamed", false);
+    mock_streaming.supports_streaming = true;
+    const providers = [_]Provider{ mock_default.provider(), mock_streaming.provider() };
+    const routes = [_]RouterProvider.RouteEntry{
+        .{ .hint = "stream", .route = .{ .provider_name = "streaming", .model = "stream-model" } },
+    };
+    var router = try RouterProvider.init(
+        std.testing.allocator,
+        &provider_names,
+        &providers,
+        &routes,
+        "default-model",
+    );
+    const prov = router.provider();
+    defer prov.deinit();
+
+    try std.testing.expect(!prov.supportsStreaming());
+    try std.testing.expect(prov.supportsStreamingForModel("hint:stream"));
+}
+
 test "vtable streamChat delegates using explicit provider ref" {
     const provider_names = [_][]const u8{ "openrouter", "groq" };
     var mock_default = MockProvider.init("default", false);
@@ -906,7 +978,7 @@ test "vtable streamChat delegates using explicit provider ref" {
         }
     }.onChunk;
 
-    const result = try prov.streamChat(
+    var result = try prov.streamChat(
         std.testing.allocator,
         request,
         request.model,
@@ -914,8 +986,7 @@ test "vtable streamChat delegates using explicit provider ref" {
         cb,
         @ptrCast(&cb_ctx),
     );
-    defer if (result.content) |content| std.testing.allocator.free(content);
-    defer if (result.model.len > 0) std.testing.allocator.free(result.model);
+    defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(cb_ctx.saw_final);
     try std.testing.expectEqualStrings("llama-3.3-70b", mock_groq.last_stream_model);

--- a/src/providers/sse.zig
+++ b/src/providers/sse.zig
@@ -19,26 +19,33 @@ fn finalizeStreamResult(
     allocator: std.mem.Allocator,
     accumulated: []const u8,
     stream_usage: ?root.TokenUsage,
+    tool_call_accumulators: ?*const ToolCallAccumulators,
 ) !root.StreamChatResult {
-    var content: ?[]const u8 = null;
-    var reasoning_content: ?[]const u8 = null;
+    var result = root.StreamChatResult{};
+    errdefer result.deinit(allocator);
+
     if (accumulated.len > 0) {
         const split = try root.splitThinkContent(allocator, accumulated);
-        content = split.visible;
-        reasoning_content = split.reasoning;
+        result.content = split.visible;
+        result.reasoning_content = split.reasoning;
+    }
+    if (tool_call_accumulators) |accumulators| {
+        result.tool_calls = try accumulators.toOwnedToolCalls(allocator);
     }
 
     var usage = stream_usage orelse root.TokenUsage{};
     if (usage.completion_tokens == 0) {
-        usage.completion_tokens = @intCast((accumulated.len + 3) / 4);
+        const tool_bytes = if (tool_call_accumulators) |accumulators|
+            accumulators.estimatedOutputBytes()
+        else
+            0;
+        usage.completion_tokens = @intCast((accumulated.len +| tool_bytes +| 3) / 4);
     }
-
-    return .{
-        .content = content,
-        .reasoning_content = reasoning_content,
-        .usage = usage,
-        .model = "",
-    };
+    if (usage.total_tokens == 0 and (usage.prompt_tokens > 0 or usage.completion_tokens > 0)) {
+        usage.total_tokens = usage.prompt_tokens +| usage.completion_tokens;
+    }
+    result.usage = usage;
+    return result;
 }
 
 fn parseCurlVersionComponent(component: []const u8) ?u32 {
@@ -109,6 +116,20 @@ pub fn appendCurlStallDetectionArgs(argv_buf: [][]const u8, argc: *usize) void {
     }
 }
 
+fn appendCurlTimeoutArgs(
+    argv_buf: [][]const u8,
+    argc: *usize,
+    timeout_buf: []u8,
+    timeout_secs: u64,
+) void {
+    if (timeout_secs == 0) return;
+    const timeout_str = std.fmt.bufPrint(timeout_buf, "{d}", .{timeout_secs}) catch unreachable;
+    argv_buf[argc.*] = "--max-time";
+    argc.* += 1;
+    argv_buf[argc.*] = timeout_str;
+    argc.* += 1;
+}
+
 /// Content delta from an SSE chunk.
 pub const DeltaContent = union(enum) {
     text: []const u8,
@@ -122,6 +143,182 @@ pub const DeltaContent = union(enum) {
     }
 };
 
+const MAX_STREAM_TOOL_CALLS: usize = 128;
+
+/// One fragmented OpenAI-compatible tool-call update from an SSE chunk.
+const ToolCallDelta = struct {
+    index: usize,
+    id: ?[]const u8 = null,
+    name: ?[]const u8 = null,
+    arguments: ?[]const u8 = null,
+
+    fn deinit(self: ToolCallDelta, allocator: std.mem.Allocator) void {
+        if (self.id) |id| allocator.free(id);
+        if (self.name) |name| allocator.free(name);
+        if (self.arguments) |arguments| allocator.free(arguments);
+    }
+};
+
+fn deinitToolCallDeltas(allocator: std.mem.Allocator, deltas: []const ToolCallDelta) void {
+    for (deltas) |delta| delta.deinit(allocator);
+    if (deltas.len > 0) allocator.free(deltas);
+}
+
+const ToolCallAccumulator = struct {
+    index: usize,
+    id: std.ArrayListUnmanaged(u8) = .empty,
+    name: std.ArrayListUnmanaged(u8) = .empty,
+    arguments: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn deinit(self: *ToolCallAccumulator, allocator: std.mem.Allocator) void {
+        self.id.deinit(allocator);
+        self.name.deinit(allocator);
+        self.arguments.deinit(allocator);
+    }
+};
+
+const ToolCallAccumulators = struct {
+    entries: std.ArrayListUnmanaged(ToolCallAccumulator) = .empty,
+
+    fn deinit(self: *ToolCallAccumulators, allocator: std.mem.Allocator) void {
+        for (self.entries.items) |*entry| entry.deinit(allocator);
+        self.entries.deinit(allocator);
+    }
+
+    fn getOrCreate(
+        self: *ToolCallAccumulators,
+        allocator: std.mem.Allocator,
+        index: usize,
+    ) !*ToolCallAccumulator {
+        var insert_at: usize = 0;
+        while (insert_at < self.entries.items.len and self.entries.items[insert_at].index < index) : (insert_at += 1) {}
+        if (insert_at < self.entries.items.len and self.entries.items[insert_at].index == index) {
+            return &self.entries.items[insert_at];
+        }
+        if (self.entries.items.len >= MAX_STREAM_TOOL_CALLS) return error.TooManyStreamToolCalls;
+        try self.entries.insert(allocator, insert_at, .{ .index = index });
+        return &self.entries.items[insert_at];
+    }
+
+    fn appendDelta(
+        self: *ToolCallAccumulators,
+        allocator: std.mem.Allocator,
+        delta: ToolCallDelta,
+    ) !void {
+        const entry = try self.getOrCreate(allocator, delta.index);
+        if (delta.id) |id| try entry.id.appendSlice(allocator, id);
+        if (delta.name) |name| try entry.name.appendSlice(allocator, name);
+        if (delta.arguments) |arguments| try entry.arguments.appendSlice(allocator, arguments);
+    }
+
+    fn estimatedOutputBytes(self: *const ToolCallAccumulators) usize {
+        var total: usize = 0;
+        for (self.entries.items) |entry| {
+            total +|= entry.id.items.len;
+            total +|= entry.name.items.len;
+            total +|= entry.arguments.items.len;
+        }
+        return total;
+    }
+
+    fn toOwnedToolCalls(
+        self: *const ToolCallAccumulators,
+        allocator: std.mem.Allocator,
+    ) ![]const root.ToolCall {
+        var count: usize = 0;
+        for (self.entries.items) |entry| {
+            if (entry.name.items.len > 0) count += 1;
+        }
+        if (count == 0) return &.{};
+
+        const tool_calls = try allocator.alloc(root.ToolCall, count);
+        var initialized: usize = 0;
+        errdefer {
+            for (tool_calls[0..initialized]) |tool_call| {
+                if (tool_call.id.len > 0) allocator.free(tool_call.id);
+                allocator.free(tool_call.name);
+                allocator.free(tool_call.arguments);
+            }
+            allocator.free(tool_calls);
+        }
+
+        for (self.entries.items) |entry| {
+            if (entry.name.items.len == 0) continue;
+            const id: []const u8 = if (entry.id.items.len > 0)
+                try allocator.dupe(u8, entry.id.items)
+            else
+                "";
+            errdefer if (id.len > 0) allocator.free(id);
+            const name = try allocator.dupe(u8, entry.name.items);
+            errdefer allocator.free(name);
+            const arguments = try allocator.dupe(
+                u8,
+                if (entry.arguments.items.len > 0) entry.arguments.items else "{}",
+            );
+            tool_calls[initialized] = .{
+                .id = id,
+                .name = name,
+                .arguments = arguments,
+            };
+            initialized += 1;
+        }
+        return tool_calls;
+    }
+};
+
+fn toolCallStreamIsConfirmed(
+    finish_reason: OpenAiFinishReason,
+    has_tool_call_fragments: bool,
+    had_invalid_data: bool,
+) bool {
+    // A truncated native call is executable data, not display-only partial
+    // text. `[DONE]` alone is insufficient because it is also emitted after
+    // finish_reason=length; require the explicit tool_calls finish reason.
+    return !has_tool_call_fragments or (!had_invalid_data and finish_reason == .tool_calls);
+}
+
+fn shouldRecoverPartialStreamSafely(
+    accumulated_len: usize,
+    saw_done: bool,
+    finish_reason: OpenAiFinishReason,
+    has_tool_call_fragments: bool,
+    had_invalid_data: bool,
+    saw_stream_error: bool,
+) bool {
+    if (saw_stream_error) return false;
+    if (has_tool_call_fragments) return !had_invalid_data and finish_reason == .tool_calls;
+    return root.shouldRecoverPartialStream(accumulated_len, saw_done);
+}
+
+const OpenAiFinishReason = enum {
+    none,
+    tool_calls,
+    length,
+    other,
+};
+
+const OpenAiSseEvent = struct {
+    content: ?DeltaContent = null,
+    tool_call_deltas: []const ToolCallDelta = &.{},
+    usage: ?root.TokenUsage = null,
+    finish_reason: OpenAiFinishReason = .none,
+    api_error: bool = false,
+
+    fn deinit(self: *OpenAiSseEvent, allocator: std.mem.Allocator) void {
+        if (self.content) |content| content.deinit(allocator);
+        deinitToolCallDeltas(allocator, self.tool_call_deltas);
+        self.* = .{};
+    }
+
+    fn hasPayload(self: OpenAiSseEvent) bool {
+        return self.content != null or
+            self.tool_call_deltas.len > 0 or
+            self.usage != null or
+            self.finish_reason != .none or
+            self.api_error;
+    }
+};
+
 /// Result of parsing a single SSE line.
 pub const SseLineResult = union(enum) {
     /// Text or reasoning delta content (owned, caller frees).
@@ -131,6 +328,12 @@ pub const SseLineResult = union(enum) {
     /// Token usage from a stream chunk.
     usage: root.TokenUsage,
     /// Line should be skipped (empty, comment, or no content).
+    skip: void,
+};
+
+const OpenAiSseLineResult = union(enum) {
+    event: OpenAiSseEvent,
+    done: void,
     skip: void,
 };
 
@@ -176,13 +379,39 @@ fn appendDeltaContent(
     }
 }
 
+fn applyOpenAiStreamEvent(
+    allocator: std.mem.Allocator,
+    event_value: OpenAiSseEvent,
+    accumulated: *std.ArrayListUnmanaged(u8),
+    in_reasoning: *bool,
+    tool_call_accumulators: *ToolCallAccumulators,
+    stream_usage: *?root.TokenUsage,
+    finish_reason: *OpenAiFinishReason,
+    saw_stream_error: *bool,
+    callback: root.StreamCallback,
+    ctx: *anyopaque,
+) !void {
+    var event = event_value;
+    defer event.deinit(allocator);
+
+    if (event.content) |content| {
+        try appendDeltaContent(allocator, accumulated, in_reasoning, callback, ctx, content);
+    }
+    for (event.tool_call_deltas) |delta| {
+        try tool_call_accumulators.appendDelta(allocator, delta);
+    }
+    if (event.usage) |usage| stream_usage.* = usage;
+    if (event.finish_reason != .none) finish_reason.* = event.finish_reason;
+    if (event.api_error) saw_stream_error.* = true;
+}
+
 /// Parse a single SSE line in OpenAI streaming format.
 ///
 /// Handles:
 /// - `data: [DONE]` → `.done`
-/// - `data: {JSON}` → extracts `choices[0].delta.content` → `.delta`
+/// - `data: {JSON}` → extracts text/reasoning and fragmented native tool calls
 /// - Empty lines, comments (`:`) → `.skip`
-pub fn parseSseLine(allocator: std.mem.Allocator, line: []const u8) !SseLineResult {
+fn parseOpenAiSseLine(allocator: std.mem.Allocator, line: []const u8) !OpenAiSseLineResult {
     const trimmed = std_compat.mem.trimRight(u8, line, "\r");
 
     if (trimmed.len == 0) return .skip;
@@ -201,18 +430,176 @@ pub fn parseSseLine(allocator: std.mem.Allocator, line: []const u8) !SseLineResu
 
     if (std.mem.eql(u8, data, "[DONE]")) return .done;
 
-    const content = try extractDeltaContent(allocator, data) orelse {
-        // No content delta — check for usage data (sent in the final chunk).
-        if (extractStreamUsage(data)) |u| return .{ .usage = u };
-        return .skip;
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return error.InvalidSseJson;
     };
-    return .{ .delta = content };
+    defer parsed.deinit();
+
+    var event = OpenAiSseEvent{};
+    errdefer event.deinit(allocator);
+    event.content = try extractDeltaContentFromValue(allocator, parsed.value);
+    event.tool_call_deltas = try extractToolCallDeltasFromValue(allocator, parsed.value);
+    event.usage = extractStreamUsageFromValue(parsed.value);
+    event.finish_reason = extractOpenAiFinishReason(parsed.value);
+    if (parsed.value == .object) {
+        if (parsed.value.object.get("error")) |error_value| {
+            // OpenAI-compatible APIs sometimes include `"error": null` in a
+            // successful envelope. Only a concrete error payload terminates
+            // the stream.
+            event.api_error = error_value != .null;
+        }
+    }
+    if (!event.hasPayload()) return .skip;
+    return .{ .event = event };
+}
+
+/// Parse one OpenAI-compatible SSE line using the legacy public result shape.
+/// Rich tool-call and terminal metadata is consumed by curlStream internally.
+pub fn parseSseLine(allocator: std.mem.Allocator, line: []const u8) !SseLineResult {
+    const parsed = try parseOpenAiSseLine(allocator, line);
+    return switch (parsed) {
+        .event => |event_value| blk: {
+            var event = event_value;
+            if (event.content) |content| {
+                event.content = null;
+                event.deinit(allocator);
+                break :blk .{ .delta = content };
+            }
+            if (event.usage) |usage| {
+                event.deinit(allocator);
+                break :blk .{ .usage = usage };
+            }
+            event.deinit(allocator);
+            break :blk .skip;
+        },
+        .done => .done,
+        .skip => .skip,
+    };
+}
+
+fn parseToolCallDelta(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+    fallback_index: usize,
+) !?ToolCallDelta {
+    if (value != .object) return null;
+    const obj = value.object;
+
+    const index = if (obj.get("index")) |index_value| switch (index_value) {
+        .integer => |raw| if (raw >= 0) std.math.cast(usize, raw) orelse return null else return null,
+        else => return null,
+    } else fallback_index;
+
+    const id_source: ?[]const u8 = if (obj.get("id")) |id_value|
+        if (id_value == .string and id_value.string.len > 0) id_value.string else null
+    else
+        null;
+
+    var name_source: ?[]const u8 = null;
+    var arguments_source: ?[]const u8 = null;
+    if (obj.get("function")) |function_value| {
+        if (function_value == .object) {
+            if (function_value.object.get("name")) |name_value| {
+                if (name_value == .string and name_value.string.len > 0) name_source = name_value.string;
+            }
+            if (function_value.object.get("arguments")) |arguments_value| {
+                if (arguments_value == .string and arguments_value.string.len > 0) arguments_source = arguments_value.string;
+            }
+        }
+    }
+
+    if (id_source == null and name_source == null and arguments_source == null) return null;
+
+    var result = ToolCallDelta{ .index = index };
+    errdefer result.deinit(allocator);
+    if (id_source) |id| result.id = try allocator.dupe(u8, id);
+    if (name_source) |name| result.name = try allocator.dupe(u8, name);
+    if (arguments_source) |arguments| result.arguments = try allocator.dupe(u8, arguments);
+    return result;
+}
+
+/// Extract OpenAI-compatible `choices[0].delta.tool_calls` fragments.
+fn extractToolCallDeltas(
+    allocator: std.mem.Allocator,
+    json_str: []const u8,
+) ![]const ToolCallDelta {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return error.InvalidSseJson;
+    };
+    defer parsed.deinit();
+
+    return extractToolCallDeltasFromValue(allocator, parsed.value);
+}
+
+fn extractToolCallDeltasFromValue(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) ![]const ToolCallDelta {
+    if (value != .object) return &.{};
+    const choices = value.object.get("choices") orelse return &.{};
+    if (choices != .array or choices.array.items.len == 0) return &.{};
+    const first = choices.array.items[0];
+    if (first != .object) return &.{};
+    const delta = first.object.get("delta") orelse return &.{};
+    if (delta != .object) return &.{};
+    const tool_calls = delta.object.get("tool_calls") orelse return &.{};
+    if (tool_calls != .array or tool_calls.array.items.len == 0) return &.{};
+
+    var result: std.ArrayListUnmanaged(ToolCallDelta) = .empty;
+    errdefer {
+        for (result.items) |item| item.deinit(allocator);
+        result.deinit(allocator);
+    }
+    for (tool_calls.array.items, 0..) |item, fallback_index| {
+        const parsed_delta = try parseToolCallDelta(allocator, item, fallback_index) orelse continue;
+        result.append(allocator, parsed_delta) catch |err| {
+            parsed_delta.deinit(allocator);
+            return err;
+        };
+    }
+    if (result.items.len == 0) {
+        result.deinit(allocator);
+        return &.{};
+    }
+    return try result.toOwnedSlice(allocator);
+}
+
+fn extractOpenAiFinishReason(value: std.json.Value) OpenAiFinishReason {
+    if (value != .object) return .none;
+    const choices = value.object.get("choices") orelse return .none;
+    if (choices != .array or choices.array.items.len == 0) return .none;
+    const first = choices.array.items[0];
+    if (first != .object) return .none;
+    const finish_reason = first.object.get("finish_reason") orelse return .none;
+    if (finish_reason == .null) return .none;
+    if (finish_reason != .string) return .other;
+    if (std.mem.eql(u8, finish_reason.string, "tool_calls")) return .tool_calls;
+    if (std.mem.eql(u8, finish_reason.string, "length")) return .length;
+    return .other;
 }
 
 /// Extract `usage` object from an OpenAI-compatible streaming chunk.
 /// The final chunk typically has `choices:[]` and a top-level `usage` object.
 /// OpenAI usage chunks may contain nested objects (prompt_tokens_details,
 /// completion_tokens_details) so we use a generous 32 KB stack buffer.
+fn tokenCountFromJsonValue(value: std.json.Value) ?u32 {
+    return switch (value) {
+        .integer => |raw| if (raw <= 0)
+            0
+        else
+            std.math.cast(u32, raw) orelse std.math.maxInt(u32),
+        .float => |raw| if (std.math.isNan(raw) or raw <= 0)
+            0
+        else if (!std.math.isFinite(raw) or raw >= @as(f64, @floatFromInt(std.math.maxInt(u32))))
+            std.math.maxInt(u32)
+        else
+            @intFromFloat(raw),
+        else => null,
+    };
+}
+
 fn extractStreamUsage(json_str: []const u8) ?root.TokenUsage {
     // 32 KB is sufficient for OpenAI's nested usage objects.
     var buf: [32 * 1024]u8 = undefined;
@@ -223,8 +610,12 @@ fn extractStreamUsage(json_str: []const u8) ?root.TokenUsage {
         return null;
     defer parsed.deinit();
 
-    if (parsed.value != .object) return null;
-    const obj = parsed.value.object;
+    return extractStreamUsageFromValue(parsed.value);
+}
+
+fn extractStreamUsageFromValue(value: std.json.Value) ?root.TokenUsage {
+    if (value != .object) return null;
+    const obj = value.object;
     const usage_val = obj.get("usage") orelse return null;
     if (usage_val != .object) return null;
 
@@ -233,29 +624,17 @@ fn extractStreamUsage(json_str: []const u8) ?root.TokenUsage {
     const prompt_val = usage_val.object.get("prompt_tokens") orelse
         usage_val.object.get("input_tokens");
     if (prompt_val) |v| {
-        switch (v) {
-            .integer => |n| usage.prompt_tokens = @intCast(@max(0, n)),
-            .float => |f| usage.prompt_tokens = @intFromFloat(@max(0.0, f)),
-            else => {},
-        }
+        usage.prompt_tokens = tokenCountFromJsonValue(v) orelse 0;
     }
 
     const completion_val = usage_val.object.get("completion_tokens") orelse
         usage_val.object.get("output_tokens");
     if (completion_val) |v| {
-        switch (v) {
-            .integer => |n| usage.completion_tokens = @intCast(@max(0, n)),
-            .float => |f| usage.completion_tokens = @intFromFloat(@max(0.0, f)),
-            else => {},
-        }
+        usage.completion_tokens = tokenCountFromJsonValue(v) orelse 0;
     }
 
     if (usage_val.object.get("total_tokens")) |v| {
-        switch (v) {
-            .integer => |n| usage.total_tokens = @intCast(@max(0, n)),
-            .float => |f| usage.total_tokens = @intFromFloat(@max(0.0, f)),
-            else => {},
-        }
+        usage.total_tokens = tokenCountFromJsonValue(v) orelse 0;
     } else {
         usage.total_tokens = usage.prompt_tokens +| usage.completion_tokens;
     }
@@ -281,11 +660,20 @@ pub fn extractDeltaContent(allocator: std.mem.Allocator, json_str: []const u8) !
 
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch |err| {
         if (verbose.isVerbose()) log.err("Failed to parse SSE JSON payload: len={d} error={s}", .{ json_str.len, @errorName(err) });
+        if (err == error.OutOfMemory) return err;
         return error.InvalidSseJson;
     };
     defer parsed.deinit();
 
-    const obj = parsed.value.object;
+    return extractDeltaContentFromValue(allocator, parsed.value);
+}
+
+fn extractDeltaContentFromValue(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !?DeltaContent {
+    if (value != .object) return null;
+    const obj = value.object;
     const choices = obj.get("choices") orelse return null;
     if (choices != .array or choices.array.items.len == 0) return null;
 
@@ -354,13 +742,7 @@ pub fn curlStream(
     argc += 1;
 
     var timeout_buf: [32]u8 = undefined;
-    if (timeout_secs > 0) {
-        const timeout_str = std.fmt.bufPrint(&timeout_buf, "{d}", .{timeout_secs}) catch unreachable;
-        argv_buf[argc] = "--max-time";
-        argc += 1;
-        argv_buf[argc] = timeout_str;
-        argc += 1;
-    }
+    appendCurlTimeoutArgs(argv_buf[0..], &argc, &timeout_buf, timeout_secs);
 
     // Kill the curl process if transfer rate drops below 1 byte/second for 60 seconds.
     // This catches providers that open the SSE connection but stall mid-stream without
@@ -432,6 +814,11 @@ pub fn curlStream(
         debug_log.info("spawning curl process...", .{});
     }
     try child.spawn();
+    var child_reaped = false;
+    errdefer if (!child_reaped) {
+        _ = child.kill() catch {};
+        _ = child.wait() catch {};
+    };
     if (log_enabled) {
         const pid: i64 = if (@import("builtin").os.tag == .windows) @intCast(@intFromPtr(child.id)) else child.id;
         debug_log.info("curl process spawned, pid={d}", .{pid});
@@ -441,21 +828,20 @@ pub fn curlStream(
         stdin_file.writeAll(body) catch {
             stdin_file.close();
             child.stdin = null;
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
             return error.CurlWriteError;
         };
         stdin_file.close();
         child.stdin = null;
     } else {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
         return error.CurlWriteError;
     }
 
     // Read stdout line by line, parse SSE events
     var accumulated: std.ArrayListUnmanaged(u8) = .empty;
     defer accumulated.deinit(allocator);
+
+    var tool_call_accumulators = ToolCallAccumulators{};
+    defer tool_call_accumulators.deinit(allocator);
 
     var line_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer line_buf.deinit(allocator);
@@ -465,6 +851,9 @@ pub fn curlStream(
     var saw_done = false;
     var total_stdout: usize = 0;
     var stream_usage: ?root.TokenUsage = null;
+    var finish_reason: OpenAiFinishReason = .none;
+    var had_invalid_data = false;
+    var saw_stream_error = false;
     var in_reasoning = false;
 
     outer: while (true) {
@@ -501,12 +890,14 @@ pub fn curlStream(
                 defer p.deinit();
                 if (error_classify.classifyKnownApiError(p.value.object)) |kind| {
                     _ = child.wait() catch {};
+                    child_reaped = true;
                     return error_classify.kindToError(kind);
                 }
             }
 
             // Return a meaningful error
             _ = child.wait() catch {};
+            child_reaped = true;
             debug_log.err("Server returned JSON error payload: len={d}", .{json_response.len});
             return error.ServerError;
         }
@@ -516,17 +907,26 @@ pub fn curlStream(
                 if (log_enabled) {
                     debug_log.info("parsing SSE line: len={d}", .{line_buf.items.len});
                 }
-                const result = parseSseLine(allocator, line_buf.items) catch {
+                const result = parseOpenAiSseLine(allocator, line_buf.items) catch |err| {
                     line_buf.clearRetainingCapacity();
+                    if (err == error.OutOfMemory) return err;
+                    had_invalid_data = true;
                     continue;
                 };
                 line_buf.clearRetainingCapacity();
                 switch (result) {
-                    .delta => |content| {
-                        defer content.deinit(allocator);
-                        try appendDeltaContent(allocator, &accumulated, &in_reasoning, callback, ctx, content);
-                    },
-                    .usage => |u| stream_usage = u,
+                    .event => |event| try applyOpenAiStreamEvent(
+                        allocator,
+                        event,
+                        &accumulated,
+                        &in_reasoning,
+                        &tool_call_accumulators,
+                        &stream_usage,
+                        &finish_reason,
+                        &saw_stream_error,
+                        callback,
+                        ctx,
+                    ),
                     .done => {
                         if (log_enabled) {
                             debug_log.info("SSE stream done", .{});
@@ -548,16 +948,27 @@ pub fn curlStream(
 
     // Parse a trailing line when the stream ends without a final '\n'.
     if (!saw_done and line_buf.items.len > 0) {
-        const trailing = parseSseLine(allocator, line_buf.items) catch null;
+        const trailing = parseOpenAiSseLine(allocator, line_buf.items) catch |err| blk: {
+            if (err == error.OutOfMemory) return err;
+            had_invalid_data = true;
+            break :blk null;
+        };
         line_buf.clearRetainingCapacity();
         if (trailing) |result| {
             switch (result) {
-                .delta => |content| {
-                    defer content.deinit(allocator);
-                    try appendDeltaContent(allocator, &accumulated, &in_reasoning, callback, ctx, content);
-                },
-                .usage => |u| stream_usage = u,
-                .done => {},
+                .event => |event| try applyOpenAiStreamEvent(
+                    allocator,
+                    event,
+                    &accumulated,
+                    &in_reasoning,
+                    &tool_call_accumulators,
+                    &stream_usage,
+                    &finish_reason,
+                    &saw_stream_error,
+                    callback,
+                    ctx,
+                ),
+                .done => saw_done = true,
                 .skip => {},
             }
         }
@@ -576,48 +987,89 @@ pub fn curlStream(
         debug_log.info("waiting for curl process to exit...", .{});
     }
     const term = child.wait() catch |err| {
+        _ = child.kill() catch {};
+        _ = child.wait() catch {};
+        child_reaped = true;
         log.err("curlStream child.wait failed: {}", .{err});
-        if (root.shouldRecoverPartialStream(accumulated.items.len, saw_done)) {
+        if (shouldRecoverPartialStreamSafely(accumulated.items.len, saw_done, finish_reason, tool_call_accumulators.entries.items.len > 0, had_invalid_data, saw_stream_error)) {
             log.warn("curlStream proceeding despite wait failure after partial stream output", .{});
             try closeReasoningBlock(allocator, &accumulated, &in_reasoning, callback, ctx);
             callback(ctx, root.StreamChunk.finalChunk());
-            return finalizeStreamResult(allocator, accumulated.items, stream_usage);
+            return finalizeStreamResult(allocator, accumulated.items, stream_usage, &tool_call_accumulators);
         }
         return error.CurlWaitError;
     };
+    child_reaped = true;
     if (log_enabled) {
         debug_log.info("curl process terminated: {}", .{term});
     }
     switch (term) {
         .exited => |code| if (code != 0) {
-            if (root.shouldRecoverPartialStream(accumulated.items.len, saw_done)) {
+            if (shouldRecoverPartialStreamSafely(accumulated.items.len, saw_done, finish_reason, tool_call_accumulators.entries.items.len > 0, had_invalid_data, saw_stream_error)) {
                 log.warn("curlStream exit code {d} after partial stream output; returning accumulated output", .{code});
                 try closeReasoningBlock(allocator, &accumulated, &in_reasoning, callback, ctx);
                 callback(ctx, root.StreamChunk.finalChunk());
-                return finalizeStreamResult(allocator, accumulated.items, stream_usage);
+                return finalizeStreamResult(allocator, accumulated.items, stream_usage, &tool_call_accumulators);
             }
             return error.CurlFailed;
         },
         else => {
-            if (root.shouldRecoverPartialStream(accumulated.items.len, saw_done)) {
+            if (shouldRecoverPartialStreamSafely(accumulated.items.len, saw_done, finish_reason, tool_call_accumulators.entries.items.len > 0, had_invalid_data, saw_stream_error)) {
                 log.warn("curlStream abnormal termination after partial stream output; returning accumulated output", .{});
                 try closeReasoningBlock(allocator, &accumulated, &in_reasoning, callback, ctx);
                 callback(ctx, root.StreamChunk.finalChunk());
-                return finalizeStreamResult(allocator, accumulated.items, stream_usage);
+                return finalizeStreamResult(allocator, accumulated.items, stream_usage, &tool_call_accumulators);
             }
             return error.CurlFailed;
         },
     }
 
+    if (saw_stream_error or !toolCallStreamIsConfirmed(finish_reason, tool_call_accumulators.entries.items.len > 0, had_invalid_data)) {
+        return error.CurlFailed;
+    }
+
     // Signal stream completion only after curl exits successfully.
     try closeReasoningBlock(allocator, &accumulated, &in_reasoning, callback, ctx);
     callback(ctx, root.StreamChunk.finalChunk());
-    return finalizeStreamResult(allocator, accumulated.items, stream_usage);
+    return finalizeStreamResult(allocator, accumulated.items, stream_usage, &tool_call_accumulators);
 }
 
 // ════════════════════════════════════════════════════════════════════════════
 // Anthropic SSE Parsing
 // ════════════════════════════════════════════════════════════════════════════
+
+const AnthropicStopReason = enum {
+    none,
+    tool_use,
+    max_tokens,
+    other,
+};
+
+const AnthropicMessageDelta = struct {
+    usage: ?u32 = null,
+    stop_reason: AnthropicStopReason = .none,
+};
+
+fn anthropicToolCallStreamIsConfirmed(
+    stop_reason: AnthropicStopReason,
+    has_tool_call_fragments: bool,
+    had_invalid_data: bool,
+) bool {
+    return !has_tool_call_fragments or (!had_invalid_data and stop_reason == .tool_use);
+}
+
+fn shouldRecoverAnthropicPartialStreamSafely(
+    accumulated_len: usize,
+    saw_done: bool,
+    stop_reason: AnthropicStopReason,
+    has_tool_call_fragments: bool,
+    had_invalid_data: bool,
+    saw_stream_error: bool,
+) bool {
+    if (saw_stream_error) return false;
+    if (has_tool_call_fragments) return !had_invalid_data and stop_reason == .tool_use;
+    return root.shouldRecoverPartialStream(accumulated_len, saw_done);
+}
 
 /// Result of parsing a single Anthropic SSE line.
 pub const AnthropicSseResult = union(enum) {
@@ -633,6 +1085,17 @@ pub const AnthropicSseResult = union(enum) {
     skip: void,
 };
 
+const AnthropicStreamResult = union(enum) {
+    event: []const u8,
+    delta: []const u8,
+    tool_call_start: ToolCallDelta,
+    tool_call_delta: ToolCallDelta,
+    message_delta: AnthropicMessageDelta,
+    done: void,
+    stream_error: void,
+    skip: void,
+};
+
 /// Parse a single SSE line in Anthropic streaming format.
 ///
 /// Anthropic SSE is stateful: `event:` lines set the context for subsequent `data:` lines.
@@ -640,10 +1103,11 @@ pub const AnthropicSseResult = union(enum) {
 ///
 /// - `event: X` → `.event` (caller remembers X)
 /// - `data: {JSON}` + current_event=="content_block_delta" → extracts `delta.text` → `.delta`
+/// - `content_block_start`/`input_json_delta` → native tool-call fragments
 /// - `data: {JSON}` + current_event=="message_delta" → extracts `usage.output_tokens` → `.usage`
 /// - `data: {JSON}` + current_event=="message_stop" → `.done`
 /// - Everything else → `.skip`
-pub fn parseAnthropicSseLine(allocator: std.mem.Allocator, line: []const u8, current_event: []const u8) !AnthropicSseResult {
+fn parseAnthropicStreamLine(allocator: std.mem.Allocator, line: []const u8, current_event: []const u8) !AnthropicStreamResult {
     const trimmed = std_compat.mem.trimRight(u8, line, "\r");
 
     if (trimmed.len == 0) return .skip;
@@ -662,28 +1126,139 @@ pub fn parseAnthropicSseLine(allocator: std.mem.Allocator, line: []const u8, cur
     const data = trimmed[data_prefix.len..];
 
     if (std.mem.eql(u8, current_event, "message_stop")) return .done;
+    if (std.mem.eql(u8, current_event, "error")) return .stream_error;
+
+    if (std.mem.eql(u8, current_event, "content_block_start")) {
+        const start = try extractAnthropicToolCallStart(allocator, data) orelse return .skip;
+        return .{ .tool_call_start = start };
+    }
 
     if (std.mem.eql(u8, current_event, "content_block_delta")) {
-        const text = try extractAnthropicDelta(allocator, data) orelse return .skip;
-        return .{ .delta = text };
+        return extractAnthropicContentBlockDelta(allocator, data);
     }
 
     if (std.mem.eql(u8, current_event, "message_delta")) {
-        const tokens = try extractAnthropicUsage(data) orelse return .skip;
-        return .{ .usage = tokens };
+        const message_delta = try extractAnthropicMessageDelta(allocator, data);
+        if (message_delta.usage == null and message_delta.stop_reason == .none) return .skip;
+        return .{ .message_delta = message_delta };
     }
 
     return .skip;
 }
 
+/// Parse an Anthropic SSE line using the original public result variants.
+/// Structured tool-call and terminal metadata remains internal to the curl
+/// streaming implementation.
+pub fn parseAnthropicSseLine(allocator: std.mem.Allocator, line: []const u8, current_event: []const u8) !AnthropicSseResult {
+    const trimmed = std_compat.mem.trimRight(u8, line, "\r");
+    if (trimmed.len == 0 or trimmed[0] == ':') return .skip;
+
+    const event_prefix = "event: ";
+    if (std.mem.startsWith(u8, trimmed, event_prefix)) {
+        return .{ .event = trimmed[event_prefix.len..] };
+    }
+
+    const data_prefix = "data: ";
+    if (!std.mem.startsWith(u8, trimmed, data_prefix)) return .skip;
+    const data = trimmed[data_prefix.len..];
+
+    if (std.mem.eql(u8, current_event, "message_stop")) return .done;
+    if (std.mem.eql(u8, current_event, "content_block_delta")) {
+        const text = try extractAnthropicDelta(allocator, data) orelse return .skip;
+        return .{ .delta = text };
+    }
+    if (std.mem.eql(u8, current_event, "message_delta")) {
+        const usage = try extractAnthropicUsage(data) orelse return .skip;
+        return .{ .usage = usage };
+    }
+    return .skip;
+}
+
+fn extractNonNegativeIndex(obj: std.json.ObjectMap) ?usize {
+    const index_value = obj.get("index") orelse return null;
+    if (index_value != .integer or index_value.integer < 0) return null;
+    return std.math.cast(usize, index_value.integer);
+}
+
+/// Parse an Anthropic `content_block_start` event for a client tool call.
+fn extractAnthropicToolCallStart(
+    allocator: std.mem.Allocator,
+    json_str: []const u8,
+) !?ToolCallDelta {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return error.InvalidSseJson;
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+
+    const index = extractNonNegativeIndex(parsed.value.object) orelse return null;
+    const content_block = parsed.value.object.get("content_block") orelse return null;
+    if (content_block != .object) return null;
+    const block_type = content_block.object.get("type") orelse return null;
+    if (block_type != .string or !std.mem.eql(u8, block_type.string, "tool_use")) return null;
+    const id_value = content_block.object.get("id") orelse return null;
+    const name_value = content_block.object.get("name") orelse return null;
+    if (id_value != .string or name_value != .string or name_value.string.len == 0) return null;
+
+    var result = ToolCallDelta{ .index = index };
+    errdefer result.deinit(allocator);
+    if (id_value.string.len > 0) result.id = try allocator.dupe(u8, id_value.string);
+    result.name = try allocator.dupe(u8, name_value.string);
+    return result;
+}
+
+/// Parse an Anthropic `input_json_delta` fragment.
+fn extractAnthropicToolCallDelta(
+    allocator: std.mem.Allocator,
+    json_str: []const u8,
+) !?ToolCallDelta {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return error.InvalidSseJson;
+    };
+    defer parsed.deinit();
+
+    return extractAnthropicToolCallDeltaFromValue(allocator, parsed.value);
+}
+
+fn extractAnthropicToolCallDeltaFromValue(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !?ToolCallDelta {
+    if (value != .object) return null;
+    const index = extractNonNegativeIndex(value.object) orelse return null;
+    const delta = value.object.get("delta") orelse return null;
+    if (delta != .object) return null;
+    const delta_type = delta.object.get("type") orelse return null;
+    if (delta_type != .string or !std.mem.eql(u8, delta_type.string, "input_json_delta")) return null;
+    const partial_json = delta.object.get("partial_json") orelse return null;
+    if (partial_json != .string or partial_json.string.len == 0) return null;
+
+    return .{
+        .index = index,
+        .arguments = try allocator.dupe(u8, partial_json.string),
+    };
+}
+
 /// Extract `delta.text` from an Anthropic content_block_delta JSON payload.
 /// Returns owned slice or null if not a text_delta.
 pub fn extractAnthropicDelta(allocator: std.mem.Allocator, json_str: []const u8) !?[]const u8 {
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
         return error.InvalidSseJson;
+    };
     defer parsed.deinit();
 
-    const obj = parsed.value.object;
+    return extractAnthropicDeltaFromValue(allocator, parsed.value);
+}
+
+fn extractAnthropicDeltaFromValue(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) !?[]const u8 {
+    if (value != .object) return null;
+    const obj = value.object;
     const delta = obj.get("delta") orelse return null;
     if (delta != .object) return null;
 
@@ -695,6 +1270,62 @@ pub fn extractAnthropicDelta(allocator: std.mem.Allocator, json_str: []const u8)
     if (text.string.len == 0) return null;
 
     return try allocator.dupe(u8, text.string);
+}
+
+fn extractAnthropicContentBlockDelta(
+    allocator: std.mem.Allocator,
+    json_str: []const u8,
+) !AnthropicStreamResult {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return error.InvalidSseJson;
+    };
+    defer parsed.deinit();
+
+    if (try extractAnthropicDeltaFromValue(allocator, parsed.value)) |text| {
+        return .{ .delta = text };
+    }
+    const delta = try extractAnthropicToolCallDeltaFromValue(allocator, parsed.value) orelse return .skip;
+    return .{ .tool_call_delta = delta };
+}
+
+fn extractAnthropicMessageDelta(
+    allocator: std.mem.Allocator,
+    json_str: []const u8,
+) !AnthropicMessageDelta {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return error.InvalidSseJson;
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return .{};
+
+    const obj = parsed.value.object;
+    var result = AnthropicMessageDelta{};
+    if (obj.get("usage")) |usage| {
+        if (usage == .object) {
+            if (usage.object.get("output_tokens")) |output_tokens| {
+                if (output_tokens == .integer) {
+                    result.usage = std.math.cast(u32, output_tokens.integer);
+                }
+            }
+        }
+    }
+    if (obj.get("delta")) |delta| {
+        if (delta == .object) {
+            if (delta.object.get("stop_reason")) |stop_reason| {
+                if (stop_reason == .string) {
+                    result.stop_reason = if (std.mem.eql(u8, stop_reason.string, "tool_use"))
+                        .tool_use
+                    else if (std.mem.eql(u8, stop_reason.string, "max_tokens"))
+                        .max_tokens
+                    else
+                        .other;
+                }
+            }
+        }
+    }
+    return result;
 }
 
 /// Extract `usage.output_tokens` from an Anthropic message_delta JSON payload.
@@ -709,6 +1340,7 @@ pub fn extractAnthropicUsage(json_str: []const u8) !?u32 {
         return error.InvalidSseJson;
     defer parsed.deinit();
 
+    if (parsed.value != .object) return null;
     const obj = parsed.value.object;
     const usage = obj.get("usage") orelse return null;
     if (usage != .object) return null;
@@ -716,18 +1348,19 @@ pub fn extractAnthropicUsage(json_str: []const u8) !?u32 {
     const output_tokens = usage.object.get("output_tokens") orelse return null;
     if (output_tokens != .integer) return null;
 
-    return @intCast(output_tokens.integer);
+    return std.math.cast(u32, output_tokens.integer);
 }
 
 /// Run curl in SSE streaming mode for Anthropic and parse output line by line.
 ///
 /// Similar to `curlStream()` but uses stateful Anthropic SSE parsing.
 /// `headers` is a slice of pre-formatted header strings (e.g. "x-api-key: sk-...").
-pub fn curlStreamAnthropic(
+pub fn curlStreamAnthropicTimed(
     allocator: std.mem.Allocator,
     url: []const u8,
     body: []const u8,
     headers: []const []const u8,
+    timeout_secs: u64,
     callback: root.StreamCallback,
     ctx: *anyopaque,
 ) !root.StreamChatResult {
@@ -741,6 +1374,13 @@ pub fn curlStreamAnthropic(
     argc += 1;
     argv_buf[argc] = "--no-buffer";
     argc += 1;
+    argv_buf[argc] = curlFailFastArg(allocator);
+    argc += 1;
+
+    var timeout_buf: [32]u8 = undefined;
+    appendCurlTimeoutArgs(argv_buf[0..], &argc, &timeout_buf, timeout_secs);
+    appendCurlStallDetectionArgs(argv_buf[0..], &argc);
+
     argv_buf[argc] = "-X";
     argc += 1;
     argv_buf[argc] = "POST";
@@ -793,20 +1433,21 @@ pub fn curlStreamAnthropic(
     child.stderr_behavior = .Ignore;
 
     try child.spawn();
+    var child_reaped = false;
+    errdefer if (!child_reaped) {
+        _ = child.kill() catch {};
+        _ = child.wait() catch {};
+    };
 
     if (child.stdin) |stdin_file| {
         stdin_file.writeAll(body) catch {
             stdin_file.close();
             child.stdin = null;
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
             return error.CurlWriteError;
         };
         stdin_file.close();
         child.stdin = null;
     } else {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
         return error.CurlWriteError;
     }
 
@@ -814,12 +1455,19 @@ pub fn curlStreamAnthropic(
     var accumulated: std.ArrayListUnmanaged(u8) = .empty;
     defer accumulated.deinit(allocator);
 
+    var tool_call_accumulators = ToolCallAccumulators{};
+    defer tool_call_accumulators.deinit(allocator);
+
     var line_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer line_buf.deinit(allocator);
 
     var current_event: []const u8 = "";
+    defer if (current_event.len > 0) allocator.free(@constCast(current_event));
     var anthropic_usage: root.TokenUsage = .{};
     var saw_done = false;
+    var stop_reason: AnthropicStopReason = .none;
+    var had_invalid_data = false;
+    var saw_stream_error = false;
 
     const file = child.stdout.?;
     var read_buf: [4096]u8 = undefined;
@@ -830,27 +1478,40 @@ pub fn curlStreamAnthropic(
 
         for (read_buf[0..n]) |byte| {
             if (byte == '\n') {
-                const result = parseAnthropicSseLine(allocator, line_buf.items, current_event) catch {
+                const result = parseAnthropicStreamLine(allocator, line_buf.items, current_event) catch |err| {
                     line_buf.clearRetainingCapacity();
+                    if (err == error.OutOfMemory) return err;
+                    had_invalid_data = true;
                     continue;
                 };
                 switch (result) {
                     .event => |ev| {
                         // Dupe event name — it points into line_buf which we're about to clear
-                        if (current_event.len > 0) allocator.free(@constCast(current_event));
-                        current_event = allocator.dupe(u8, ev) catch "";
+                        if (current_event.len > 0) {
+                            allocator.free(@constCast(current_event));
+                            current_event = "";
+                        }
+                        current_event = try allocator.dupe(u8, ev);
                     },
                     .delta => |text| {
                         defer allocator.free(text);
                         try accumulated.appendSlice(allocator, text);
                         callback(ctx, root.StreamChunk.textDelta(text));
                     },
-                    .usage => |tokens| anthropic_usage.completion_tokens = tokens,
+                    .tool_call_start, .tool_call_delta => |delta| {
+                        defer delta.deinit(allocator);
+                        try tool_call_accumulators.appendDelta(allocator, delta);
+                    },
+                    .message_delta => |message_delta| {
+                        if (message_delta.usage) |tokens| anthropic_usage.completion_tokens = tokens;
+                        if (message_delta.stop_reason != .none) stop_reason = message_delta.stop_reason;
+                    },
                     .done => {
                         saw_done = true;
                         line_buf.clearRetainingCapacity();
                         break :outer;
                     },
+                    .stream_error => saw_stream_error = true,
                     .skip => {},
                 }
                 line_buf.clearRetainingCapacity();
@@ -860,8 +1521,34 @@ pub fn curlStreamAnthropic(
         }
     }
 
-    // Free owned event string
-    if (current_event.len > 0) allocator.free(@constCast(current_event));
+    // Parse a trailing line when the stream ends without a final newline.
+    if (!saw_done and line_buf.items.len > 0) {
+        const trailing = parseAnthropicStreamLine(allocator, line_buf.items, current_event) catch |err| blk: {
+            if (err == error.OutOfMemory) return err;
+            had_invalid_data = true;
+            break :blk null;
+        };
+        line_buf.clearRetainingCapacity();
+        if (trailing) |result| switch (result) {
+            .event => {},
+            .delta => |text| {
+                defer allocator.free(text);
+                try accumulated.appendSlice(allocator, text);
+                callback(ctx, root.StreamChunk.textDelta(text));
+            },
+            .tool_call_start, .tool_call_delta => |delta| {
+                defer delta.deinit(allocator);
+                try tool_call_accumulators.appendDelta(allocator, delta);
+            },
+            .message_delta => |message_delta| {
+                if (message_delta.usage) |tokens| anthropic_usage.completion_tokens = tokens;
+                if (message_delta.stop_reason != .none) stop_reason = message_delta.stop_reason;
+            },
+            .done => saw_done = true,
+            .stream_error => saw_stream_error = true,
+            .skip => {},
+        };
+    }
 
     // Drain remaining stdout to prevent deadlock on wait()
     while (true) {
@@ -870,35 +1557,56 @@ pub fn curlStreamAnthropic(
     }
 
     const term = child.wait() catch |err| {
+        _ = child.kill() catch {};
+        _ = child.wait() catch {};
+        child_reaped = true;
         log.err("curlStreamAnthropic child.wait failed: {}", .{err});
-        if (root.shouldRecoverPartialStream(accumulated.items.len, saw_done)) {
+        if (shouldRecoverAnthropicPartialStreamSafely(accumulated.items.len, saw_done, stop_reason, tool_call_accumulators.entries.items.len > 0, had_invalid_data, saw_stream_error)) {
             log.warn("curlStreamAnthropic proceeding despite wait failure after partial stream output", .{});
             callback(ctx, root.StreamChunk.finalChunk());
-            return finalizeStreamResult(allocator, accumulated.items, anthropic_usage);
+            return finalizeStreamResult(allocator, accumulated.items, anthropic_usage, &tool_call_accumulators);
         }
         return error.CurlWaitError;
     };
+    child_reaped = true;
     switch (term) {
         .exited => |code| if (code != 0) {
-            if (root.shouldRecoverPartialStream(accumulated.items.len, saw_done)) {
+            if (shouldRecoverAnthropicPartialStreamSafely(accumulated.items.len, saw_done, stop_reason, tool_call_accumulators.entries.items.len > 0, had_invalid_data, saw_stream_error)) {
                 log.warn("curlStreamAnthropic exit code {d} after partial stream output; returning accumulated output", .{code});
                 callback(ctx, root.StreamChunk.finalChunk());
-                return finalizeStreamResult(allocator, accumulated.items, anthropic_usage);
+                return finalizeStreamResult(allocator, accumulated.items, anthropic_usage, &tool_call_accumulators);
             }
             return error.CurlFailed;
         },
         else => {
-            if (root.shouldRecoverPartialStream(accumulated.items.len, saw_done)) {
+            if (shouldRecoverAnthropicPartialStreamSafely(accumulated.items.len, saw_done, stop_reason, tool_call_accumulators.entries.items.len > 0, had_invalid_data, saw_stream_error)) {
                 log.warn("curlStreamAnthropic abnormal termination after partial stream output; returning accumulated output", .{});
                 callback(ctx, root.StreamChunk.finalChunk());
-                return finalizeStreamResult(allocator, accumulated.items, anthropic_usage);
+                return finalizeStreamResult(allocator, accumulated.items, anthropic_usage, &tool_call_accumulators);
             }
             return error.CurlFailed;
         },
     }
 
+    if (saw_stream_error or !anthropicToolCallStreamIsConfirmed(stop_reason, tool_call_accumulators.entries.items.len > 0, had_invalid_data)) {
+        return error.CurlFailed;
+    }
+
     callback(ctx, root.StreamChunk.finalChunk());
-    return finalizeStreamResult(allocator, accumulated.items, anthropic_usage);
+    return finalizeStreamResult(allocator, accumulated.items, anthropic_usage, &tool_call_accumulators);
+}
+
+/// Backward-compatible Anthropic streaming entry point without an explicit
+/// timeout. New callers should use curlStreamAnthropicTimed.
+pub fn curlStreamAnthropic(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    body: []const u8,
+    headers: []const []const u8,
+    callback: root.StreamCallback,
+    ctx: *anyopaque,
+) !root.StreamChatResult {
+    return curlStreamAnthropicTimed(allocator, url, body, headers, 0, callback, ctx);
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -909,9 +1617,9 @@ test "parseSseLine valid delta" {
     const allocator = std.testing.allocator;
     const result = try parseSseLine(allocator, "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}");
     switch (result) {
-        .delta => |d| {
-            defer d.deinit(allocator);
-            try std.testing.expectEqualStrings("Hello", d.text);
+        .delta => |delta| {
+            defer delta.deinit(allocator);
+            try std.testing.expectEqualStrings("Hello", delta.text);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -921,12 +1629,146 @@ test "parseSseLine valid delta without optional space" {
     const allocator = std.testing.allocator;
     const result = try parseSseLine(allocator, "data:{\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}");
     switch (result) {
-        .delta => |d| {
-            defer d.deinit(allocator);
-            try std.testing.expectEqualStrings("Hello", d.text);
+        .delta => |delta| {
+            defer delta.deinit(allocator);
+            try std.testing.expectEqualStrings("Hello", delta.text);
         },
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "parseSseLine returns text and native tool fields from one chunk" {
+    // Regression: providers may emit visible content and the first tool-call
+    // fragment together; neither side of the chunk may be discarded.
+    const allocator = std.testing.allocator;
+    const line = "data: {\"choices\":[{\"delta\":{\"content\":\"Calling tool\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"weather\",\"arguments\":\"{}\"}}]}}]}";
+    const result = try parseOpenAiSseLine(allocator, line);
+    switch (result) {
+        .event => |event_value| {
+            var event = event_value;
+            defer event.deinit(allocator);
+            try std.testing.expectEqualStrings("Calling tool", event.content.?.text);
+            try std.testing.expectEqual(@as(usize, 1), event.tool_call_deltas.len);
+            try std.testing.expectEqualStrings("call_1", event.tool_call_deltas[0].id.?);
+            try std.testing.expectEqualStrings("weather", event.tool_call_deltas[0].name.?);
+            try std.testing.expectEqualStrings("{}", event.tool_call_deltas[0].arguments.?);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "parseSseLine exposes terminal tool reason and streamed API errors" {
+    const allocator = std.testing.allocator;
+    const finished = try parseOpenAiSseLine(
+        allocator,
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}",
+    );
+    switch (finished) {
+        .event => |event_value| {
+            var event = event_value;
+            defer event.deinit(allocator);
+            try std.testing.expect(event.finish_reason == .tool_calls);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    const api_error = try parseOpenAiSseLine(
+        allocator,
+        "data: {\"error\":{\"message\":\"stream failed\"}}",
+    );
+    switch (api_error) {
+        .event => |event_value| {
+            var event = event_value;
+            defer event.deinit(allocator);
+            try std.testing.expect(event.api_error);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    // Regression: compatible APIs may include an explicit null error field in
+    // otherwise successful streaming envelopes.
+    const null_error = try parseOpenAiSseLine(
+        allocator,
+        "data: {\"error\":null,\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}",
+    );
+    switch (null_error) {
+        .event => |event_value| {
+            var event = event_value;
+            defer event.deinit(allocator);
+            try std.testing.expect(!event.api_error);
+            try std.testing.expectEqualStrings("ok", event.content.?.text);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "OpenAI streaming tool call fragments accumulate by index" {
+    // Regression: Chat Completions and vLLM split function arguments across
+    // multiple delta.tool_calls chunks.
+    const allocator = std.testing.allocator;
+    const lines = [_][]const u8{
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"weather\",\"arguments\":\"\"}}]}}]}",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\":\"}}]}}]}",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"Paris\\\"}\"}}]}}]}",
+    };
+
+    var accumulators = ToolCallAccumulators{};
+    defer accumulators.deinit(allocator);
+    for (lines) |line| {
+        const parsed = try parseOpenAiSseLine(allocator, line);
+        switch (parsed) {
+            .event => |event_value| {
+                var event = event_value;
+                defer event.deinit(allocator);
+                for (event.tool_call_deltas) |delta| try accumulators.appendDelta(allocator, delta);
+            },
+            else => return error.TestUnexpectedResult,
+        }
+    }
+
+    var result = try finalizeStreamResult(allocator, "", null, &accumulators);
+    defer result.deinit(allocator);
+    try std.testing.expect(result.content == null);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", result.tool_calls[0].id);
+    try std.testing.expectEqualStrings("weather", result.tool_calls[0].name);
+    try std.testing.expectEqualStrings("{\"city\":\"Paris\"}", result.tool_calls[0].arguments);
+    try std.testing.expect(result.usage.completion_tokens > 0);
+}
+
+test "partial stream recovery rejects unconfirmed native tool calls" {
+    // Regression: a premature EOF must never turn a truncated function name
+    // or argument fragment into an executable call.
+    try std.testing.expect(!shouldRecoverPartialStreamSafely(0, false, .none, true, false, false));
+    try std.testing.expect(!shouldRecoverPartialStreamSafely(12, true, .length, true, false, false));
+    try std.testing.expect(shouldRecoverPartialStreamSafely(0, false, .tool_calls, true, false, false));
+    try std.testing.expect(!shouldRecoverPartialStreamSafely(0, true, .tool_calls, true, true, false));
+    try std.testing.expect(shouldRecoverPartialStreamSafely(12, false, .none, false, true, false));
+    try std.testing.expect(!toolCallStreamIsConfirmed(.length, true, false));
+    try std.testing.expect(!toolCallStreamIsConfirmed(.tool_calls, true, true));
+    try std.testing.expect(toolCallStreamIsConfirmed(.tool_calls, true, false));
+}
+
+fn streamingToolCallAllocationTest(allocator: std.mem.Allocator) !void {
+    var accumulators = ToolCallAccumulators{};
+    defer accumulators.deinit(allocator);
+    const line = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"weather\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\"}}]}}]}";
+    const parsed = try parseOpenAiSseLine(allocator, line);
+    switch (parsed) {
+        .event => |event_value| {
+            var event = event_value;
+            defer event.deinit(allocator);
+            for (event.tool_call_deltas) |delta| try accumulators.appendDelta(allocator, delta);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    var result = try finalizeStreamResult(allocator, "", null, &accumulators);
+    defer result.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.len);
+}
+
+test "streaming tool call allocation failures do not leak" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, streamingToolCallAllocationTest, .{});
 }
 
 test "appendCurlStallDetectionArgs appends curl speed flags in order" {
@@ -941,6 +1783,20 @@ test "appendCurlStallDetectionArgs appends curl speed flags in order" {
     try std.testing.expectEqualStrings("1", argv_buf[1]);
     try std.testing.expectEqualStrings("--speed-time", argv_buf[2]);
     try std.testing.expectEqualStrings("60", argv_buf[3]);
+}
+
+test "appendCurlTimeoutArgs preserves configured stream timeout" {
+    var argv_buf: [4][]const u8 = undefined;
+    var timeout_buf: [32]u8 = undefined;
+    var argc: usize = 0;
+    appendCurlTimeoutArgs(argv_buf[0..], &argc, &timeout_buf, 42);
+    try std.testing.expectEqual(@as(usize, 2), argc);
+    try std.testing.expectEqualStrings("--max-time", argv_buf[0]);
+    try std.testing.expectEqualStrings("42", argv_buf[1]);
+
+    argc = 0;
+    appendCurlTimeoutArgs(argv_buf[0..], &argc, &timeout_buf, 0);
+    try std.testing.expectEqual(@as(usize, 0), argc);
 }
 
 test "parseSseLine DONE sentinel" {
@@ -1005,6 +1861,12 @@ test "extractDeltaContent with content" {
 test "extractDeltaContent without content" {
     const result = try extractDeltaContent(std.testing.allocator, "{\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}");
     try std.testing.expect(result == null);
+}
+
+test "extractDeltaContent ignores non-object JSON" {
+    // Regression: provider-controlled JSON must not reach `.object` on a
+    // non-object value and panic the streaming process.
+    try std.testing.expect((try extractDeltaContent(std.testing.allocator, "[]")) == null);
 }
 
 test "extractDeltaContent empty content" {
@@ -1129,11 +1991,85 @@ test "parseAnthropicSseLine data with content_block_delta returns delta" {
     }
 }
 
+test "Anthropic streaming tool_use fragments become a native tool call" {
+    // Regression: tool_use metadata arrives in content_block_start while its
+    // arguments arrive later as fragmented input_json_delta events.
+    const allocator = std.testing.allocator;
+    const start_line = "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"weather\",\"input\":{}}}";
+    const delta_lines = [_][]const u8{
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\":\"}}",
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"Paris\\\"}\"}}",
+    };
+
+    var accumulators = ToolCallAccumulators{};
+    defer accumulators.deinit(allocator);
+
+    const start = try parseAnthropicStreamLine(allocator, start_line, "content_block_start");
+    switch (start) {
+        .tool_call_start => |delta| {
+            defer delta.deinit(allocator);
+            try accumulators.appendDelta(allocator, delta);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    for (delta_lines) |line| {
+        const parsed = try parseAnthropicStreamLine(allocator, line, "content_block_delta");
+        switch (parsed) {
+            .tool_call_delta => |delta| {
+                defer delta.deinit(allocator);
+                try accumulators.appendDelta(allocator, delta);
+            },
+            else => return error.TestUnexpectedResult,
+        }
+    }
+
+    var result = try finalizeStreamResult(allocator, "", null, &accumulators);
+    defer result.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.len);
+    try std.testing.expectEqualStrings("toolu_1", result.tool_calls[0].id);
+    try std.testing.expectEqualStrings("weather", result.tool_calls[0].name);
+    try std.testing.expectEqualStrings("{\"city\":\"Paris\"}", result.tool_calls[0].arguments);
+}
+
+test "Anthropic empty tool input defaults to empty JSON object" {
+    const allocator = std.testing.allocator;
+    const line = "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_empty\",\"name\":\"ping\",\"input\":{}}}";
+    const parsed = try parseAnthropicStreamLine(allocator, line, "content_block_start");
+    var accumulators = ToolCallAccumulators{};
+    defer accumulators.deinit(allocator);
+    switch (parsed) {
+        .tool_call_start => |delta| {
+            defer delta.deinit(allocator);
+            try accumulators.appendDelta(allocator, delta);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    var result = try finalizeStreamResult(allocator, "", null, &accumulators);
+    defer result.deinit(allocator);
+    try std.testing.expectEqualStrings("{}", result.tool_calls[0].arguments);
+}
+
 test "parseAnthropicSseLine data with message_delta returns usage" {
     const json = "data: {\"type\":\"message_delta\",\"delta\":{},\"usage\":{\"output_tokens\":42}}";
     const result = try parseAnthropicSseLine(std.testing.allocator, json, "message_delta");
     switch (result) {
-        .usage => |tokens| try std.testing.expect(tokens == 42),
+        .usage => |usage| try std.testing.expect(usage == 42),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "Anthropic tool stream rejects max_tokens termination" {
+    // Regression: message_stop also follows max_tokens, where partial_json may
+    // be truncated and must never become an executable tool call.
+    try std.testing.expect(!anthropicToolCallStreamIsConfirmed(.max_tokens, true, false));
+    try std.testing.expect(!anthropicToolCallStreamIsConfirmed(.tool_use, true, true));
+    try std.testing.expect(anthropicToolCallStreamIsConfirmed(.tool_use, true, false));
+
+    const json = "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":42}}";
+    const result = try parseAnthropicStreamLine(std.testing.allocator, json, "message_delta");
+    switch (result) {
+        .message_delta => |message_delta| try std.testing.expect(message_delta.stop_reason == .max_tokens),
         else => return error.TestUnexpectedResult,
     }
 }
@@ -1141,6 +2077,15 @@ test "parseAnthropicSseLine data with message_delta returns usage" {
 test "parseAnthropicSseLine data with message_stop returns done" {
     const result = try parseAnthropicSseLine(std.testing.allocator, "data: {\"type\":\"message_stop\"}", "message_stop");
     try std.testing.expect(result == .done);
+}
+
+test "parseAnthropicSseLine surfaces HTTP-200 stream errors" {
+    const result = try parseAnthropicStreamLine(
+        std.testing.allocator,
+        "data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\"}}",
+        "error",
+    );
+    try std.testing.expect(result == .stream_error);
 }
 
 test "parseAnthropicSseLine empty line returns skip" {
@@ -1173,10 +2118,26 @@ test "extractAnthropicDelta without text returns null" {
     try std.testing.expect(result == null);
 }
 
+test "extractAnthropicDelta ignores non-object JSON" {
+    try std.testing.expect((try extractAnthropicDelta(std.testing.allocator, "[]")) == null);
+}
+
 test "extractAnthropicUsage correct JSON returns token count" {
     const json = "{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":57}}";
     const result = (try extractAnthropicUsage(json)).?;
     try std.testing.expect(result == 57);
+}
+
+test "extractAnthropicUsage rejects out-of-range token counts" {
+    try std.testing.expect((try extractAnthropicUsage("{\"usage\":{\"output_tokens\":-1}}")) == null);
+    try std.testing.expect((try extractAnthropicUsage("{\"usage\":{\"output_tokens\":4294967296}}")) == null);
+}
+
+test "extractAnthropicUsage ignores non-object JSON" {
+    // Regression: provider-controlled usage events must not select `.object`
+    // on a different JSON union tag.
+    try std.testing.expect((try extractAnthropicUsage("[]")) == null);
+    try std.testing.expect((try extractAnthropicUsage("null")) == null);
 }
 
 // ── Stream Usage Extraction Tests ───────────────────────────────
@@ -1198,16 +2159,22 @@ test "extractStreamUsage returns null for invalid JSON" {
     try std.testing.expect(extractStreamUsage("not-json{{{") == null);
 }
 
+test "extractStreamUsage clamps provider-controlled token counts" {
+    const json = "{\"usage\":{\"prompt_tokens\":9223372036854775807,\"completion_tokens\":1e40}}";
+    const usage = extractStreamUsage(json).?;
+    try std.testing.expectEqual(std.math.maxInt(u32), usage.prompt_tokens);
+    try std.testing.expectEqual(std.math.maxInt(u32), usage.completion_tokens);
+    try std.testing.expectEqual(std.math.maxInt(u32), usage.total_tokens);
+}
+
 test "finalizeStreamResult separates think blocks into reasoning content" {
-    const result = try finalizeStreamResult(
+    var result = try finalizeStreamResult(
         std.testing.allocator,
         "<think>private trace</think>Visible answer",
         .{ .completion_tokens = 4, .total_tokens = 4 },
+        null,
     );
-    defer {
-        if (result.content) |content| std.testing.allocator.free(content);
-        if (result.reasoning_content) |reasoning| std.testing.allocator.free(reasoning);
-    }
+    defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqualStrings("Visible answer", result.content.?);
     try std.testing.expectEqualStrings("private trace", result.reasoning_content.?);


### PR DESCRIPTION
# PR: Enable native API-level tool calls during streaming

## Problem

Streaming requests could include API-level tools, but structured tool-call deltas were not preserved in StreamChatResult. The Agent therefore could not execute a pure streamed tool response. Provider-wide capability checks were also unsafe for RouterProvider and ReliableProvider because the selected target can vary by model and request content.

## Changes

- StreamChatResult now owns native tool calls and transfers them into the Agent response path.
- OpenAI-compatible SSE parsing accumulates choices[0].delta.tool_calls fragments by index.
- Anthropic SSE parsing handles content_block_start tool_use events plus input_json_delta fragments.
- Incomplete, malformed, API-error, and non-tool terminal streams never execute partial tool calls.
- Provider, RouterProvider, and ReliableProvider expose model-specific streaming and native-tool capability checks.
- ReliableProvider checks the provider actually selected for streaming, including vision routing and streaming opt-out.
- CLI always attaches the stream sink and lets the Agent make the per-model decision.
- Dedicated OpenAI, OpenRouter, and Anthropic providers honor native_tools: false consistently with compatible providers.
- Anthropic streaming now honors the configured request timeout.
- Ownership and OOM cleanup were hardened across streamed responses, structured tool conversion, compatible normalization, and cached system-prompt replacement.
- Legacy public SSE parser result shapes and the original curlStreamAnthropic entry point remain source-compatible.
- Current main was merged without conflicts.

## Safety

- Tool calls are emitted only after an explicit successful tool-call termination.
- Truncated partial_json and unfinished OpenAI tool fragments are discarded rather than executed.
- Streamed tool calls are capped at 128 per response.
- Provider-controlled usage values are range-checked before conversion.
- No force-push was used.

## Tests

Added 34 targeted regression tests covering:

- OpenAI and Anthropic fragmented native tool calls
- end-to-end Agent tool execution during streaming
- model-specific Router and Reliable routing
- vision-selected providers and streaming opt-out
- native_tools configuration for dedicated and fallback providers
- malformed, truncated, API-error, timeout, and allocation-failure paths
- ownership transfer and leak-free cleanup

Validation:

- zig fmt --check src/
- zig build test --summary all: 7400 passed, 9 skipped, 0 failed
- zig build -Doptimize=ReleaseSmall

## Protocol references

- OpenAI streaming function-call deltas: https://platform.openai.com/docs/api-reference/responses-streaming/response/refusal/delta?lang=curl
- Anthropic streaming tool use: https://platform.claude.com/docs/en/build-with-claude/streaming
- vLLM streamed tool calls: https://docs.vllm.ai/en/stable/examples/tool_calling/openai_chat_completion_client_with_tools_xlam_streaming/
