### PR TITLE
fix(http): secure buffered curl fallback on Android

### DIFF
--- a/src/auth.zig
+++ b/src/auth.zig
@@ -380,7 +380,7 @@ pub fn refreshAccessToken(
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
-    const result = try client.client.fetch(.{
+    const result = try client.fetch(.{
         .location = .{ .url = token_url },
         .method = .POST,
         .payload = payload,
@@ -506,7 +506,7 @@ pub fn startDeviceCodeFlow(
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
-    const result = try client.client.fetch(.{
+    const result = try client.fetch(.{
         .location = .{ .url = device_auth_url },
         .method = .POST,
         .payload = payload,
@@ -599,7 +599,7 @@ pub fn pollDeviceCode(
 
         var aw: std.Io.Writer.Allocating = .init(allocator);
         defer aw.deinit();
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = token_url },
             .method = .POST,
             .payload = payload,

--- a/src/channels/dingtalk.zig
+++ b/src/channels/dingtalk.zig
@@ -721,7 +721,7 @@ pub const DingTalkChannel = struct {
     fn postJson(self: *DingTalkChannel, webhook_url: []const u8, body: []const u8) !void {
         var client = try http_util.ProxyHttpClient.init(self.allocator);
         defer client.deinit();
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = webhook_url },
             .method = .POST,
             .payload = body,

--- a/src/channels/whatsapp.zig
+++ b/src/channels/whatsapp.zig
@@ -295,7 +295,7 @@ pub const WhatsAppChannel = struct {
         var client = try http_util.ProxyHttpClient.init(self.allocator);
         defer client.deinit();
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = .POST,
             .payload = body,

--- a/src/http_util.zig
+++ b/src/http_util.zig
@@ -3,8 +3,15 @@
 //! Keeps legacy curl helpers for non-secret requests, but routes credentialed
 //! headers and sensitive token URLs through std.http so secrets are not exposed
 //! through child process argv.
+//!
+//! Android exception: `std.http.Client` cannot complete credentialed HTTPS
+//! requests on `aarch64-linux-android` (TLS handshake / Host header path
+//! regresses in the stdlib client on that target), so on Android we always go
+//! through the curl subprocess path. Credentials are still passed via
+//! `-H @<tempfile>` (`prepareCurlHeaderArg`) and never appear in argv.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const std_compat = @import("compat");
 const Allocator = std.mem.Allocator;
 const AtomicBool = std.atomic.Value(bool);
@@ -284,6 +291,11 @@ pub fn prepareCurlHeaderArg(allocator: Allocator, headers: []const []const u8) !
 }
 
 fn credentialedCurlUsesHttpFallback(url: []const u8, headers: []const []const u8, resolve_entry: ?[]const u8) bool {
+    // Regression: aarch64-linux-android.24 (Termux) — std.http.Client cannot
+    // complete credentialed HTTPS requests to mm.agility.plus / Discord etc.
+    // Force the curl subprocess path on Android; credentials still flow via
+    // `-H @<tempfile>` (see prepareCurlHeaderArg), so argv stays clean.
+    if (comptime builtin.abi == .android) return false;
     return hasCredentialedCurlArgs(url, headers) and resolve_entry == null;
 }
 
@@ -1677,6 +1689,29 @@ test "credentialed curl args route to std http fallback" {
     try std.testing.expect(hasCredentialedCurlArgs("https://example.com/v1", &.{"Authorization: Bearer test-token"}));
     try std.testing.expect(hasCredentialedCurlArgs("https://example.com/v1?access_token=test-token", &.{}));
     try std.testing.expect(!hasCredentialedCurlArgs("https://example.com/v1", &.{"User-Agent: nullclaw-test"}));
+}
+
+// Regression: aarch64-linux-android (Termux) — std.http.Client cannot complete
+// credentialed HTTPS requests, so the curl subprocess path must be used on
+// Android. Verified at comptime; the curl subprocess itself is exercised by
+// the existing curlGet/curlPost test suite on every host platform.
+test "credentialed curl falls through to curl on android" {
+    const cred_headers = [_][]const u8{"Authorization: Bearer test-token"};
+    if (comptime builtin.abi == .android) {
+        try std.testing.expect(!credentialedCurlUsesHttpFallback(
+            "https://example.com/v1",
+            &cred_headers,
+            null,
+        ));
+    } else {
+        // On non-Android platforms the existing std.http fallback path is
+        // preserved. Behavior is unchanged from before this fix.
+        try std.testing.expect(credentialedCurlUsesHttpFallback(
+            "https://example.com/v1",
+            &cred_headers,
+            null,
+        ));
+    }
 }
 
 const LegacyCredentialedCurlHelper = enum {

--- a/src/http_util.zig
+++ b/src/http_util.zig
@@ -1,14 +1,9 @@
 //! Shared HTTP utilities.
 //!
-//! Keeps legacy curl helpers for non-secret requests, but routes credentialed
-//! headers and sensitive token URLs through std.http so secrets are not exposed
-//! through child process argv.
-//!
-//! Android exception: `std.http.Client` cannot complete credentialed HTTPS
-//! requests on `aarch64-linux-android` (TLS handshake / Host header path
-//! regresses in the stdlib client on that target), so on Android we always go
-//! through the curl subprocess path. Credentials are still passed via
-//! `-H @<tempfile>` (`prepareCurlHeaderArg`) and never appear in argv.
+//! Buffered std.http calls share proxy setup through `ProxyHttpClient`. Legacy
+//! and Android curl paths share one executor; URL, proxy, and caller headers are
+//! stored in mode-0600 temporary files instead of process argv. Android uses
+//! curl because Termux lacks the resolver configuration Zig expects.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -23,6 +18,9 @@ threadlocal var thread_interrupt_flag: ?*const AtomicBool = null;
 const DEFAULT_CURL_GET_MAX_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_CURL_POST_MAX_BYTES: usize = 8 * 1024 * 1024;
 const MAX_CURL_STDERR_BYTES: usize = 16 * 1024;
+const MAX_CURL_RESPONSE_HEADERS_BYTES: usize = 64 * 1024;
+const STD_HTTP_USER_AGENT_HEADER = "User-Agent: zig/" ++ builtin.zig_version_string ++ " (std.http)";
+const STD_HTTP_ACCEPT_ENCODING_HEADER = "Accept-Encoding: gzip, deflate";
 pub const CredentialedCurlArgError = error{CredentialedCurlArgRejected};
 
 fn classifyCurlExitCode(code: u8) []const u8 {
@@ -79,6 +77,7 @@ const StderrCapture = struct {
 
 fn stderrCaptureMain(ctx: *StderrCapture) void {
     const file = ctx.file orelse return;
+    defer file.close();
     while (ctx.len < ctx.buffer.len) {
         const n = file.read(ctx.buffer[ctx.len..]) catch return;
         if (n == 0) return;
@@ -97,7 +96,12 @@ fn stderrCaptureMain(ctx: *StderrCapture) void {
 fn startStderrCapture(child: *std_compat.process.Child, capture: *StderrCapture) ?std.Thread {
     capture.* = .{ .file = child.stderr };
     if (capture.file == null) return null;
-    return std.Thread.spawn(.{}, stderrCaptureMain, .{capture}) catch null;
+    child.stderr = null;
+    return std.Thread.spawn(.{}, stderrCaptureMain, .{capture}) catch {
+        capture.file.?.close();
+        capture.file = null;
+        return null;
+    };
 }
 
 fn finishStderrCapture(thread_opt: *?std.Thread, capture: *const StderrCapture) ?[]const u8 {
@@ -150,6 +154,27 @@ fn cancelWatcherMain(ctx: *CancelWatcherCtx) void {
         }
         std_compat.thread.sleep(20 * std.time.ns_per_ms);
     }
+}
+
+fn stopCancelWatcher(done: *AtomicBool, watcher: *?std.Thread) void {
+    done.store(true, .release);
+    if (watcher.*) |thread| {
+        thread.join();
+        watcher.* = null;
+    }
+}
+
+fn abortCurlChild(
+    child: *std_compat.process.Child,
+    cancel_done: *AtomicBool,
+    cancel_watcher: *?std.Thread,
+    stderr_thread: *?std.Thread,
+    stderr_capture: *const StderrCapture,
+) void {
+    stopCancelWatcher(cancel_done, cancel_watcher);
+    _ = child.kill() catch {};
+    _ = finishStderrCapture(stderr_thread, stderr_capture);
+    _ = child.wait() catch {};
 }
 
 pub const HttpResponse = struct {
@@ -230,7 +255,7 @@ pub const CurlHeaderArg = struct {
 };
 
 fn validateCurlHeaderLine(header: []const u8) !void {
-    if (std.mem.indexOfAny(u8, header, "\r\n") != null) return error.InvalidHeader;
+    if (std.mem.indexOfAny(u8, header, "\r\n\x00") != null) return error.InvalidHeader;
 }
 
 pub fn prepareCurlHeaderArg(allocator: Allocator, headers: []const []const u8) !CurlHeaderArg {
@@ -290,47 +315,458 @@ pub fn prepareCurlHeaderArg(allocator: Allocator, headers: []const []const u8) !
     return prepared;
 }
 
+const CurlTempPath = struct {
+    path_buf: [std_compat.fs.max_path_bytes]u8 = undefined,
+    path_len: usize = 0,
+
+    fn path(self: *const CurlTempPath) []const u8 {
+        return self.path_buf[0..self.path_len];
+    }
+
+    fn deinit(self: *CurlTempPath) void {
+        if (self.path_len == 0) return;
+        std_compat.fs.deleteFileAbsolute(self.path()) catch {};
+        self.path_len = 0;
+    }
+};
+
+fn createSecureCurlTempFile(
+    allocator: Allocator,
+    prepared: *CurlTempPath,
+    prefix: []const u8,
+) !std_compat.fs.File {
+    const tmp_dir_path = platform.getTempDir(allocator) catch return error.TempDirNotFound;
+    defer allocator.free(tmp_dir_path);
+
+    var tmp_dir = std_compat.fs.openDirAbsolute(tmp_dir_path, .{}) catch return error.TempDirNotFound;
+    defer tmp_dir.close();
+
+    var attempt: u8 = 0;
+    while (attempt < 8) : (attempt += 1) {
+        const path = std.fmt.bufPrint(
+            &prepared.path_buf,
+            "{s}{s}{s}_{x}.tmp",
+            .{ tmp_dir_path, std_compat.fs.path.sep_str, prefix, std_compat.crypto.random.int(u64) },
+        ) catch return error.PathTooLong;
+        prepared.path_len = path.len;
+
+        return tmp_dir.createFile(
+            path[tmp_dir_path.len + 1 ..],
+            .{ .truncate = true, .exclusive = true, .permissions = std_compat.fs.permissionsFromMode(0o600) },
+        ) catch |err| switch (err) {
+            error.PathAlreadyExists => continue,
+            else => return error.TempFileCreateFailed,
+        };
+    }
+    prepared.path_len = 0;
+    return error.TempFileCreateFailed;
+}
+
+fn validateHttpUrl(url: []const u8) !std.Uri {
+    if (std.mem.indexOfScalar(u8, url, 0) != null or std.mem.indexOfAny(u8, url, "\r\n") != null) {
+        return error.InvalidUrl;
+    }
+    const uri = std.Uri.parse(url) catch return error.InvalidUrl;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "http") and !std.ascii.eqlIgnoreCase(uri.scheme, "https")) {
+        return error.UnsupportedUriScheme;
+    }
+    if (uri.host == null) return error.InvalidUrl;
+    return uri;
+}
+
+fn writeCurlConfigQuoted(file: std_compat.fs.File, value: []const u8) !void {
+    try file.writeAll("\"");
+    for (value) |c| {
+        switch (c) {
+            '\\', '"' => {
+                const escaped = [_]u8{ '\\', c };
+                try file.writeAll(&escaped);
+            },
+            0...0x1f, 0x7f => return error.InvalidCurlConfigValue,
+            else => {
+                const byte = [_]u8{c};
+                try file.writeAll(&byte);
+            },
+        }
+    }
+    try file.writeAll("\"");
+}
+
+pub const ProtectedCurlConfig = struct {
+    temp: CurlTempPath = .{},
+
+    pub fn path(self: *const ProtectedCurlConfig) []const u8 {
+        return self.temp.path();
+    }
+
+    pub fn deinit(self: *ProtectedCurlConfig) void {
+        self.temp.deinit();
+    }
+};
+
+fn prepareCurlConfig(
+    allocator: Allocator,
+    url: []const u8,
+    proxy: ?[]const u8,
+    force_proxy: bool,
+) !ProtectedCurlConfig {
+    _ = try validateHttpUrl(url);
+
+    var prepared: ProtectedCurlConfig = .{};
+    var file = try createSecureCurlTempFile(allocator, &prepared.temp, "curl_request");
+    errdefer prepared.deinit();
+    defer file.close();
+
+    // Config URLs still participate in curl glob expansion unless disabled.
+    // One request must never fan out because a signed URL contains [] or {}.
+    try file.writeAll("globoff\nurl = ");
+    try writeCurlConfigQuoted(file, url);
+    try file.writeAll("\n");
+    if (proxy) |proxy_url| {
+        try file.writeAll("proxy = ");
+        try writeCurlConfigQuoted(file, proxy_url);
+        try file.writeAll("\n");
+        if (force_proxy) try file.writeAll("noproxy = \"\"\n");
+    }
+    return prepared;
+}
+
+/// Store a validated HTTP(S) URL and optional proxy outside process argv.
+/// The returned mode-0600 config file must outlive curl and be deinitialized.
+pub fn prepareProtectedCurlConfig(
+    allocator: Allocator,
+    url: []const u8,
+    proxy: ?[]const u8,
+) !ProtectedCurlConfig {
+    return prepareCurlConfig(allocator, url, proxy, false);
+}
+
+/// Store a URL with the effective process proxy policy. Environment proxies
+/// continue to honor NO_PROXY; an explicit process-wide config override does
+/// not, matching ProxyHttpClient semantics.
+pub fn prepareProtectedCurlConfigFromEnvironment(
+    allocator: Allocator,
+    url: []const u8,
+) !ProtectedCurlConfig {
+    var selected_proxy = try getProxyForUrl(allocator, url);
+    defer selected_proxy.deinit(allocator);
+    return prepareCurlConfig(allocator, url, selected_proxy.value, selected_proxy.force);
+}
+
+pub const CurlRequestOptions = struct {
+    method: std.http.Method,
+    url: []const u8,
+    body: ?[]const u8 = null,
+    headers: []const []const u8 = &.{},
+    content_type: ?[]const u8 = null,
+    proxy: ?[]const u8 = null,
+    max_time: ?[]const u8 = null,
+    max_response_bytes: usize = std.math.maxInt(usize),
+    max_redirects: ?u16 = null,
+    resolve_entry: ?[]const u8 = null,
+    accept_compression: bool = false,
+    discard_response_body: bool = false,
+    response_writer: ?*std.Io.Writer = null,
+    std_http_defaults: bool = false,
+    generated_redirect_headers_only: bool = false,
+    fail_on_http_error: bool = false,
+};
+
+const CurlRequestSpec = CurlRequestOptions;
+
+const CurlCommand = struct {
+    argv: [40][]const u8 = undefined,
+    argc: usize = 0,
+
+    fn append(self: *CurlCommand, arg: []const u8) !void {
+        if (self.argc >= self.argv.len) return error.CurlArgsOverflow;
+        self.argv[self.argc] = arg;
+        self.argc += 1;
+    }
+
+    fn slice(self: *const CurlCommand) []const []const u8 {
+        return self.argv[0..self.argc];
+    }
+};
+
+fn buildSecureCurlCommand(
+    spec: CurlRequestSpec,
+    config_path: []const u8,
+    header_arg: ?[]const u8,
+    response_headers_path: []const u8,
+    max_redirects: ?[]const u8,
+) !CurlCommand {
+    var command: CurlCommand = .{};
+    try command.append("curl");
+    // Must be curl's first option so a user-controlled .curlrc cannot weaken
+    // protocol or TLS behavior or redirect request data elsewhere.
+    try command.append("-q");
+    try command.append("--silent");
+    try command.append("--show-error");
+    try command.append("--globoff");
+    try command.append("--proto");
+    try command.append("=http,https");
+    try command.append("--proto-redir");
+    try command.append("=http,https");
+    if (spec.fail_on_http_error) try command.append("--fail");
+    if (spec.accept_compression) try command.append("--compressed");
+    try command.append("--request");
+    try command.append(@tagName(spec.method));
+
+    if (spec.method == .HEAD) try command.append("--head");
+    if (header_arg) |arg| {
+        try command.append("--header");
+        try command.append(arg);
+    }
+    try command.append("--dump-header");
+    try command.append(response_headers_path);
+
+    if (max_redirects) |redirects| {
+        try command.append("--location");
+        try command.append("--max-redirs");
+        try command.append(redirects);
+    }
+    if (spec.resolve_entry) |entry| {
+        try command.append("--resolve");
+        try command.append(entry);
+    }
+    if (spec.max_time) |max_time| {
+        try command.append("--max-time");
+        try command.append(max_time);
+    }
+    if (spec.body != null) {
+        try command.append("--data-binary");
+        try command.append("@-");
+    }
+    if (spec.discard_response_body or spec.method == .HEAD) {
+        try command.append("--output");
+        try command.append(if (comptime builtin.os.tag == .windows) "NUL" else "/dev/null");
+    }
+    try command.append("--config");
+    try command.append(config_path);
+    return command;
+}
+
+fn finalResponseHeaders(raw: []const u8) []const u8 {
+    var start: usize = 0;
+    var search_from: usize = 0;
+    while (std.mem.indexOfPos(u8, raw, search_from, "HTTP/")) |candidate| {
+        if (candidate == 0 or raw[candidate - 1] == '\n') start = candidate;
+        search_from = candidate + "HTTP/".len;
+    }
+    const remaining = raw[start..];
+    const crlf_end = std.mem.indexOf(u8, remaining, "\r\n\r\n");
+    const lf_end = std.mem.indexOf(u8, remaining, "\n\n");
+    const end = if (crlf_end) |pos| pos else if (lf_end) |pos| pos else remaining.len;
+    return remaining[0..end];
+}
+
+fn responseStatusCode(headers: []const u8) !u16 {
+    const line_end = std.mem.indexOfScalar(u8, headers, '\n') orelse headers.len;
+    const status_line = std.mem.trim(u8, headers[0..line_end], " \t\r\n");
+    var fields = std.mem.tokenizeScalar(u8, status_line, ' ');
+    const protocol = fields.next() orelse return error.CurlParseError;
+    if (!std.mem.startsWith(u8, protocol, "HTTP/")) return error.CurlParseError;
+    const status_raw = fields.next() orelse return error.CurlParseError;
+    if (status_raw.len != 3) return error.CurlParseError;
+    return std.fmt.parseInt(u16, status_raw, 10) catch error.CurlParseError;
+}
+
+fn safeCurlMaxRedirects(spec: CurlRequestSpec) ?u16 {
+    if (spec.method != .GET or spec.body != null or spec.content_type != null) return null;
+    if (spec.headers.len != 0 and !spec.generated_redirect_headers_only) return null;
+    return spec.max_redirects;
+}
+
+fn streamCurlStdout(file: std_compat.fs.File, writer: ?*std.Io.Writer, max_bytes: usize) !void {
+    var buf: [8192]u8 = undefined;
+    var total: usize = 0;
+    while (true) {
+        const n = file.read(&buf) catch return error.CurlReadError;
+        if (n == 0) return;
+        if (n > max_bytes -| total) return error.CurlReadError;
+        total += n;
+        if (writer) |output| try output.writeAll(buf[0..n]);
+    }
+}
+
+fn secureCurlRequestWithStatusAndHeaders(
+    allocator: Allocator,
+    spec: CurlRequestSpec,
+) !HttpResponseWithHeaders {
+    _ = try validateHttpUrl(spec.url);
+
+    var all_headers: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer all_headers.deinit(allocator);
+    var content_type_header: ?[]u8 = null;
+    defer if (content_type_header) |header| allocator.free(header);
+    var has_content_type = false;
+
+    if (spec.std_http_defaults) {
+        try all_headers.append(allocator, STD_HTTP_USER_AGENT_HEADER);
+        try all_headers.append(allocator, STD_HTTP_ACCEPT_ENCODING_HEADER);
+    }
+
+    if (spec.content_type) |content_type| {
+        if (content_type.len == 0 or std.mem.indexOfAny(u8, content_type, "\r\n\x00") != null) {
+            return error.InvalidHeader;
+        }
+        content_type_header = try std.fmt.allocPrint(allocator, "Content-Type: {s}", .{content_type});
+        try all_headers.append(allocator, content_type_header.?);
+        has_content_type = true;
+    }
+    for (spec.headers) |header| {
+        try validateCurlHeaderLine(header);
+        const parsed = parseHeader(header) orelse return error.InvalidHeader;
+        has_content_type = has_content_type or std.ascii.eqlIgnoreCase(parsed.name, "content-type");
+        try all_headers.append(allocator, header);
+    }
+    // curl otherwise invents application/x-www-form-urlencoded for --data-binary,
+    // while std.http sends no Content-Type when the caller leaves it at default.
+    if (spec.body != null and !has_content_type) try all_headers.append(allocator, "Content-Type:");
+
+    var selected_proxy = if (spec.proxy == null) try getProxyForUrl(allocator, spec.url) else ProxySelection{};
+    defer selected_proxy.deinit(allocator);
+    const effective_proxy = spec.proxy orelse selected_proxy.value;
+
+    var config = try prepareCurlConfig(allocator, spec.url, effective_proxy, spec.proxy != null or selected_proxy.force);
+    defer config.deinit();
+
+    var prepared_headers = try prepareCurlHeaderArg(allocator, all_headers.items);
+    defer prepared_headers.deinit(allocator);
+
+    var response_headers_temp: CurlTempPath = .{};
+    var response_headers_file = try createSecureCurlTempFile(allocator, &response_headers_temp, "curl_response_headers");
+    response_headers_file.close();
+    defer response_headers_temp.deinit();
+
+    var redirects_buf: [5]u8 = undefined;
+    const redirects_arg = if (safeCurlMaxRedirects(spec)) |max_redirects|
+        try std.fmt.bufPrint(&redirects_buf, "{d}", .{max_redirects})
+    else
+        null;
+    const command = try buildSecureCurlCommand(
+        spec,
+        config.path(),
+        prepared_headers.arg,
+        response_headers_temp.path(),
+        redirects_arg,
+    );
+
+    var child = std_compat.process.Child.init(command.slice(), allocator);
+    if (spec.body != null) child.stdin_behavior = .Pipe;
+    // Keep a pipe even when curl writes the body to /dev/null. Draining it to
+    // EOF lets us stop the cancellation watcher before child.wait() touches id.
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+
+    try child.spawn();
+    const cancel_flag = thread_interrupt_flag;
+    var cancel_done = AtomicBool.init(false);
+    var cancel_watcher: ?std.Thread = null;
+    var watcher_ctx: CancelWatcherCtx = undefined;
+    if (cancel_flag) |flag| {
+        watcher_ctx = .{ .child = &child, .cancel_flag = flag, .done = &cancel_done };
+        cancel_watcher = std.Thread.spawn(.{}, cancelWatcherMain, .{&watcher_ctx}) catch null;
+    }
+    defer stopCancelWatcher(&cancel_done, &cancel_watcher);
+
+    var stderr_capture = StderrCapture{};
+    var stderr_thread = startStderrCapture(&child, &stderr_capture);
+    defer if (stderr_thread) |thread| thread.join();
+
+    if (spec.body) |body| {
+        if (child.stdin) |stdin_file| {
+            stdin_file.writeAll(body) catch {
+                stdin_file.close();
+                child.stdin = null;
+                abortCurlChild(&child, &cancel_done, &cancel_watcher, &stderr_thread, &stderr_capture);
+                return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
+            };
+            stdin_file.close();
+            child.stdin = null;
+        } else {
+            abortCurlChild(&child, &cancel_done, &cancel_watcher, &stderr_thread, &stderr_capture);
+            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
+        }
+    }
+
+    var buffered_body: ?[]u8 = null;
+    errdefer if (buffered_body) |body| allocator.free(body);
+    if (spec.discard_response_body or spec.method == .HEAD) {
+        streamCurlStdout(child.stdout.?, null, 0) catch |err| {
+            abortCurlChild(&child, &cancel_done, &cancel_watcher, &stderr_thread, &stderr_capture);
+            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else err;
+        };
+    } else {
+        if (spec.response_writer) |writer| {
+            streamCurlStdout(child.stdout.?, writer, spec.max_response_bytes) catch |err| {
+                abortCurlChild(&child, &cancel_done, &cancel_watcher, &stderr_thread, &stderr_capture);
+                return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else err;
+            };
+        } else {
+            buffered_body = child.stdout.?.readToEndAlloc(allocator, spec.max_response_bytes) catch |err| {
+                abortCurlChild(&child, &cancel_done, &cancel_watcher, &stderr_thread, &stderr_capture);
+                if (err == error.OutOfMemory) return error.OutOfMemory;
+                return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlReadError;
+            };
+        }
+    }
+
+    // Both output pipes reached EOF, so curl has closed them and is exiting.
+    // Join their readers and the watcher before wait() can clear/reuse child.id.
+    const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
+    stopCancelWatcher(&cancel_done, &cancel_watcher);
+    const term = child.wait() catch |err| {
+        _ = child.kill() catch {};
+        // curl diagnostics may echo credentialed proxy/URL values. Keep the
+        // captured bytes only for synchronization; never write them to logs.
+        _ = stderr_msg;
+        logCurlWaitFailure(@tagName(spec.method), err, null);
+        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWaitError;
+    };
+    switch (term) {
+        .exited => |code| if (code != 0) {
+            logCurlExitFailure(@tagName(spec.method), code, null);
+            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else mapCurlExitCodeToError(code);
+        },
+        else => return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed,
+    }
+
+    const headers_file = try std_compat.fs.openFileAbsolute(response_headers_temp.path(), .{});
+    defer headers_file.close();
+    const raw_headers = try headers_file.readToEndAlloc(allocator, MAX_CURL_RESPONSE_HEADERS_BYTES);
+    defer allocator.free(raw_headers);
+    const final_headers = finalResponseHeaders(raw_headers);
+    const status_code = try responseStatusCode(final_headers);
+    const response_headers = try allocator.dupe(u8, final_headers);
+    errdefer allocator.free(response_headers);
+    const response_body = buffered_body orelse try allocator.dupe(u8, "");
+    buffered_body = null;
+
+    return .{
+        .status_code = status_code,
+        .headers = response_headers,
+        .body = response_body,
+    };
+}
+
+/// Execute a buffered curl request with URL, proxy, and headers kept out of
+/// process argv. Automatic redirects are restricted to header-free GETs.
+pub fn curlRequestWithStatusAndHeaders(
+    allocator: Allocator,
+    options: CurlRequestOptions,
+) !HttpResponseWithHeaders {
+    return secureCurlRequestWithStatusAndHeaders(allocator, options);
+}
+
 fn credentialedCurlUsesHttpFallback(url: []const u8, headers: []const []const u8, resolve_entry: ?[]const u8) bool {
     // Regression: aarch64-linux-android.24 (Termux) — std.http.Client cannot
-    // complete credentialed HTTPS requests to mm.agility.plus / Discord etc.
+    // complete credentialed HTTPS requests to remote service endpoints.
     // Force the curl subprocess path on Android; credentials still flow via
     // `-H @<tempfile>` (see prepareCurlHeaderArg), so argv stays clean.
     if (comptime builtin.abi == .android) return false;
     return hasCredentialedCurlArgs(url, headers) and resolve_entry == null;
-}
-
-fn prepareCurlHeadersForArgv(allocator: Allocator, url: []const u8, headers: []const []const u8) !CurlHeaderArg {
-    if (hasCredentialedCurlArgs(url, headers)) {
-        if (hasSensitiveUrlToken(url)) return error.CredentialedCurlArgRejected;
-        return try prepareCurlHeaderArg(allocator, headers);
-    }
-
-    try validateNoCredentialedCurlArgs(url, headers);
-    return .{};
-}
-
-fn appendPreparedCurlHeaders(
-    argv_buf: []([]const u8),
-    argc: *usize,
-    headers: []const []const u8,
-    prepared_arg: ?[]const u8,
-) !void {
-    if (prepared_arg) |headers_arg| {
-        if (argc.* + 2 > argv_buf.len) return error.CurlArgsOverflow;
-        argv_buf[argc.*] = "-H";
-        argc.* += 1;
-        argv_buf[argc.*] = headers_arg;
-        argc.* += 1;
-        return;
-    }
-
-    for (headers) |hdr| {
-        if (argc.* + 2 > argv_buf.len) break;
-        argv_buf[argc.*] = "-H";
-        argc.* += 1;
-        argv_buf[argc.*] = hdr;
-        argc.* += 1;
-    }
 }
 
 fn parseHeader(header: []const u8) ?std.http.Header {
@@ -374,31 +810,47 @@ pub fn httpRequestWithStatusAndHeaders(
     content_type: ?[]const u8,
     proxy: ?[]const u8,
 ) !HttpResponseWithHeaders {
-    // Regression: aarch64-linux-android (Termux) — std.http.Client fails with
-    // error.NameServerFailure and other TLS/lookup errors on this target, so
-    // every caller of httpRequest / httpPostJsonWithProxy / httpGetWithProxy
-    // (Discord, Telegram, Lark, MAX, LINE, Composio, providers, gateway, etc.)
-    // is affected. Route through the curl subprocess instead. Credentials flow
-    // via -H @<tempfile> (see prepareCurlHeaderArg) so argv stays clean.
-    if (comptime builtin.abi == .android) {
-        return httpRequestCurlOnAndroid(allocator, method, url, body, headers, content_type, proxy);
-    }
     var header_buf: [20]std.http.Header = undefined;
     var header_count: usize = 0;
     if (content_type) |ct| {
+        if (ct.len == 0 or std.mem.indexOfAny(u8, ct, "\r\n\x00") != null) return error.InvalidHeader;
         header_buf[header_count] = .{ .name = "Content-Type", .value = ct };
         header_count += 1;
     }
     for (headers) |header| {
         if (header_count >= header_buf.len) return error.TooManyHeaders;
+        try validateCurlHeaderLine(header);
         header_buf[header_count] = parseHeader(header) orelse return error.InvalidHeader;
         header_count += 1;
+    }
+
+    const uri = try std.Uri.parse(url);
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "http") and !std.ascii.eqlIgnoreCase(uri.scheme, "https")) {
+        return error.UnsupportedUriScheme;
+    }
+
+    // Regression: Termux has no resolver configuration where Zig expects it,
+    // so std.http reports NameServerFailure. Keep the public wrapper semantics
+    // while using a secure curl subprocess on Android.
+    if (comptime builtin.abi == .android) {
+        return secureCurlRequestWithStatusAndHeaders(allocator, .{
+            .method = method,
+            .url = url,
+            .body = body,
+            .headers = headers,
+            .content_type = content_type,
+            .proxy = proxy,
+            // curl forwards arbitrary custom headers across origins. Only
+            // follow automatically when there are no caller headers to leak.
+            .max_redirects = if (method == .GET and body == null and headers.len == 0 and content_type == null) 3 else null,
+            .accept_compression = true,
+            .std_http_defaults = true,
+        });
     }
 
     var client = try initProxyClientWithOptionalProxy(allocator, proxy);
     defer client.deinit();
 
-    const uri = try std.Uri.parse(url);
     const redirect_behavior: std.http.Client.Request.RedirectBehavior =
         if (body == null) @enumFromInt(3) else .unhandled;
     var req = try client.client.request(method, uri, .{
@@ -501,53 +953,6 @@ pub fn httpGetWithProxy(
     return httpRequest(allocator, .GET, url, null, headers, null, proxy);
 }
 
-/// Android-only dispatcher used by `httpRequestWithStatusAndHeaders` on
-/// `aarch64-linux-android` (Termux), where `std.http.Client` cannot complete
-/// HTTPS requests (NameServerFailure, TLS/Host header regressions). Routes
-/// to the existing curl subprocess path which is verified to work on Termux
-/// (Termux curl with `/data/data/com.termux/files/usr/etc/tls/cert.pem`).
-///
-/// Credentials flow through `prepareCurlHeaderArg` → `-H @<tempfile>`, so
-/// they never appear in argv.
-///
-/// `proxy` is currently unsupported on this branch — the curl path here
-/// uses the system resolver and direct connection. NullClaw channel and
-/// provider call sites in the Termux deployment all pass `proxy = null`.
-fn httpRequestCurlOnAndroid(
-    allocator: Allocator,
-    method: std.http.Method,
-    url: []const u8,
-    body: ?[]const u8,
-    headers: []const []const u8,
-    content_type: ?[]const u8,
-    proxy: ?[]const u8,
-) !HttpResponseWithHeaders {
-    if (proxy) |_| {
-        // Fail loud rather than silently ignore a proxy on Android — the
-        // operator should know if their deployment relied on one.
-        return error.ProxyNotSupportedOnAndroid;
-    }
-    _ = content_type; // curl infers Content-Type from body; helper omits it.
-
-    const timeout: ?[]const u8 = "30";
-    const curl_resp = switch (method) {
-        .GET => try curlGetWithStatusAndTimeout(allocator, url, headers, timeout),
-        .DELETE => try curlGetWithStatusAndTimeout(allocator, url, headers, timeout),
-        .HEAD => try curlGetWithStatusAndTimeout(allocator, url, headers, timeout),
-        .POST, .PUT, .PATCH => blk: {
-            const payload = body orelse "";
-            break :blk try curlPostWithStatusAndTimeout(allocator, url, payload, headers, timeout);
-        },
-        else => return error.HttpMethodNotSupportedOnAndroid,
-    };
-
-    return .{
-        .status_code = curl_resp.status_code,
-        .headers = "",
-        .body = curl_resp.body,
-    };
-}
-
 const proxy_env_var_names = [_][]const u8{
     "http_proxy",
     "HTTP_PROXY",
@@ -568,6 +973,58 @@ const https_proxy_env_var_names = [_][]const u8{
     "all_proxy",
     "ALL_PROXY",
 };
+
+fn appendOwnedFetchHeader(
+    allocator: Allocator,
+    headers: *std.ArrayListUnmanaged([]const u8),
+    name: []const u8,
+    value: []const u8,
+) !void {
+    if (name.len == 0 or std.mem.indexOfAny(u8, name, ":\r\n\x00") != null or
+        std.mem.indexOfAny(u8, value, "\r\n\x00") != null)
+    {
+        return error.InvalidHeader;
+    }
+    const line = try std.fmt.allocPrint(allocator, "{s}: {s}", .{ name, value });
+    errdefer allocator.free(line);
+    try headers.append(allocator, line);
+}
+
+fn appendFetchHeaderValue(
+    allocator: Allocator,
+    headers: *std.ArrayListUnmanaged([]const u8),
+    name: []const u8,
+    value: std.http.Client.Request.Headers.Value,
+    default_value: ?[]const u8,
+) !void {
+    switch (value) {
+        .default => if (default_value) |default| try appendOwnedFetchHeader(allocator, headers, name, default),
+        .override => |override| try appendOwnedFetchHeader(allocator, headers, name, override),
+        .omit => try appendOwnedFetchHeader(allocator, headers, name, ""),
+    }
+}
+
+fn fetchHasCallerHeaders(options: std.http.Client.FetchOptions) bool {
+    return options.extra_headers.len > 0 or
+        options.privileged_headers.len > 0 or
+        options.headers.host != .default or
+        options.headers.authorization != .default or
+        options.headers.user_agent != .default or
+        options.headers.connection != .default or
+        options.headers.accept_encoding != .default or
+        options.headers.content_type != .default;
+}
+
+fn fetchCurlMaxRedirects(options: std.http.Client.FetchOptions) ?u16 {
+    const method = options.method orelse if (options.payload != null) std.http.Method.POST else .GET;
+    if (method != .GET) return null;
+    const redirect_behavior = options.redirect_behavior orelse
+        if (options.payload == null) @as(std.http.Client.Request.RedirectBehavior, @enumFromInt(3)) else .unhandled;
+    if (redirect_behavior == .unhandled) return null;
+    if (redirect_behavior == .not_allowed) return 0;
+    if (fetchHasCallerHeaders(options)) return null;
+    return @intFromEnum(redirect_behavior);
+}
 
 pub const ProxyHttpClient = struct {
     proxy_arena: std.heap.ArenaAllocator,
@@ -592,6 +1049,78 @@ pub const ProxyHttpClient = struct {
         self.client.deinit();
         self.proxy_arena.deinit();
         self.* = undefined;
+    }
+
+    /// Use std.http everywhere except Android, where Termux lacks the resolver
+    /// configuration Zig expects. The curl adapter preserves request/response
+    /// semantics but returns non-GET and caller-header redirects unhandled:
+    /// curl cannot both reproduce std.http method rewriting and safely scope
+    /// opaque headers to the original origin.
+    pub fn fetch(self: *ProxyHttpClient, options: std.http.Client.FetchOptions) !std.http.Client.FetchResult {
+        if (comptime builtin.abi == .android) return self.fetchWithCurl(options);
+        return self.client.fetch(options);
+    }
+
+    fn fetchWithCurl(self: *ProxyHttpClient, options: std.http.Client.FetchOptions) !std.http.Client.FetchResult {
+        const allocator = self.client.allocator;
+        var uri_writer: std.Io.Writer.Allocating = .init(allocator);
+        defer uri_writer.deinit();
+        const url: []const u8 = switch (options.location) {
+            .url => |value| value,
+            .uri => |uri| blk: {
+                try uri.format(&uri_writer.writer);
+                break :blk uri_writer.writer.buffer[0..uri_writer.writer.end];
+            },
+        };
+
+        const method = options.method orelse if (options.payload != null) std.http.Method.POST else .GET;
+        // Unlike std.http, curl cannot strip arbitrary custom headers only on
+        // a cross-origin hop or reproduce every non-GET 303 rewrite. Return
+        // those redirects for caller handling.
+        const max_redirects = fetchCurlMaxRedirects(options);
+
+        var request_headers: std.ArrayListUnmanaged([]const u8) = .empty;
+        defer {
+            for (request_headers.items) |header| allocator.free(header);
+            request_headers.deinit(allocator);
+        }
+
+        try appendFetchHeaderValue(allocator, &request_headers, "Host", options.headers.host, null);
+        try appendFetchHeaderValue(allocator, &request_headers, "Authorization", options.headers.authorization, null);
+        const default_user_agent = try std.fmt.allocPrint(allocator, "zig/{s} (std.http)", .{builtin.zig_version_string});
+        defer allocator.free(default_user_agent);
+        try appendFetchHeaderValue(allocator, &request_headers, "User-Agent", options.headers.user_agent, default_user_agent);
+        try appendFetchHeaderValue(
+            allocator,
+            &request_headers,
+            "Connection",
+            options.headers.connection,
+            if (options.keep_alive) "keep-alive" else "close",
+        );
+        try appendFetchHeaderValue(allocator, &request_headers, "Accept-Encoding", options.headers.accept_encoding, "gzip, deflate");
+        try appendFetchHeaderValue(allocator, &request_headers, "Content-Type", options.headers.content_type, null);
+        for (options.extra_headers) |header| {
+            try appendOwnedFetchHeader(allocator, &request_headers, header.name, header.value);
+        }
+        for (options.privileged_headers) |header| {
+            try appendOwnedFetchHeader(allocator, &request_headers, header.name, header.value);
+        }
+
+        const response = try secureCurlRequestWithStatusAndHeaders(allocator, .{
+            .method = method,
+            .url = url,
+            .body = options.payload,
+            .headers = request_headers.items,
+            .max_redirects = max_redirects,
+            .accept_compression = options.headers.accept_encoding != .omit,
+            .discard_response_body = options.response_writer == null,
+            .response_writer = options.response_writer,
+            .generated_redirect_headers_only = !fetchHasCallerHeaders(options),
+        });
+        defer allocator.free(response.headers);
+        defer allocator.free(response.body);
+
+        return .{ .status = @enumFromInt(@as(u10, @intCast(response.status_code))) };
     }
 };
 
@@ -633,8 +1162,10 @@ fn buildCurlResolveEntry(
 }
 
 /// Build an optional curl `--resolve` entry for remote provider requests.
-/// Remote hosts are pinned to a concrete globally-routable address; explicit
-/// local/private hosts are left untouched so intentional local providers still work.
+/// Direct connections are pinned to a concrete globally-routable address;
+/// explicit local/private hosts are left untouched so intentional local
+/// providers still work. A configured proxy is a separate trust boundary:
+/// curl may delegate the proxy's upstream DNS lookup despite `--resolve`.
 ///
 /// DNS resolution failures are fail-closed. Falling back to curl's resolver would
 /// bypass the single resolved-address check and weaken SSRF protection against
@@ -760,123 +1291,25 @@ fn curlRequestWithProxy(
     max_time: ?[]const u8,
     resolve_entry: ?[]const u8,
 ) ![]u8 {
+    const method_enum = std.meta.stringToEnum(std.http.Method, method) orelse return error.UnsupportedHttpMethod;
+    const content_type = contentTypeHeaderValue(content_type_header) orelse return error.InvalidHeader;
     if (credentialedCurlUsesHttpFallback(url, headers, resolve_entry)) {
-        const method_enum = std.meta.stringToEnum(std.http.Method, method) orelse return error.UnsupportedHttpMethod;
-        const content_type = contentTypeHeaderValue(content_type_header) orelse return error.InvalidHeader;
-        const resp = try httpRequestWithStatus(allocator, method_enum, url, body, headers, content_type, proxy);
-        return resp.body;
+        const response = try httpRequestWithStatus(allocator, method_enum, url, body, headers, content_type, proxy);
+        return response.body;
     }
-    var prepared_headers = try prepareCurlHeadersForArgv(allocator, url, headers);
-    defer prepared_headers.deinit(allocator);
-
-    var argv_buf: [40][]const u8 = undefined;
-    var argc: usize = 0;
-
-    argv_buf[argc] = "curl";
-    argc += 1;
-    argv_buf[argc] = "-s";
-    argc += 1;
-    argv_buf[argc] = "-X";
-    argc += 1;
-    argv_buf[argc] = method;
-    argc += 1;
-    argv_buf[argc] = "-H";
-    argc += 1;
-    argv_buf[argc] = content_type_header;
-    argc += 1;
-
-    if (proxy) |p| {
-        argv_buf[argc] = "--proxy";
-        argc += 1;
-        argv_buf[argc] = p;
-        argc += 1;
-    }
-
-    appendCurlResolveArgs(argv_buf[0..], &argc, resolve_entry);
-
-    if (max_time) |mt| {
-        argv_buf[argc] = "--max-time";
-        argc += 1;
-        argv_buf[argc] = mt;
-        argc += 1;
-    }
-
-    try appendPreparedCurlHeaders(argv_buf[0..], &argc, headers, prepared_headers.arg);
-
-    // Pass payload via stdin to avoid OS argv length limits for large JSON
-    // bodies (e.g. multimodal base64 images).
-    argv_buf[argc] = "--data-binary";
-    argc += 1;
-    argv_buf[argc] = "@-";
-    argc += 1;
-    argv_buf[argc] = url;
-    argc += 1;
-
-    var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);
-    child.stdin_behavior = .Pipe;
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    try child.spawn();
-    const cancel_flag = thread_interrupt_flag;
-    var cancel_done = AtomicBool.init(false);
-    var cancel_watcher: ?std.Thread = null;
-    var watcher_ctx: CancelWatcherCtx = undefined;
-    if (cancel_flag) |flag| {
-        watcher_ctx = .{ .child = &child, .cancel_flag = flag, .done = &cancel_done };
-        cancel_watcher = std.Thread.spawn(.{}, cancelWatcherMain, .{&watcher_ctx}) catch null;
-    }
-    defer {
-        cancel_done.store(true, .release);
-        if (cancel_watcher) |t| t.join();
-    }
-    var stderr_capture = StderrCapture{};
-    var stderr_thread = startStderrCapture(&child, &stderr_capture);
-    defer if (stderr_thread) |thread| thread.join();
-
-    if (child.stdin) |stdin_file| {
-        stdin_file.writeAll(body) catch {
-            stdin_file.close();
-            child.stdin = null;
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
-        };
-        stdin_file.close();
-        child.stdin = null;
-    } else {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
-    }
-
-    const stdout = child.stdout.?.readToEndAlloc(allocator, DEFAULT_CURL_POST_MAX_BYTES) catch {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlReadError;
-    };
-
-    const term = child.wait() catch |err| {
-        _ = child.kill() catch {};
-        const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-        logCurlWaitFailure(method, err, stderr_msg);
-        allocator.free(stdout);
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWaitError;
-    };
-    const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            logCurlExitFailure(method, code, stderr_msg);
-            allocator.free(stdout);
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else mapCurlExitCodeToError(code);
-        },
-        else => {
-            allocator.free(stdout);
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed;
-        },
-    }
-
-    return stdout;
+    const response = try secureCurlRequestWithStatusAndHeaders(allocator, .{
+        .method = method_enum,
+        .url = url,
+        .body = body,
+        .headers = headers,
+        .content_type = content_type,
+        .proxy = proxy,
+        .max_time = max_time,
+        .max_response_bytes = DEFAULT_CURL_POST_MAX_BYTES,
+        .resolve_entry = resolve_entry,
+    });
+    allocator.free(response.headers);
+    return response.body;
 }
 
 /// HTTP POST via curl subprocess (no proxy, no timeout).
@@ -935,120 +1368,18 @@ pub fn curlPostWithStatusAndTimeoutAndResolve(
     if (credentialedCurlUsesHttpFallback(url, headers, resolve_entry)) {
         return httpRequestWithStatus(allocator, .POST, url, body, headers, "application/json", null);
     }
-    var prepared_headers = try prepareCurlHeadersForArgv(allocator, url, headers);
-    defer prepared_headers.deinit(allocator);
-
-    var argv_buf: [48][]const u8 = undefined;
-    var argc: usize = 0;
-
-    argv_buf[argc] = "curl";
-    argc += 1;
-    argv_buf[argc] = "-s";
-    argc += 1;
-
-    if (max_time) |mt| {
-        argv_buf[argc] = "--max-time";
-        argc += 1;
-        argv_buf[argc] = mt;
-        argc += 1;
-    }
-
-    appendCurlResolveArgs(argv_buf[0..], &argc, resolve_entry);
-
-    argv_buf[argc] = "-X";
-    argc += 1;
-    argv_buf[argc] = "POST";
-    argc += 1;
-    argv_buf[argc] = "-H";
-    argc += 1;
-    argv_buf[argc] = "Content-Type: application/json";
-    argc += 1;
-
-    try appendPreparedCurlHeaders(argv_buf[0..], &argc, headers, prepared_headers.arg);
-
-    argv_buf[argc] = "--data-binary";
-    argc += 1;
-    argv_buf[argc] = "@-";
-    argc += 1;
-    argv_buf[argc] = "-w";
-    argc += 1;
-    argv_buf[argc] = "\n%{http_code}";
-    argc += 1;
-    argv_buf[argc] = url;
-    argc += 1;
-
-    var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);
-    child.stdin_behavior = .Pipe;
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    try child.spawn();
-    const cancel_flag = thread_interrupt_flag;
-    var cancel_done = AtomicBool.init(false);
-    var cancel_watcher: ?std.Thread = null;
-    var watcher_ctx: CancelWatcherCtx = undefined;
-    if (cancel_flag) |flag| {
-        watcher_ctx = .{ .child = &child, .cancel_flag = flag, .done = &cancel_done };
-        cancel_watcher = std.Thread.spawn(.{}, cancelWatcherMain, .{&watcher_ctx}) catch null;
-    }
-    defer {
-        cancel_done.store(true, .release);
-        if (cancel_watcher) |t| t.join();
-    }
-    var stderr_capture = StderrCapture{};
-    var stderr_thread = startStderrCapture(&child, &stderr_capture);
-    defer if (stderr_thread) |thread| thread.join();
-
-    if (child.stdin) |stdin_file| {
-        stdin_file.writeAll(body) catch {
-            stdin_file.close();
-            child.stdin = null;
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
-        };
-        stdin_file.close();
-        child.stdin = null;
-    } else {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
-    }
-
-    const stdout = child.stdout.?.readToEndAlloc(allocator, DEFAULT_CURL_POST_MAX_BYTES) catch {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlReadError;
-    };
-    errdefer allocator.free(stdout);
-
-    const term = child.wait() catch |err| {
-        _ = child.kill() catch {};
-        const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-        logCurlWaitFailure("POST", err, stderr_msg);
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWaitError;
-    };
-    const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            logCurlExitFailure("POST", code, stderr_msg);
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else mapCurlExitCodeToError(code);
-        },
-        else => return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed,
-    }
-
-    const status_sep = std.mem.lastIndexOfScalar(u8, stdout, '\n') orelse return error.CurlParseError;
-    const status_raw = std.mem.trim(u8, stdout[status_sep + 1 ..], " \t\r\n");
-    if (status_raw.len != 3) return error.CurlParseError;
-    const status_code = std.fmt.parseInt(u16, status_raw, 10) catch return error.CurlParseError;
-    const body_slice = stdout[0..status_sep];
-    const response_body = try allocator.dupe(u8, body_slice);
-    allocator.free(stdout);
-
-    return .{
-        .status_code = status_code,
-        .body = response_body,
-    };
+    const response = try secureCurlRequestWithStatusAndHeaders(allocator, .{
+        .method = .POST,
+        .url = url,
+        .body = body,
+        .headers = headers,
+        .content_type = "application/json",
+        .max_time = max_time,
+        .max_response_bytes = DEFAULT_CURL_POST_MAX_BYTES,
+        .resolve_entry = resolve_entry,
+    });
+    allocator.free(response.headers);
+    return .{ .status_code = response.status_code, .body = response.body };
 }
 
 /// HTTP POST via curl subprocess and include HTTP status code and response headers,
@@ -1075,145 +1406,16 @@ pub fn curlPostWithStatusHeadersAndTimeoutAndResolve(
     if (credentialedCurlUsesHttpFallback(url, headers, resolve_entry)) {
         return httpRequestWithStatusAndHeaders(allocator, .POST, url, body, headers, "application/json", null);
     }
-    var prepared_headers = try prepareCurlHeadersForArgv(allocator, url, headers);
-    defer prepared_headers.deinit(allocator);
-
-    var argv_buf: [56][]const u8 = undefined;
-    var argc: usize = 0;
-
-    argv_buf[argc] = "curl";
-    argc += 1;
-    argv_buf[argc] = "-s";
-    argc += 1;
-
-    if (max_time) |mt| {
-        argv_buf[argc] = "--max-time";
-        argc += 1;
-        argv_buf[argc] = mt;
-        argc += 1;
-    }
-
-    appendCurlResolveArgs(argv_buf[0..], &argc, resolve_entry);
-
-    argv_buf[argc] = "-X";
-    argc += 1;
-    argv_buf[argc] = "POST";
-    argc += 1;
-    argv_buf[argc] = "-H";
-    argc += 1;
-    argv_buf[argc] = "Content-Type: application/json";
-    argc += 1;
-
-    try appendPreparedCurlHeaders(argv_buf[0..], &argc, headers, prepared_headers.arg);
-
-    // Dump response headers to stdout so we can capture session IDs.
-    argv_buf[argc] = "-D";
-    argc += 1;
-    argv_buf[argc] = "-";
-    argc += 1;
-
-    argv_buf[argc] = "--data-binary";
-    argc += 1;
-    argv_buf[argc] = "@-";
-    argc += 1;
-    argv_buf[argc] = "-w";
-    argc += 1;
-    argv_buf[argc] = "\n%{http_code}";
-    argc += 1;
-    argv_buf[argc] = url;
-    argc += 1;
-
-    var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);
-    child.stdin_behavior = .Pipe;
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    try child.spawn();
-    const cancel_flag = thread_interrupt_flag;
-    var cancel_done = AtomicBool.init(false);
-    var cancel_watcher: ?std.Thread = null;
-    var watcher_ctx: CancelWatcherCtx = undefined;
-    if (cancel_flag) |flag| {
-        watcher_ctx = .{ .child = &child, .cancel_flag = flag, .done = &cancel_done };
-        cancel_watcher = std.Thread.spawn(.{}, cancelWatcherMain, .{&watcher_ctx}) catch null;
-    }
-    defer {
-        cancel_done.store(true, .release);
-        if (cancel_watcher) |t| t.join();
-    }
-    var stderr_capture = StderrCapture{};
-    var stderr_thread = startStderrCapture(&child, &stderr_capture);
-    defer if (stderr_thread) |thread| thread.join();
-
-    if (child.stdin) |stdin_file| {
-        stdin_file.writeAll(body) catch {
-            stdin_file.close();
-            child.stdin = null;
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
-        };
-        stdin_file.close();
-        child.stdin = null;
-    } else {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
-    }
-
-    const stdout = child.stdout.?.readToEndAlloc(allocator, 1024 * 1024) catch {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlReadError;
-    };
-    errdefer allocator.free(stdout);
-
-    const term = child.wait() catch |err| {
-        _ = child.kill() catch {};
-        const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-        logCurlWaitFailure("POST", err, stderr_msg);
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWaitError;
-    };
-    const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            logCurlExitFailure("POST", code, stderr_msg);
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else mapCurlExitCodeToError(code);
-        },
-        else => return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed,
-    }
-
-    const status_sep = std.mem.lastIndexOfScalar(u8, stdout, '\n') orelse return error.CurlParseError;
-    const status_raw = std.mem.trim(u8, stdout[status_sep + 1 ..], " \t\r\n");
-    if (status_raw.len != 3) return error.CurlParseError;
-    const status_code = std.fmt.parseInt(u16, status_raw, 10) catch return error.CurlParseError;
-
-    const payload = stdout[0..status_sep];
-    const header_end_crlf = std.mem.indexOf(u8, payload, "\r\n\r\n");
-    const header_end_lf = std.mem.indexOf(u8, payload, "\n\n");
-
-    var headers_slice: []const u8 = "";
-    var body_slice: []const u8 = payload;
-
-    if (header_end_crlf) |pos| {
-        headers_slice = payload[0..pos];
-        body_slice = payload[pos + 4 ..];
-    } else if (header_end_lf) |pos| {
-        headers_slice = payload[0..pos];
-        body_slice = payload[pos + 2 ..];
-    }
-
-    const headers_out = try allocator.dupe(u8, headers_slice);
-    errdefer allocator.free(headers_out);
-    const body_out = try allocator.dupe(u8, body_slice);
-
-    allocator.free(stdout);
-
-    return .{
-        .status_code = status_code,
-        .headers = headers_out,
-        .body = body_out,
-    };
+    return secureCurlRequestWithStatusAndHeaders(allocator, .{
+        .method = .POST,
+        .url = url,
+        .body = body,
+        .headers = headers,
+        .content_type = "application/json",
+        .max_time = max_time,
+        .max_response_bytes = DEFAULT_CURL_POST_MAX_BYTES,
+        .resolve_entry = resolve_entry,
+    });
 }
 
 pub fn curlGetWithStatusAndTimeout(
@@ -1235,90 +1437,16 @@ pub fn curlGetWithStatusAndTimeoutAndResolve(
     if (credentialedCurlUsesHttpFallback(url, headers, resolve_entry)) {
         return httpRequestWithStatus(allocator, .GET, url, null, headers, null, null);
     }
-    var prepared_headers = try prepareCurlHeadersForArgv(allocator, url, headers);
-    defer prepared_headers.deinit(allocator);
-
-    var argv_buf: [48][]const u8 = undefined;
-    var argc: usize = 0;
-
-    argv_buf[argc] = "curl";
-    argc += 1;
-    argv_buf[argc] = "-s";
-    argc += 1;
-
-    if (max_time) |mt| {
-        argv_buf[argc] = "--max-time";
-        argc += 1;
-        argv_buf[argc] = mt;
-        argc += 1;
-    }
-
-    appendCurlResolveArgs(argv_buf[0..], &argc, resolve_entry);
-
-    try appendPreparedCurlHeaders(argv_buf[0..], &argc, headers, prepared_headers.arg);
-
-    argv_buf[argc] = "-w";
-    argc += 1;
-    argv_buf[argc] = "\n%{http_code}";
-    argc += 1;
-    argv_buf[argc] = url;
-    argc += 1;
-
-    var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    try child.spawn();
-    const cancel_flag = thread_interrupt_flag;
-    var cancel_done = AtomicBool.init(false);
-    var cancel_watcher: ?std.Thread = null;
-    var watcher_ctx: CancelWatcherCtx = undefined;
-    if (cancel_flag) |flag| {
-        watcher_ctx = .{ .child = &child, .cancel_flag = flag, .done = &cancel_done };
-        cancel_watcher = std.Thread.spawn(.{}, cancelWatcherMain, .{&watcher_ctx}) catch null;
-    }
-    defer {
-        cancel_done.store(true, .release);
-        if (cancel_watcher) |t| t.join();
-    }
-    var stderr_capture = StderrCapture{};
-    var stderr_thread = startStderrCapture(&child, &stderr_capture);
-    defer if (stderr_thread) |thread| thread.join();
-
-    const stdout = child.stdout.?.readToEndAlloc(allocator, DEFAULT_CURL_GET_MAX_BYTES) catch {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlReadError;
-    };
-    errdefer allocator.free(stdout);
-
-    const term = child.wait() catch |err| {
-        _ = child.kill() catch {};
-        const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-        logCurlWaitFailure("GET", err, stderr_msg);
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWaitError;
-    };
-    const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            logCurlExitFailure("GET", code, stderr_msg);
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else mapCurlExitCodeToError(code);
-        },
-        else => return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed,
-    }
-
-    const status_sep = std.mem.lastIndexOfScalar(u8, stdout, '\n') orelse return error.CurlParseError;
-    const status_raw = std.mem.trim(u8, stdout[status_sep + 1 ..], " \t\r\n");
-    if (status_raw.len != 3) return error.CurlParseError;
-    const status_code = std.fmt.parseInt(u16, status_raw, 10) catch return error.CurlParseError;
-    const body_slice = stdout[0..status_sep];
-    const response_body = try allocator.dupe(u8, body_slice);
-    allocator.free(stdout);
-
-    return .{
-        .status_code = status_code,
-        .body = response_body,
-    };
+    const response = try secureCurlRequestWithStatusAndHeaders(allocator, .{
+        .method = .GET,
+        .url = url,
+        .headers = headers,
+        .max_time = max_time,
+        .max_response_bytes = DEFAULT_CURL_GET_MAX_BYTES,
+        .resolve_entry = resolve_entry,
+    });
+    allocator.free(response.headers);
+    return .{ .status_code = response.status_code, .body = response.body };
 }
 
 /// HTTP PUT via curl subprocess (no proxy, no timeout).
@@ -1352,87 +1480,18 @@ fn curlGetWithProxyAndResolve(
     if (credentialedCurlUsesHttpFallback(url, headers, resolve_entry)) {
         return httpRequest(allocator, .GET, url, null, headers, null, proxy);
     }
-    var prepared_headers = try prepareCurlHeadersForArgv(allocator, url, headers);
-    defer prepared_headers.deinit(allocator);
-
-    var argv_buf: [48][]const u8 = undefined;
-    var argc: usize = 0;
-
-    argv_buf[argc] = "curl";
-    argc += 1;
-    argv_buf[argc] = "-sf";
-    argc += 1;
-    argv_buf[argc] = "--max-time";
-    argc += 1;
-    argv_buf[argc] = timeout_secs;
-    argc += 1;
-
-    if (proxy) |p| {
-        argv_buf[argc] = "--proxy";
-        argc += 1;
-        argv_buf[argc] = p;
-        argc += 1;
-    }
-
-    if (resolve_entry) |entry| {
-        argv_buf[argc] = "--resolve";
-        argc += 1;
-        argv_buf[argc] = entry;
-        argc += 1;
-    }
-
-    try appendPreparedCurlHeaders(argv_buf[0..], &argc, headers, prepared_headers.arg);
-
-    argv_buf[argc] = url;
-    argc += 1;
-
-    var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    try child.spawn();
-    const cancel_flag = thread_interrupt_flag;
-    var cancel_done = AtomicBool.init(false);
-    var cancel_watcher: ?std.Thread = null;
-    var watcher_ctx: CancelWatcherCtx = undefined;
-    if (cancel_flag) |flag| {
-        watcher_ctx = .{ .child = &child, .cancel_flag = flag, .done = &cancel_done };
-        cancel_watcher = std.Thread.spawn(.{}, cancelWatcherMain, .{&watcher_ctx}) catch null;
-    }
-    defer {
-        cancel_done.store(true, .release);
-        if (cancel_watcher) |t| t.join();
-    }
-    var stderr_capture = StderrCapture{};
-    var stderr_thread = startStderrCapture(&child, &stderr_capture);
-    defer if (stderr_thread) |thread| thread.join();
-
-    const stdout = child.stdout.?.readToEndAlloc(allocator, max_bytes) catch {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlReadError;
-    };
-
-    const term = child.wait() catch |err| {
-        _ = child.kill() catch {};
-        const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-        logCurlWaitFailure("GET", err, stderr_msg);
-        return error.CurlWaitError;
-    };
-    const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            logCurlExitFailure("GET", code, stderr_msg);
-            allocator.free(stdout);
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else mapCurlExitCodeToError(code);
-        },
-        else => {
-            allocator.free(stdout);
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed;
-        },
-    }
-
-    return stdout;
+    const response = try secureCurlRequestWithStatusAndHeaders(allocator, .{
+        .method = .GET,
+        .url = url,
+        .headers = headers,
+        .proxy = proxy,
+        .max_time = timeout_secs,
+        .max_response_bytes = max_bytes,
+        .resolve_entry = resolve_entry,
+        .fail_on_http_error = true,
+    });
+    allocator.free(response.headers);
+    return response.body;
 }
 
 /// HTTP GET via curl subprocess with optional proxy.
@@ -1563,6 +1622,23 @@ fn getProxyFromEnvMap(
     return null;
 }
 
+const ProxySelection = struct {
+    value: ?[]const u8 = null,
+    force: bool = false,
+
+    fn deinit(self: *ProxySelection, allocator: Allocator) void {
+        if (self.value) |value| allocator.free(value);
+        self.* = .{};
+    }
+};
+
+fn getProxyOverrideOwned(allocator: Allocator) !?[]u8 {
+    proxy_override_mutex.lock();
+    defer proxy_override_mutex.unlock();
+    const value = proxy_override_value orelse return null;
+    return try allocator.dupe(u8, value);
+}
+
 fn initClientDefaultProxiesFromEnvMap(
     client: *std.http.Client,
     arena: Allocator,
@@ -1588,6 +1664,23 @@ pub fn getProxyFromEnv(allocator: Allocator) !?[]const u8 {
     return try getProxyFromEnvMap(allocator, &env_map, &http_proxy_env_var_names);
 }
 
+fn getProxyForUrl(allocator: Allocator, url: []const u8) !ProxySelection {
+    const uri = try validateHttpUrl(url);
+    if (try getProxyOverrideOwned(allocator)) |override| {
+        return .{ .value = override, .force = true };
+    }
+
+    var env_map = std_compat.process.EnvMap.init(allocator);
+    defer env_map.deinit();
+    for (proxy_env_var_names) |key| try putProxyEnvVarFromProcess(&env_map, allocator, key);
+
+    const names = if (std.ascii.eqlIgnoreCase(uri.scheme, "https"))
+        &https_proxy_env_var_names
+    else
+        &http_proxy_env_var_names;
+    return .{ .value = try getProxyFromEnvMap(allocator, &env_map, names) };
+}
+
 /// HTTP GET via curl for SSE (Server-Sent Events).
 ///
 /// Uses -N (--no-buffer) to disable output buffering, allowing
@@ -1597,15 +1690,22 @@ pub fn curlGetSSE(
     url: []const u8,
     timeout_secs: []const u8,
 ) ![]u8 {
-    try validateNoCredentialedCurlArgs(url, &.{});
+    var config = try prepareProtectedCurlConfig(allocator, url, null);
+    defer config.deinit();
     var argv_buf: [40][]const u8 = undefined;
     var argc: usize = 0;
 
     argv_buf[argc] = "curl";
     argc += 1;
+    argv_buf[argc] = "-q";
+    argc += 1;
     argv_buf[argc] = "-sf";
     argc += 1;
     argv_buf[argc] = "-N";
+    argc += 1;
+    argv_buf[argc] = "--proto";
+    argc += 1;
+    argv_buf[argc] = "=http,https";
     argc += 1;
     argv_buf[argc] = "--max-time";
     argc += 1;
@@ -1615,7 +1715,9 @@ pub fn curlGetSSE(
     argc += 1;
     argv_buf[argc] = "Accept: text/event-stream";
     argc += 1;
-    argv_buf[argc] = url;
+    argv_buf[argc] = "--config";
+    argc += 1;
+    argv_buf[argc] = config.path();
     argc += 1;
 
     var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);
@@ -1635,28 +1737,24 @@ pub fn curlGetSSE(
         watcher_ctx = .{ .child = &child, .cancel_flag = flag, .done = &cancel_done };
         cancel_watcher = std.Thread.spawn(.{}, cancelWatcherMain, .{&watcher_ctx}) catch null;
     }
-    defer {
-        cancel_done.store(true, .release);
-        if (cancel_watcher) |t| t.join();
-    }
+    defer stopCancelWatcher(&cancel_done, &cancel_watcher);
     var stderr_capture = StderrCapture{};
     var stderr_thread = startStderrCapture(&child, &stderr_capture);
     defer if (stderr_thread) |thread| thread.join();
 
     const stdout = child.stdout.?.readToEndAlloc(allocator, 4 * 1024 * 1024) catch {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
+        abortCurlChild(&child, &cancel_done, &cancel_watcher, &stderr_thread, &stderr_capture);
         return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlReadError;
     };
+    errdefer allocator.free(stdout);
 
+    _ = finishStderrCapture(&stderr_thread, &stderr_capture);
+    stopCancelWatcher(&cancel_done, &cancel_watcher);
     const term = child.wait() catch |err| {
         _ = child.kill() catch {};
-        const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
-        logCurlWaitFailure("GET-SSE", err, stderr_msg);
-        allocator.free(stdout);
+        logCurlWaitFailure("GET-SSE", err, null);
         return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWaitError;
     };
-    const stderr_msg = finishStderrCapture(&stderr_thread, &stderr_capture);
     switch (term) {
         .exited => |code| {
             if (code != 0) {
@@ -1664,68 +1762,19 @@ pub fn curlGetSSE(
                 // but curl may have received some data before timing out - return it.
                 // For other exit codes, treat as error.
                 if (code != 28) {
-                    logCurlExitFailure("GET-SSE", code, stderr_msg);
-                    allocator.free(stdout);
+                    logCurlExitFailure("GET-SSE", code, null);
                     return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else mapCurlExitCodeToError(code);
                 }
                 // Timeout (code 28) - return any data we received
             }
         },
-        else => {
-            allocator.free(stdout);
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed;
-        },
+        else => return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed,
     }
 
     return stdout;
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
-
-test "curlPostWithProxy header guard allows at most (argv_buf_len - base_args) / 2 headers" {
-    // argv_buf is [40][]const u8. Base args consume 8 slots (curl -s -X POST -H
-    // Content-Type --data-binary @- url), leaving 32 slots = 16 header pairs.
-    // The guard `argc + 2 > argv_buf.len` stops additions before overflow.
-    // We verify the guard constant is consistent: remaining = 40 - 8 = 32, max headers = 16.
-    const argv_buf_len = 40;
-    const base_args = 8; // curl -s -X POST -H <ct> --data-binary @- <url>
-    const max_header_pairs = (argv_buf_len - base_args) / 2;
-    try std.testing.expectEqual(@as(usize, 16), max_header_pairs);
-}
-
-test "curlPostWithStatus compiles and is callable" {
-    try std.testing.expect(true);
-}
-
-test "curlGetWithStatus compiles and is callable" {
-    try std.testing.expect(true);
-}
-
-test "curlPut compiles and is callable" {
-    try std.testing.expect(true);
-}
-
-test "curlPostForm uses exactly 9 fixed args plus url" {
-    // argv_buf is [10][]const u8: curl -s -X POST -H <ct> --data-binary @- <url> = 9 slots.
-    // Verify the constant is consistent with the implementation.
-    const argv_buf_len = 10;
-    const fixed_args = 9; // curl -s -X POST -H Content-Type --data-binary @- (url)
-    try std.testing.expect(fixed_args < argv_buf_len);
-}
-
-test "curlGet with zero headers compiles and is callable" {
-    // Smoke-test: verifies the function signature is reachable and the arg-building
-    // path with an empty header slice does not panic at comptime.
-    _ = curlGet;
-}
-
-test "curlGetWithResolve compiles and is callable" {
-    try std.testing.expect(true);
-}
-
-test "curlGetMaxBytes compiles and is callable" {
-    _ = curlGetMaxBytes;
-}
 
 test "credentialed curl argv validation rejects authorization header" {
     try std.testing.expectError(
@@ -1770,26 +1819,163 @@ test "credentialed curl falls through to curl on android" {
     }
 }
 
-// Regression: aarch64-linux-android — std.http.Client fails with
-// error.NameServerFailure on this target, so httpRequestWithStatusAndHeaders
-// (the stdlib path used by Discord, Telegram, Lark, MAX, LINE, Composio,
-// providers, gateway) must route through curl subprocess on Android.
-//
-// On non-Android hosts this test exercises the stdlib path against
-// example.com via curl, verifying the call shape compiles and runs.
-test "httpRequest stdlib path also routes to curl on android" {
-    // No-op assertion that documents the intended dispatch.
-    if (comptime builtin.abi == .android) {
-        // Both the legacy curl helpers (curlGet / curlPost) AND the stdlib
-        // HTTP wrapper (httpRequest) must end up at curl subprocess on
-        // Android. Verified manually on 15t (2026-06-19).
-        try std.testing.expect(builtin.abi == .android);
-    } else {
-        // On non-Android: the stdlib path is preserved. Smoke check: the
-        // function compiles and the helper signature is what callers expect.
-        try std.testing.expect(@hasDecl(@This(), "httpRequestWithStatusAndHeaders"));
-        try std.testing.expect(@hasDecl(@This(), "httpRequestCurlOnAndroid"));
+test "secure curl command preserves methods and keeps secrets out of argv" {
+    // Regression: the Android fallback must not collapse PATCH/PUT to POST or
+    // DELETE/HEAD to GET, and no opaque caller data may enter process argv.
+    const methods = [_]std.http.Method{ .GET, .HEAD, .DELETE, .POST, .PUT, .PATCH, .OPTIONS };
+    const secret_url = "https://example.com/bot-test-token/action?session=query-secret";
+    const secret_header = "X-Custom-Key: header-secret";
+    const secret_proxy = "http://user:proxy-secret@proxy.example:8080";
+    for (methods) |method| {
+        const body: ?[]const u8 = switch (method) {
+            .POST, .PUT, .PATCH => "request-body",
+            else => null,
+        };
+        const spec: CurlRequestSpec = .{
+            .method = method,
+            .url = secret_url,
+            .body = body,
+            .headers = &.{secret_header},
+            .content_type = "multipart/form-data; boundary=test-boundary",
+            .proxy = secret_proxy,
+        };
+        const command = try buildSecureCurlCommand(
+            spec,
+            "/tmp/curl-config",
+            "@/tmp/curl-headers",
+            "/tmp/curl-response-headers",
+            null,
+        );
+
+        try std.testing.expectEqualStrings("curl", command.argv[0]);
+        try std.testing.expectEqualStrings("-q", command.argv[1]);
+        var saw_method = false;
+        var saw_head = false;
+        var saw_stdin_body = false;
+        var saw_location = false;
+        for (command.slice(), 0..) |arg, index| {
+            try std.testing.expect(std.mem.indexOf(u8, arg, "test-token") == null);
+            try std.testing.expect(std.mem.indexOf(u8, arg, "query-secret") == null);
+            try std.testing.expect(std.mem.indexOf(u8, arg, "header-secret") == null);
+            try std.testing.expect(std.mem.indexOf(u8, arg, "proxy-secret") == null);
+            if (std.mem.eql(u8, arg, "--request") and index + 1 < command.argc) {
+                try std.testing.expectEqualStrings(@tagName(method), command.argv[index + 1]);
+                saw_method = true;
+            }
+            saw_head = saw_head or std.mem.eql(u8, arg, "--head");
+            saw_stdin_body = saw_stdin_body or std.mem.eql(u8, arg, "@-");
+            saw_location = saw_location or std.mem.eql(u8, arg, "--location");
+        }
+        try std.testing.expect(saw_method);
+        try std.testing.expectEqual(method == .HEAD, saw_head);
+        try std.testing.expectEqual(body != null, saw_stdin_body);
+        try std.testing.expect(!saw_location);
     }
+}
+
+test "secure curl config contains URL and proxy only in protected file" {
+    var config = try prepareCurlConfig(
+        std.testing.allocator,
+        "https://example.com/api?session=test-token",
+        "http://user:proxy-secret@proxy.example:8080",
+        true,
+    );
+    defer config.deinit();
+
+    const file = try std_compat.fs.openFileAbsolute(config.path(), .{});
+    defer file.close();
+    if (comptime builtin.os.tag != .windows and builtin.os.tag != .wasi) {
+        const stat = try file.stat();
+        try std.testing.expectEqual(@as(std_compat.fs.File.Mode, 0), stat.mode & 0o077);
+        try std.testing.expect((stat.mode & 0o600) == 0o600);
+    }
+    const content = try file.readToEndAlloc(std.testing.allocator, 4096);
+    defer std.testing.allocator.free(content);
+    try std.testing.expect(std.mem.startsWith(u8, content, "globoff\n"));
+    try std.testing.expect(std.mem.indexOf(u8, content, "session=test-token") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "proxy-secret") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "noproxy = \"\"") != null);
+}
+
+test "protected curl config escapes values and rejects control injection" {
+    var config = try prepareProtectedCurlConfig(
+        std.testing.allocator,
+        "https://example.com/api",
+        "http://proxy.example/quote\"slash\\tail",
+    );
+    defer config.deinit();
+
+    const file = try std_compat.fs.openFileAbsolute(config.path(), .{});
+    defer file.close();
+    const content = try file.readToEndAlloc(std.testing.allocator, 4096);
+    defer std.testing.allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "quote\\\"slash\\\\tail") != null);
+
+    try std.testing.expectError(
+        error.InvalidCurlConfigValue,
+        prepareProtectedCurlConfig(
+            std.testing.allocator,
+            "https://example.com/api",
+            "http://proxy.example/ok\nurl = \"https://attacker.example\"",
+        ),
+    );
+}
+
+test "secure curl rejects non-http URLs and header injection before spawning" {
+    try std.testing.expectError(
+        error.UnsupportedUriScheme,
+        prepareCurlConfig(std.testing.allocator, "file:///tmp/test-token", null, false),
+    );
+    try std.testing.expectError(
+        error.InvalidHeader,
+        secureCurlRequestWithStatusAndHeaders(std.testing.allocator, .{
+            .method = .GET,
+            .url = "https://example.com/",
+            .headers = &.{"X-Test: ok\r\nX-Injected: bad"},
+            .proxy = "",
+        }),
+    );
+}
+
+test "android fetch adapter validates typed headers before spawning" {
+    var client = try ProxyHttpClient.init(std.testing.allocator);
+    defer client.deinit();
+    try std.testing.expectError(
+        error.InvalidHeader,
+        client.fetchWithCurl(.{
+            .location = .{ .url = "https://example.com/" },
+            .extra_headers = &.{.{ .name = "X-Test\r\nInjected", .value = "bad" }},
+        }),
+    );
+}
+
+test "android fetch adapter never auto-redirects caller headers" {
+    // Regression: curl forwards arbitrary custom headers across origins, so a
+    // bodyless request carrying an opaque API key must not use --location.
+    const with_secret: std.http.Client.FetchOptions = .{
+        .location = .{ .url = "https://example.com/start" },
+        .extra_headers = &.{.{ .name = "X-Custom-Key", .value = "test-token" }},
+    };
+    try std.testing.expect(fetchHasCallerHeaders(with_secret));
+    try std.testing.expectEqual(@as(?u16, null), fetchCurlMaxRedirects(with_secret));
+
+    const without_headers: std.http.Client.FetchOptions = .{
+        .location = .{ .url = "https://example.com/start" },
+    };
+    try std.testing.expectEqual(@as(?u16, 3), fetchCurlMaxRedirects(without_headers));
+    try std.testing.expectEqual(@as(?u16, 3), safeCurlMaxRedirects(.{
+        .method = .GET,
+        .url = "https://example.com/start",
+        .headers = &.{STD_HTTP_USER_AGENT_HEADER},
+        .max_redirects = 3,
+        .generated_redirect_headers_only = true,
+    }));
+    try std.testing.expectEqual(@as(?u16, null), safeCurlMaxRedirects(.{
+        .method = .GET,
+        .url = "https://example.com/start",
+        .headers = &.{"Authorization: Bearer test-token"},
+        .max_redirects = 3,
+    }));
 }
 
 const LegacyCredentialedCurlHelper = enum {
@@ -1842,6 +2028,158 @@ fn serveCredentialedCurlFallbackTest(ctx: *CredentialedCurlFallbackServerCtx) vo
         "\r\n" ++
         "{\"ok\":true}";
     conn.stream.writeAll(response) catch {};
+}
+
+const SecureCurlTransportServerCtx = struct {
+    server: *std_compat.net.Server,
+    expected_method: []const u8,
+    expected_body: []const u8,
+    expected_content_type: ?[]const u8,
+    saw_request: AtomicBool = AtomicBool.init(false),
+    saw_expected_method: AtomicBool = AtomicBool.init(false),
+    saw_expected_body: AtomicBool = AtomicBool.init(false),
+    saw_expected_content_type: AtomicBool = AtomicBool.init(false),
+    saw_unexpected_content_type: AtomicBool = AtomicBool.init(false),
+    saw_custom_header: AtomicBool = AtomicBool.init(false),
+};
+
+fn serveSecureCurlTransportTest(ctx: *SecureCurlTransportServerCtx) void {
+    var conn = ctx.server.accept() catch return;
+    defer conn.stream.close();
+
+    var buf: [8192]u8 = undefined;
+    var filled: usize = 0;
+    var request_end: ?usize = null;
+    while (filled < buf.len) {
+        const n = conn.stream.read(buf[filled..]) catch return;
+        if (n == 0) break;
+        filled += n;
+        if (request_end == null) {
+            if (std.mem.indexOf(u8, buf[0..filled], "\r\n\r\n")) |pos| request_end = pos + 4;
+        }
+        if (request_end) |end| {
+            if (filled >= end + ctx.expected_body.len) break;
+        }
+    }
+
+    const request = buf[0..filled];
+    ctx.saw_request.store(true, .release);
+    if (std.mem.startsWith(u8, request, ctx.expected_method) and
+        request.len > ctx.expected_method.len and request[ctx.expected_method.len] == ' ')
+    {
+        ctx.saw_expected_method.store(true, .release);
+    }
+    if (request_end) |end| {
+        if (request.len >= end + ctx.expected_body.len and
+            std.mem.eql(u8, request[end .. end + ctx.expected_body.len], ctx.expected_body))
+        {
+            ctx.saw_expected_body.store(true, .release);
+        }
+    }
+    if (ctx.expected_content_type) |content_type| {
+        if (std.mem.indexOf(u8, request, content_type) != null) {
+            ctx.saw_expected_content_type.store(true, .release);
+        }
+    } else {
+        ctx.saw_expected_content_type.store(true, .release);
+        if (std.mem.indexOf(u8, request, "Content-Type:") != null) {
+            ctx.saw_unexpected_content_type.store(true, .release);
+        }
+    }
+    if (std.mem.indexOf(u8, request, "X-Custom-Key: header-secret") != null) {
+        ctx.saw_custom_header.store(true, .release);
+    }
+
+    const response_head =
+        "HTTP/1.1 207 Multi-Status\r\n" ++
+        "X-Transport-Test: preserved\r\n" ++
+        "Content-Type: text/plain\r\n" ++
+        "Content-Length: 12\r\n" ++
+        "Connection: close\r\n" ++
+        "\r\n";
+    conn.stream.writeAll(response_head) catch return;
+    if (!std.mem.eql(u8, ctx.expected_method, "HEAD")) {
+        conn.stream.writeAll("transport-ok") catch {};
+    }
+}
+
+fn expectSecureCurlTransport(
+    method: std.http.Method,
+    body: ?[]const u8,
+    content_type: ?[]const u8,
+    use_proxy: bool,
+    use_writer: bool,
+) !void {
+    if (comptime builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const addr = try std_compat.net.Address.resolveIp("127.0.0.1", 0);
+    var server = try addr.listen(.{});
+    defer server.deinit();
+
+    var ctx = SecureCurlTransportServerCtx{
+        .server = &server,
+        .expected_method = @tagName(method),
+        .expected_body = body orelse "",
+        .expected_content_type = content_type,
+    };
+    const url = if (use_proxy)
+        try allocator.dupe(u8, "http://target.invalid/bot-test-token/action?session=query-secret")
+    else
+        try std.fmt.allocPrint(
+            allocator,
+            "http://127.0.0.1:{d}/bot-test-token/action?session=query-secret",
+            .{server.listen_address.in.getPort()},
+        );
+    defer allocator.free(url);
+    const proxy = if (use_proxy)
+        try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{server.listen_address.in.getPort()})
+    else
+        try allocator.dupe(u8, "");
+    defer allocator.free(proxy);
+    var thread = try std.Thread.spawn(.{}, serveSecureCurlTransportTest, .{&ctx});
+    var streamed: std.Io.Writer.Allocating = .init(allocator);
+    defer streamed.deinit();
+    const response = secureCurlRequestWithStatusAndHeaders(allocator, .{
+        .method = method,
+        .url = url,
+        .body = body,
+        .headers = &.{"X-Custom-Key: header-secret"},
+        .content_type = content_type,
+        .proxy = proxy,
+        .max_time = "5",
+        .response_writer = if (use_writer) &streamed.writer else null,
+    }) catch |err| {
+        if (!ctx.saw_request.load(.acquire)) unblockCredentialedCurlFallbackServer(&server);
+        thread.join();
+        return err;
+    };
+    defer allocator.free(response.headers);
+    defer allocator.free(response.body);
+    thread.join();
+
+    try std.testing.expectEqual(@as(u16, 207), response.status_code);
+    try std.testing.expect(std.mem.indexOf(u8, response.headers, "X-Transport-Test: preserved") != null);
+    if (method == .HEAD or use_writer) {
+        try std.testing.expectEqual(@as(usize, 0), response.body.len);
+    } else {
+        try std.testing.expectEqualStrings("transport-ok", response.body);
+    }
+    if (use_writer) try std.testing.expectEqualStrings("transport-ok", streamed.writer.buffered());
+    try std.testing.expect(ctx.saw_expected_method.load(.acquire));
+    try std.testing.expect(ctx.saw_expected_body.load(.acquire));
+    try std.testing.expect(ctx.saw_expected_content_type.load(.acquire));
+    try std.testing.expect(!ctx.saw_unexpected_content_type.load(.acquire));
+    try std.testing.expect(ctx.saw_custom_header.load(.acquire));
+}
+
+test "secure curl transport preserves method body content type status and headers" {
+    // Regression: these are the exact method classes broken by the original
+    // Android GET/POST dispatcher.
+    try expectSecureCurlTransport(.PATCH, "patch-body", "multipart/form-data; boundary=test-boundary", true, false);
+    try expectSecureCurlTransport(.POST, "untyped-body", null, false, true);
+    try expectSecureCurlTransport(.DELETE, null, null, false, false);
+    try expectSecureCurlTransport(.HEAD, null, null, false, false);
 }
 
 fn unblockCredentialedCurlFallbackServer(server: *std_compat.net.Server) void {
@@ -1961,7 +2299,7 @@ fn expectCredentialedCurlResolveEntry(helper: LegacyCredentialedCurlHelper, expe
 
     const host = "credentialed-curl.test";
     const port = server.listen_address.in.getPort();
-    const url = try std.fmt.allocPrint(allocator, "http://{s}:{d}/legacy", .{ host, port });
+    const url = try std.fmt.allocPrint(allocator, "http://{s}:{d}/legacy?access_token=test-token", .{ host, port });
     defer allocator.free(url);
     const resolve_entry = try std.fmt.allocPrint(allocator, "{s}:{d}:127.0.0.1", .{ host, port });
     defer allocator.free(resolve_entry);
@@ -2061,19 +2399,6 @@ test "credentialed curl helpers preserve resolve pinning" {
     try expectCredentialedCurlResolveEntry(.get_status, "GET");
     try expectCredentialedCurlResolveEntry(.post_status, "POST");
     try expectCredentialedCurlResolveEntry(.post_status_headers, "POST");
-}
-
-test "credentialed curl resolve path rejects sensitive URL tokens" {
-    try std.testing.expectError(
-        error.CredentialedCurlArgRejected,
-        curlGetWithResolve(
-            std.testing.allocator,
-            "https://example.com/v1?access_token=test-token",
-            &.{},
-            "5",
-            "example.com:443:203.0.113.10",
-        ),
-    );
 }
 
 test "prepareCurlHeaderArg writes headers outside argv" {
@@ -2212,10 +2537,25 @@ test "setProxyOverride applies and clears process-wide override" {
     const normalized_override = "socks5://proxy-override-test.invalid:1080";
 
     try setProxyOverride(override);
+    defer setProxyOverride(null) catch unreachable;
     const from_override = try getProxyFromEnv(std.testing.allocator);
     defer if (from_override) |v| std.testing.allocator.free(v);
     try std.testing.expect(from_override != null);
     try std.testing.expectEqualStrings(normalized_override, from_override.?);
+    var selected = try getProxyForUrl(std.testing.allocator, "https://example.com/");
+    defer selected.deinit(std.testing.allocator);
+    try std.testing.expect(selected.force);
+    try std.testing.expectEqualStrings(normalized_override, selected.value.?);
+
+    // Regression: streaming curl callers must not let inherited NO_PROXY
+    // silently bypass an explicit config proxy override.
+    var config = try prepareProtectedCurlConfigFromEnvironment(std.testing.allocator, "https://example.com/");
+    defer config.deinit();
+    const config_file = try std_compat.fs.openFileAbsolute(config.path(), .{});
+    defer config_file.close();
+    const config_content = try config_file.readToEndAlloc(std.testing.allocator, 4096);
+    defer std.testing.allocator.free(config_content);
+    try std.testing.expect(std.mem.indexOf(u8, config_content, "noproxy = \"\"") != null);
 
     try setProxyOverride(null);
     const after_clear = try getProxyFromEnv(std.testing.allocator);

--- a/src/http_util.zig
+++ b/src/http_util.zig
@@ -374,6 +374,15 @@ pub fn httpRequestWithStatusAndHeaders(
     content_type: ?[]const u8,
     proxy: ?[]const u8,
 ) !HttpResponseWithHeaders {
+    // Regression: aarch64-linux-android (Termux) — std.http.Client fails with
+    // error.NameServerFailure and other TLS/lookup errors on this target, so
+    // every caller of httpRequest / httpPostJsonWithProxy / httpGetWithProxy
+    // (Discord, Telegram, Lark, MAX, LINE, Composio, providers, gateway, etc.)
+    // is affected. Route through the curl subprocess instead. Credentials flow
+    // via -H @<tempfile> (see prepareCurlHeaderArg) so argv stays clean.
+    if (comptime builtin.abi == .android) {
+        return httpRequestCurlOnAndroid(allocator, method, url, body, headers, content_type, proxy);
+    }
     var header_buf: [20]std.http.Header = undefined;
     var header_count: usize = 0;
     if (content_type) |ct| {
@@ -490,6 +499,53 @@ pub fn httpGetWithProxy(
     proxy: ?[]const u8,
 ) ![]u8 {
     return httpRequest(allocator, .GET, url, null, headers, null, proxy);
+}
+
+/// Android-only dispatcher used by `httpRequestWithStatusAndHeaders` on
+/// `aarch64-linux-android` (Termux), where `std.http.Client` cannot complete
+/// HTTPS requests (NameServerFailure, TLS/Host header regressions). Routes
+/// to the existing curl subprocess path which is verified to work on Termux
+/// (Termux curl with `/data/data/com.termux/files/usr/etc/tls/cert.pem`).
+///
+/// Credentials flow through `prepareCurlHeaderArg` → `-H @<tempfile>`, so
+/// they never appear in argv.
+///
+/// `proxy` is currently unsupported on this branch — the curl path here
+/// uses the system resolver and direct connection. NullClaw channel and
+/// provider call sites in the Termux deployment all pass `proxy = null`.
+fn httpRequestCurlOnAndroid(
+    allocator: Allocator,
+    method: std.http.Method,
+    url: []const u8,
+    body: ?[]const u8,
+    headers: []const []const u8,
+    content_type: ?[]const u8,
+    proxy: ?[]const u8,
+) !HttpResponseWithHeaders {
+    if (proxy) |_| {
+        // Fail loud rather than silently ignore a proxy on Android — the
+        // operator should know if their deployment relied on one.
+        return error.ProxyNotSupportedOnAndroid;
+    }
+    _ = content_type; // curl infers Content-Type from body; helper omits it.
+
+    const timeout: ?[]const u8 = "30";
+    const curl_resp = switch (method) {
+        .GET => try curlGetWithStatusAndTimeout(allocator, url, headers, timeout),
+        .DELETE => try curlGetWithStatusAndTimeout(allocator, url, headers, timeout),
+        .HEAD => try curlGetWithStatusAndTimeout(allocator, url, headers, timeout),
+        .POST, .PUT, .PATCH => blk: {
+            const payload = body orelse "";
+            break :blk try curlPostWithStatusAndTimeout(allocator, url, payload, headers, timeout);
+        },
+        else => return error.HttpMethodNotSupportedOnAndroid,
+    };
+
+    return .{
+        .status_code = curl_resp.status_code,
+        .headers = "",
+        .body = curl_resp.body,
+    };
 }
 
 const proxy_env_var_names = [_][]const u8{
@@ -1711,6 +1767,28 @@ test "credentialed curl falls through to curl on android" {
             &cred_headers,
             null,
         ));
+    }
+}
+
+// Regression: aarch64-linux-android — std.http.Client fails with
+// error.NameServerFailure on this target, so httpRequestWithStatusAndHeaders
+// (the stdlib path used by Discord, Telegram, Lark, MAX, LINE, Composio,
+// providers, gateway) must route through curl subprocess on Android.
+//
+// On non-Android hosts this test exercises the stdlib path against
+// example.com via curl, verifying the call shape compiles and runs.
+test "httpRequest stdlib path also routes to curl on android" {
+    // No-op assertion that documents the intended dispatch.
+    if (comptime builtin.abi == .android) {
+        // Both the legacy curl helpers (curlGet / curlPost) AND the stdlib
+        // HTTP wrapper (httpRequest) must end up at curl subprocess on
+        // Android. Verified manually on 15t (2026-06-19).
+        try std.testing.expect(builtin.abi == .android);
+    } else {
+        // On non-Android: the stdlib path is preserved. Smoke check: the
+        // function compiles and the helper signature is what callers expect.
+        try std.testing.expect(@hasDecl(@This(), "httpRequestWithStatusAndHeaders"));
+        try std.testing.expect(@hasDecl(@This(), "httpRequestCurlOnAndroid"));
     }
 }
 

--- a/src/memory/engines/api.zig
+++ b/src/memory/engines/api.zig
@@ -2,10 +2,9 @@
 //!
 //! Implements the Memory + SessionStore vtable interfaces by sending
 //! HTTP requests to a user-provided REST API server.
-//! Pattern follows store_qdrant.zig: std.http.Client + std.Io.Writer.Allocating.
+//! Pattern follows store_qdrant.zig with the shared curl-based request helpers.
 
 const std = @import("std");
-const std_compat = @import("compat");
 const Allocator = std.mem.Allocator;
 const appendJsonEscaped = @import("../../util.zig").appendJsonEscaped;
 const http_util = @import("../../http_util.zig");
@@ -136,123 +135,38 @@ pub const ApiMemory = struct {
         method: std.http.Method,
         payload: ?[]const u8,
     ) !HttpResponse {
-        // Keep curl for deterministic --max-time behavior, but keep headers out
-        // of argv and send request bodies over stdin.
         const timeout_secs: u32 = @max(@as(u32, 1), (self.timeout_ms + 999) / 1000);
         var timeout_buf: [16]u8 = undefined;
         const timeout_secs_str = std.fmt.bufPrint(&timeout_buf, "{d}", .{timeout_secs}) catch unreachable;
 
         var auth_header: ?[]u8 = null;
-        defer if (auth_header) |h| alloc.free(h);
-
-        var headers_buf: [2][]const u8 = undefined;
+        defer if (auth_header) |header| alloc.free(header);
+        var headers_buf: [1][]const u8 = undefined;
         var header_count: usize = 0;
-        headers_buf[header_count] = "Content-Type: application/json";
-        header_count += 1;
         if (self.api_key) |key| {
             auth_header = try std.fmt.allocPrint(alloc, "Authorization: Bearer {s}", .{key});
             headers_buf[header_count] = auth_header.?;
             header_count += 1;
         }
 
-        var prepared_headers = try http_util.prepareCurlHeaderArg(alloc, headers_buf[0..header_count]);
-        defer prepared_headers.deinit(alloc);
-
-        var argv_buf: [24][]const u8 = undefined;
-        var argc: usize = 0;
-
-        argv_buf[argc] = "curl";
-        argc += 1;
-        argv_buf[argc] = "--silent";
-        argc += 1;
-        argv_buf[argc] = "--show-error";
-        argc += 1;
-        argv_buf[argc] = "--max-time";
-        argc += 1;
-        argv_buf[argc] = timeout_secs_str;
-        argc += 1;
-        argv_buf[argc] = "--request";
-        argc += 1;
-        argv_buf[argc] = @tagName(method);
-        argc += 1;
-
-        if (prepared_headers.arg) |headers_arg| {
-            argv_buf[argc] = "--header";
-            argc += 1;
-            argv_buf[argc] = headers_arg;
-            argc += 1;
-        }
-
-        if (payload != null) {
-            argv_buf[argc] = "--data-binary";
-            argc += 1;
-            argv_buf[argc] = "@-";
-            argc += 1;
-        }
-
-        argv_buf[argc] = "--write-out";
-        argc += 1;
-        argv_buf[argc] = "\n%{http_code}";
-        argc += 1;
-        argv_buf[argc] = url;
-        argc += 1;
-
-        var child = std_compat.process.Child.init(argv_buf[0..argc], alloc);
-        child.stdin_behavior = if (payload != null) .Pipe else .Ignore;
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Ignore;
-
-        child.spawn() catch return error.ApiConnectionError;
-
-        if (payload) |body| {
-            if (child.stdin) |stdin_file| {
-                stdin_file.writeAll(body) catch {
-                    stdin_file.close();
-                    child.stdin = null;
-                    _ = child.kill() catch {};
-                    _ = child.wait() catch {};
-                    return error.ApiConnectionError;
-                };
-                stdin_file.close();
-                child.stdin = null;
-            } else {
-                _ = child.kill() catch {};
-                _ = child.wait() catch {};
-                return error.ApiConnectionError;
-            }
-        }
-
-        const raw_out = child.stdout.?.readToEndAlloc(alloc, 16 * 1024 * 1024) catch {
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
-            return error.ApiConnectionError;
-        };
-        defer alloc.free(raw_out);
-
-        const term = child.wait() catch return error.ApiConnectionError;
-        switch (term) {
-            .exited => |code| {
-                if (code != 0) {
-                    if (code == 28) return error.ApiTimeout;
-                    return error.ApiConnectionError;
-                }
-            },
+        const response = http_util.curlRequestWithStatusAndHeaders(alloc, .{
+            .method = method,
+            .url = url,
+            .body = payload,
+            .headers = headers_buf[0..header_count],
+            .content_type = "application/json",
+            .max_time = timeout_secs_str,
+            .max_response_bytes = 16 * 1024 * 1024,
+        }) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.CurlTimeout => return error.ApiTimeout,
+            error.CurlParseError => return error.ApiInvalidResponse,
             else => return error.ApiConnectionError,
-        }
-
-        return parseCurlOutput(alloc, raw_out);
-    }
-
-    fn parseCurlOutput(alloc: Allocator, raw_out: []const u8) !HttpResponse {
-        const sep = std.mem.lastIndexOfScalar(u8, raw_out, '\n') orelse return error.ApiInvalidResponse;
-        const code_slice = std.mem.trim(u8, raw_out[sep + 1 ..], " \r\n\t");
-        if (code_slice.len == 0) return error.ApiInvalidResponse;
-
-        const status_code = std.fmt.parseInt(u10, code_slice, 10) catch return error.ApiInvalidResponse;
-        const body = try alloc.dupe(u8, raw_out[0..sep]);
+        };
+        alloc.free(response.headers);
         return .{
-            .status = @enumFromInt(status_code),
-            .body = body,
+            .status = @enumFromInt(@as(u10, @intCast(response.status_code))),
+            .body = response.body,
         };
     }
 
@@ -1570,28 +1484,6 @@ test "api parse count missing field" {
     ;
     const result = ApiMemory.parseCount(alloc, json);
     try std.testing.expectError(error.ApiInvalidResponse, result);
-}
-
-test "api parse curl output with body" {
-    const out =
-        \\{"entry":{"id":"1"}}
-        \\200
-    ;
-    const parsed = try ApiMemory.parseCurlOutput(std.testing.allocator, out);
-    defer std.testing.allocator.free(parsed.body);
-    try std.testing.expect(parsed.status == .ok);
-    try std.testing.expectEqualStrings("{\"entry\":{\"id\":\"1\"}}", parsed.body);
-}
-
-test "api parse curl output with empty body" {
-    const out =
-        \\
-        \\404
-    ;
-    const parsed = try ApiMemory.parseCurlOutput(std.testing.allocator, out);
-    defer std.testing.allocator.free(parsed.body);
-    try std.testing.expect(parsed.status == .not_found);
-    try std.testing.expectEqual(@as(usize, 0), parsed.body.len);
 }
 
 test "api build store payload" {

--- a/src/memory/engines/clickhouse.zig
+++ b/src/memory/engines/clickhouse.zig
@@ -1,6 +1,6 @@
 //! ClickHouse-backed persistent memory via HTTP API (port 8123).
 //!
-//! No C dependency — pure Zig HTTP via std.http.Client.
+//! Uses the shared HTTP transport (stdlib normally, curl fallback on Android).
 //! Writes are append-only with server-generated Snowflake ordering keys, and
 //! reads collapse to the latest row per logical key via argMax. This keeps
 //! ordering independent from client clock skew while ReplacingMergeTree(version)
@@ -398,7 +398,7 @@ const ClickHouseMemoryImpl = struct {
             header_count += 1;
         }
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = .POST,
             .payload = query,
@@ -463,7 +463,7 @@ const ClickHouseMemoryImpl = struct {
             header_count += 1;
         }
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = .POST,
             .payload = query,

--- a/src/memory/vector/embeddings.zig
+++ b/src/memory/vector/embeddings.zig
@@ -183,7 +183,7 @@ pub const OpenAiEmbedding = struct {
         var aw: std.Io.Writer.Allocating = .init(allocator);
         defer aw.deinit();
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = .POST,
             .payload = body_buf.items,

--- a/src/memory/vector/embeddings_gemini.zig
+++ b/src/memory/vector/embeddings_gemini.zig
@@ -106,7 +106,7 @@ pub const GeminiEmbedding = struct {
         var aw: std.Io.Writer.Allocating = .init(allocator);
         defer aw.deinit();
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = .POST,
             .payload = body,

--- a/src/memory/vector/embeddings_ollama.zig
+++ b/src/memory/vector/embeddings_ollama.zig
@@ -114,7 +114,7 @@ pub const OllamaEmbedding = struct {
         var aw: std.Io.Writer.Allocating = .init(allocator);
         defer aw.deinit();
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = .POST,
             .payload = body,

--- a/src/memory/vector/embeddings_voyage.zig
+++ b/src/memory/vector/embeddings_voyage.zig
@@ -111,7 +111,7 @@ pub const VoyageEmbedding = struct {
         var aw: std.Io.Writer.Allocating = .init(allocator);
         defer aw.deinit();
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = .POST,
             .payload = body,

--- a/src/memory/vector/store_qdrant.zig
+++ b/src/memory/vector/store_qdrant.zig
@@ -134,7 +134,7 @@ pub const QdrantVectorStore = struct {
             header_count += 1;
         }
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = method,
             .payload = payload,
@@ -400,7 +400,7 @@ pub const QdrantVectorStore = struct {
         var aw: std.Io.Writer.Allocating = .init(alloc);
         defer aw.deinit();
 
-        const result = client.client.fetch(.{
+        const result = client.fetch(.{
             .location = .{ .url = url },
             .method = .GET,
             .response_writer = &aw.writer,

--- a/src/providers/gemini.zig
+++ b/src/providers/gemini.zig
@@ -779,6 +779,8 @@ pub const GeminiProvider = struct {
 
         argv_buf[argc] = "curl";
         argc += 1;
+        argv_buf[argc] = "-q";
+        argc += 1;
         argv_buf[argc] = "-s";
         argc += 1;
         argv_buf[argc] = "--no-buffer";
@@ -804,16 +806,8 @@ pub const GeminiProvider = struct {
         argv_buf[argc] = "POST";
         argc += 1;
 
-        // Add proxy from environment if set
-        const proxy = http_util.getProxyFromEnv(allocator) catch null;
-        defer if (proxy) |p| allocator.free(p);
-
-        if (proxy) |p| {
-            argv_buf[argc] = "--proxy";
-            argc += 1;
-            argv_buf[argc] = p;
-            argc += 1;
-        }
+        var curl_config = try http_util.prepareProtectedCurlConfigFromEnvironment(allocator, url);
+        defer curl_config.deinit();
 
         const resolve_entry = try http_util.buildSafeResolveEntryForRemoteUrl(allocator, url);
         defer if (resolve_entry) |entry| allocator.free(entry);
@@ -842,7 +836,9 @@ pub const GeminiProvider = struct {
         argc += 1;
         argv_buf[argc] = "@-";
         argc += 1;
-        argv_buf[argc] = url;
+        argv_buf[argc] = "--config";
+        argc += 1;
+        argv_buf[argc] = curl_config.path();
         argc += 1;
 
         var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);

--- a/src/providers/helpers.zig
+++ b/src/providers/helpers.zig
@@ -501,41 +501,62 @@ pub fn convertToolsResponses(buf: *std.ArrayListUnmanaged(u8), allocator: std.me
 
 /// HTTP POST with optional LLM timeout (seconds). 0 = no limit.
 /// Automatically reads proxy from HTTPS_PROXY, HTTP_PROXY, or ALL_PROXY environment variables.
-pub fn curlPostTimed(allocator: std.mem.Allocator, url: []const u8, body: []const u8, headers: []const []const u8, timeout_secs: u64) ![]u8 {
-    _ = timeout_secs;
+fn curlTimeoutArg(buf: *[32]u8, timeout_secs: u64) ?[]const u8 {
+    if (timeout_secs == 0) return null;
+    return std.fmt.bufPrint(buf, "{d}", .{timeout_secs}) catch unreachable;
+}
+
+fn curlPostTypedTimed(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    body: []const u8,
+    headers: []const []const u8,
+    content_type: []const u8,
+    timeout_secs: u64,
+) ![]u8 {
     const resolve_entry = http_util.buildSafeResolveEntryForRemoteUrl(allocator, url) catch |err| switch (err) {
         error.InvalidUrl, error.HostResolutionFailed, error.LocalAddressBlocked => return err,
         error.OutOfMemory => return error.OutOfMemory,
     };
     defer if (resolve_entry) |entry| allocator.free(entry);
-    // Provider requests often carry Authorization/x-api-key credentials.
-    // Use std.http so secrets are never exposed through child process argv.
-    return http_util.httpPostJsonWithProxy(allocator, url, body, headers, null);
+
+    var timeout_buf: [32]u8 = undefined;
+    const response = try http_util.curlRequestWithStatusAndHeaders(allocator, .{
+        .method = .POST,
+        .url = url,
+        .body = body,
+        .headers = headers,
+        .content_type = content_type,
+        .max_time = curlTimeoutArg(&timeout_buf, timeout_secs),
+        .resolve_entry = resolve_entry,
+        .accept_compression = true,
+        .std_http_defaults = true,
+    });
+    allocator.free(response.headers);
+    errdefer allocator.free(response.body);
+    if (response.status_code < 200 or response.status_code >= 300) return error.HttpStatusError;
+    return response.body;
+}
+
+pub fn curlPostTimed(allocator: std.mem.Allocator, url: []const u8, body: []const u8, headers: []const []const u8, timeout_secs: u64) ![]u8 {
+    return curlPostTypedTimed(allocator, url, body, headers, "application/json", timeout_secs);
 }
 
 /// HTTP POST (application/x-www-form-urlencoded) with optional timeout.
 /// Automatically reads proxy from HTTPS_PROXY, HTTP_PROXY, or ALL_PROXY environment variables.
 pub fn curlPostFormTimed(allocator: std.mem.Allocator, url: []const u8, body: []const u8, timeout_secs: u64) ![]u8 {
-    _ = timeout_secs;
-    const resolve_entry = http_util.buildSafeResolveEntryForRemoteUrl(allocator, url) catch |err| switch (err) {
-        error.InvalidUrl, error.HostResolutionFailed, error.LocalAddressBlocked => return err,
-        error.OutOfMemory => return error.OutOfMemory,
-    };
-    defer if (resolve_entry) |entry| allocator.free(entry);
-    return http_util.httpRequest(
-        allocator,
-        .POST,
-        url,
-        body,
-        &.{},
-        "application/x-www-form-urlencoded",
-        null,
-    );
+    return curlPostTypedTimed(allocator, url, body, &.{}, "application/x-www-form-urlencoded", timeout_secs);
 }
 
 // ════════════════════════════════════════════════════════════════════════════
 // Tests
 // ════════════════════════════════════════════════════════════════════════════
+
+test "provider curl timeout argument preserves zero and finite values" {
+    var buf: [32]u8 = undefined;
+    try std.testing.expect(curlTimeoutArg(&buf, 0) == null);
+    try std.testing.expectEqualStrings("300", curlTimeoutArg(&buf, 300).?);
+}
 
 test "convertToolsOpenAI produces valid JSON" {
     const alloc = std.testing.allocator;

--- a/src/providers/openai_codex.zig
+++ b/src/providers/openai_codex.zig
@@ -380,6 +380,8 @@ fn codexStreamRequest(
 
     argv_buf[argc] = "curl";
     argc += 1;
+    argv_buf[argc] = "-q";
+    argc += 1;
     argv_buf[argc] = "-s";
     argc += 1;
     argv_buf[argc] = "--no-buffer";
@@ -393,16 +395,8 @@ fn codexStreamRequest(
     argv_buf[argc] = "POST";
     argc += 1;
 
-    // Add proxy from environment if set
-    const proxy = http_util.getProxyFromEnv(allocator) catch null;
-    defer if (proxy) |p| allocator.free(p);
-
-    if (proxy) |p| {
-        argv_buf[argc] = "--proxy";
-        argc += 1;
-        argv_buf[argc] = p;
-        argc += 1;
-    }
+    var curl_config = try http_util.prepareProtectedCurlConfigFromEnvironment(allocator, url);
+    defer curl_config.deinit();
 
     var timeout_buf: [32]u8 = undefined;
     if (timeout_secs > 0) {
@@ -451,7 +445,9 @@ fn codexStreamRequest(
     argc += 1;
     argv_buf[argc] = "@-";
     argc += 1;
-    argv_buf[argc] = url;
+    argv_buf[argc] = "--config";
+    argc += 1;
+    argv_buf[argc] = curl_config.path();
     argc += 1;
 
     var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);

--- a/src/providers/sse.zig
+++ b/src/providers/sse.zig
@@ -346,6 +346,8 @@ pub fn curlStream(
 
     argv_buf[argc] = "curl";
     argc += 1;
+    argv_buf[argc] = "-q";
+    argc += 1;
     argv_buf[argc] = "-s";
     argc += 1;
     argv_buf[argc] = "--no-buffer";
@@ -372,16 +374,8 @@ pub fn curlStream(
     argv_buf[argc] = "POST";
     argc += 1;
 
-    // Add proxy from environment if set
-    const proxy = http_util.getProxyFromEnv(allocator) catch null;
-    defer if (proxy) |p| allocator.free(p);
-
-    if (proxy) |p| {
-        argv_buf[argc] = "--proxy";
-        argc += 1;
-        argv_buf[argc] = p;
-        argc += 1;
-    }
+    var curl_config = try http_util.prepareProtectedCurlConfigFromEnvironment(allocator, url);
+    defer curl_config.deinit();
 
     const resolve_entry = try http_util.buildSafeResolveEntryForRemoteUrl(allocator, url);
     defer if (resolve_entry) |entry| allocator.free(entry);
@@ -416,7 +410,9 @@ pub fn curlStream(
     argc += 1;
     argv_buf[argc] = "@-";
     argc += 1;
-    argv_buf[argc] = url;
+    argv_buf[argc] = "--config";
+    argc += 1;
+    argv_buf[argc] = curl_config.path();
     argc += 1;
 
     if (log_enabled) {
@@ -737,6 +733,8 @@ pub fn curlStreamAnthropic(
 
     argv_buf[argc] = "curl";
     argc += 1;
+    argv_buf[argc] = "-q";
+    argc += 1;
     argv_buf[argc] = "-s";
     argc += 1;
     argv_buf[argc] = "--no-buffer";
@@ -746,16 +744,8 @@ pub fn curlStreamAnthropic(
     argv_buf[argc] = "POST";
     argc += 1;
 
-    // Add proxy from environment if set
-    const proxy = http_util.getProxyFromEnv(allocator) catch null;
-    defer if (proxy) |p| allocator.free(p);
-
-    if (proxy) |p| {
-        argv_buf[argc] = "--proxy";
-        argc += 1;
-        argv_buf[argc] = p;
-        argc += 1;
-    }
+    var curl_config = try http_util.prepareProtectedCurlConfigFromEnvironment(allocator, url);
+    defer curl_config.deinit();
 
     const resolve_entry = try http_util.buildSafeResolveEntryForRemoteUrl(allocator, url);
     defer if (resolve_entry) |entry| allocator.free(entry);
@@ -784,7 +774,9 @@ pub fn curlStreamAnthropic(
     argc += 1;
     argv_buf[argc] = "@-";
     argc += 1;
-    argv_buf[argc] = url;
+    argv_buf[argc] = "--config";
+    argc += 1;
+    argv_buf[argc] = curl_config.path();
     argc += 1;
 
     var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);

--- a/src/skillforge.zig
+++ b/src/skillforge.zig
@@ -103,14 +103,14 @@ pub fn scout(allocator: std.mem.Allocator, query: []const u8) !std.ArrayList(Ski
     );
     defer allocator.free(url);
 
-    // Fetch from GitHub API using std.http.Client
+    // Fetch through the shared proxy-aware client (curl fallback on Android).
     var client = try http_util.ProxyHttpClient.init(allocator);
     defer client.deinit();
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
 
-    const result = client.client.fetch(.{
+    const result = client.fetch(.{
         .location = .{ .url = url },
         .method = .GET,
         .extra_headers = &.{

--- a/src/sse_client.zig
+++ b/src/sse_client.zig
@@ -82,6 +82,10 @@ pub const SseConnection = struct {
     /// Connect to SSE endpoint and start streaming
     /// Returns the HTTP status code
     pub fn connect(self: *SseConnection) !u16 {
+        // Android note: this persistent streaming request cannot use the
+        // buffered curl fallback in http_util. Signal's supported default is
+        // the local 127.0.0.1 daemon (no DNS lookup); a remote hostname still
+        // requires a dedicated long-lived curl transport.
         // URL already includes account query param from Signal channel config.
         const uri = try std.Uri.parse(self.url);
         self.body_reader = null;

--- a/src/tools/browser.zig
+++ b/src/tools/browser.zig
@@ -5,6 +5,7 @@ const Tool = root.Tool;
 const ToolResult = root.ToolResult;
 const JsonObjectMap = root.JsonObjectMap;
 const net_security = @import("../root.zig").net_security;
+const http_util = @import("../http_util.zig");
 
 /// Maximum response body size for the "read" action (8 KB).
 const MAX_READ_BYTES: usize = 8192;
@@ -131,83 +132,47 @@ pub const BrowserTool = struct {
         };
         defer allocator.free(connect_host);
 
-        // Use curl to fetch the page. Flags:
-        //   -sS  silent but show errors
-        //   -L   follow redirects
-        //   -m 10  timeout 10 seconds
-        //   --max-filesize 65536  abort if body exceeds 64 KB
-        const max_size_str = std.fmt.comptimePrint("{d}", .{MAX_FETCH_BYTES});
         var resolve_entry: ?[]u8 = null;
         defer if (resolve_entry) |entry| allocator.free(entry);
-
-        var argv_buf: [16][]const u8 = undefined;
-        var argc: usize = 0;
-        argv_buf[argc] = "curl";
-        argc += 1;
-        argv_buf[argc] = "-sS";
-        argc += 1;
-        argv_buf[argc] = "-L";
-        argc += 1;
-        argv_buf[argc] = "-m";
-        argc += 1;
-        argv_buf[argc] = "10";
-        argc += 1;
-        argv_buf[argc] = "--max-filesize";
-        argc += 1;
-        argv_buf[argc] = max_size_str;
-        argc += 1;
-        argv_buf[argc] = "--proto";
-        argc += 1;
-        argv_buf[argc] = "=https";
-        argc += 1;
-        argv_buf[argc] = "--proto-redir";
-        argc += 1;
-        argv_buf[argc] = "=https";
-        argc += 1;
-
         if (shouldUseCurlResolve(host)) {
             resolve_entry = try buildCurlResolveEntry(allocator, host, resolved_port, connect_host);
-            argv_buf[argc] = "--resolve";
-            argc += 1;
-            argv_buf[argc] = resolve_entry.?;
-            argc += 1;
         }
 
-        argv_buf[argc] = "--";
-        argc += 1;
-        argv_buf[argc] = url;
-        argc += 1;
-
-        const proc = @import("process_util.zig");
-        const result = proc.run(allocator, argv_buf[0..argc], .{ .max_output_bytes = MAX_FETCH_BYTES }) catch {
-            return ToolResult.fail("Failed to spawn curl — is curl installed?");
+        // Do not auto-follow redirects: every destination needs its own DNS and
+        // private-address validation, otherwise a public URL can redirect curl
+        // into loopback/RFC1918 space.
+        const response = http_util.curlRequestWithStatusAndHeaders(allocator, .{
+            .method = .GET,
+            .url = url,
+            .max_time = "10",
+            .max_response_bytes = MAX_FETCH_BYTES,
+            .resolve_entry = resolve_entry,
+        }) catch |err| {
+            const msg = try std.fmt.allocPrint(allocator, "curl request failed: {}", .{err});
+            return ToolResult{ .success = false, .output = "", .error_msg = msg };
         };
-        defer allocator.free(result.stderr);
-        defer allocator.free(result.stdout);
+        defer allocator.free(response.headers);
+        defer allocator.free(response.body);
 
-        if (!result.success) {
-            if (result.exit_code) |code| {
-                const detail = if (result.stderr.len > 0) result.stderr else "curl request failed";
-                const msg = try std.fmt.allocPrint(allocator, "curl exited with code {d}: {s}", .{ code, detail });
-                return ToolResult{ .success = false, .output = "", .error_msg = msg };
-            }
-            return ToolResult{ .success = false, .output = "", .error_msg = "curl terminated by signal" };
+        if (isRedirectStatus(response.status_code)) {
+            return ToolResult.fail("Redirect not followed: destination requires a separate security check");
         }
-
-        if (result.stdout.len == 0) {
+        if (response.body.len == 0) {
             const msg = try allocator.dupe(u8, "Page returned empty response");
             return ToolResult{ .success = true, .output = msg };
         }
 
-        // Truncate to MAX_READ_BYTES
-        const truncated = result.stdout.len > MAX_READ_BYTES;
-        const body_len = if (truncated) MAX_READ_BYTES else result.stdout.len;
+        const truncated = response.body.len > MAX_READ_BYTES;
+        const body_len = if (truncated) MAX_READ_BYTES else response.body.len;
         const suffix: []const u8 = if (truncated) "\n\n[Content truncated to 8 KB]" else "";
-
-        const output = try std.fmt.allocPrint(allocator, "{s}{s}", .{ result.stdout[0..body_len], suffix });
+        const output = try std.fmt.allocPrint(allocator, "{s}{s}", .{ response.body[0..body_len], suffix });
         return ToolResult{ .success = true, .output = output };
     }
 };
+
+fn isRedirectStatus(status_code: u16) bool {
+    return status_code >= 300 and status_code < 400;
+}
 
 fn shouldUseCurlResolve(host: []const u8) bool {
     return std.mem.indexOfScalar(u8, net_security.stripHostBrackets(host), ':') == null;
@@ -230,6 +195,15 @@ fn buildCurlResolveEntry(
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
+
+test "browser read returns redirects for separate security validation" {
+    // Regression: following a redirect after validating only the first host can
+    // reach loopback/private networks through an attacker-controlled 30x.
+    try std.testing.expect(isRedirectStatus(301));
+    try std.testing.expect(isRedirectStatus(308));
+    try std.testing.expect(!isRedirectStatus(200));
+    try std.testing.expect(!isRedirectStatus(404));
+}
 
 test "browser tool name" {
     var bt = BrowserTool{};

--- a/src/tools/http_request.zig
+++ b/src/tools/http_request.zig
@@ -1,6 +1,5 @@
 const builtin = @import("builtin");
 const std = @import("std");
-const std_compat = @import("compat");
 const root = @import("root.zig");
 const Tool = root.Tool;
 const ToolResult = root.ToolResult;
@@ -136,9 +135,6 @@ pub const HttpRequestTool = struct {
         if (builtin.is_test) {
             return ToolResult.fail("Network disabled in tests");
         }
-        var curl_stderr: ?[]u8 = null;
-        defer if (curl_stderr) |s| allocator.free(s);
-
         const status_result = runCurlRequestWithStatus(
             allocator,
             methodToSlice(method),
@@ -149,16 +145,14 @@ pub const HttpRequestTool = struct {
             custom_headers,
             body,
             self.timeout_secs,
-            &curl_stderr,
             @intCast(self.max_response_size),
         ) catch |err| {
             if (err == error.CurlInterrupted) {
                 return ToolResult.fail("Interrupted by /stop");
             }
-            const msg = if (curl_stderr) |stderr_msg|
-                try std.fmt.allocPrint(allocator, "HTTP request failed: {}\ncurl stderr: {s}", .{ err, stderr_msg })
-            else
-                try std.fmt.allocPrint(allocator, "HTTP request failed: {}", .{err});
+            // curl diagnostics can echo credentialed URLs or proxy userinfo;
+            // keep errors structured instead of returning raw stderr.
+            const msg = try std.fmt.allocPrint(allocator, "HTTP request failed: {}", .{err});
             return ToolResult{ .success = false, .output = "", .error_msg = msg };
         };
         defer allocator.free(status_result.body);
@@ -239,37 +233,14 @@ fn runCurlRequestWithStatus(
     headers: []const [2][]const u8,
     body: ?[]const u8,
     timeout_secs: u64,
-    stderr_out: ?*?[]u8,
     max_response_size: usize,
 ) !http_util.HttpResponse {
-    if (stderr_out) |out| out.* = null;
-
-    var argv_buf: [64][]const u8 = undefined;
-    var argc: usize = 0;
-
-    argv_buf[argc] = "curl";
-    argc += 1;
-    argv_buf[argc] = "-sS";
-    argc += 1;
-    argv_buf[argc] = "-X";
-    argc += 1;
-    argv_buf[argc] = method;
-    argc += 1;
-    argv_buf[argc] = "--max-time";
-    argc += 1;
-    var timeout_buf: [20]u8 = undefined;
-    const timeout_str = try std.fmt.bufPrint(&timeout_buf, "{d}", .{timeout_secs});
-    argv_buf[argc] = timeout_str;
-    argc += 1;
+    const method_enum = std.meta.stringToEnum(std.http.Method, method) orelse return error.UnsupportedHttpMethod;
 
     var resolve_entry: ?[]u8 = null;
     defer if (resolve_entry) |entry| allocator.free(entry);
     if (shouldUsePinnedResolve(host, connect_host)) {
         resolve_entry = try buildCurlResolveEntry(allocator, host, resolved_port, connect_host);
-        argv_buf[argc] = "--resolve";
-        argc += 1;
-        argv_buf[argc] = resolve_entry.?;
-        argc += 1;
     }
 
     var header_lines: std.ArrayListUnmanaged([]u8) = .empty;
@@ -277,195 +248,24 @@ fn runCurlRequestWithStatus(
         for (header_lines.items) |line| allocator.free(line);
         header_lines.deinit(allocator);
     }
-
-    for (headers) |h| {
-        const line = try std.fmt.allocPrint(allocator, "{s}: {s}", .{ h[0], h[1] });
+    for (headers) |header| {
+        const line = try std.fmt.allocPrint(allocator, "{s}: {s}", .{ header[0], header[1] });
         try header_lines.append(allocator, line);
     }
 
-    var prepared_headers = try http_util.prepareCurlHeaderArg(allocator, header_lines.items);
-    defer prepared_headers.deinit(allocator);
-    if (prepared_headers.arg) |headers_arg| {
-        if (argc + 2 > argv_buf.len) return error.CurlArgsOverflow;
-        argv_buf[argc] = "-H";
-        argc += 1;
-        argv_buf[argc] = headers_arg;
-        argc += 1;
-    }
-
-    if (body != null) {
-        if (argc + 2 + 3 > argv_buf.len) return error.CurlArgsOverflow;
-        argv_buf[argc] = "--data-binary";
-        argc += 1;
-        argv_buf[argc] = "@-";
-        argc += 1;
-    }
-
-    if (argc + 3 > argv_buf.len) return error.CurlArgsOverflow;
-    argv_buf[argc] = "-w";
-    argc += 1;
-    argv_buf[argc] = "\n%{http_code}";
-    argc += 1;
-    argv_buf[argc] = url;
-    argc += 1;
-
-    var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);
-    child.stdin_behavior = if (body != null) .Pipe else .Ignore;
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    try child.spawn();
-
-    const cancel_flag = http_util.currentThreadInterruptFlag();
-    const AtomicBool = std.atomic.Value(bool);
-    const CancelCtx = struct {
-        child: *std_compat.process.Child,
-        cancel_flag: *const AtomicBool,
-        done: *AtomicBool,
-    };
-    const watcherFn = struct {
-        fn run(ctx: *CancelCtx) void {
-            while (!ctx.done.load(.acquire)) {
-                if (ctx.cancel_flag.load(.acquire)) {
-                    if (comptime @import("builtin").os.tag == .windows) {
-                        _ = ctx.child.kill() catch {};
-                    } else {
-                        std.posix.kill(ctx.child.id, std.posix.SIG.TERM) catch {};
-                    }
-                    break;
-                }
-                std_compat.thread.sleep(20 * std.time.ns_per_ms);
-            }
-        }
-    }.run;
-    var done = AtomicBool.init(false);
-    var watcher: ?std.Thread = null;
-    var cancel_ctx: CancelCtx = undefined;
-    if (cancel_flag) |flag| {
-        cancel_ctx = .{ .child = &child, .cancel_flag = flag, .done = &done };
-        watcher = std.Thread.spawn(.{}, watcherFn, .{&cancel_ctx}) catch null;
-    }
-    defer {
-        done.store(true, .release);
-        if (watcher) |t| t.join();
-    }
-
-    if (body) |b| {
-        if (child.stdin) |stdin_file| {
-            stdin_file.writeAll(b) catch {
-                stdin_file.close();
-                child.stdin = null;
-                _ = child.kill() catch {};
-                _ = child.wait() catch {};
-                return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
-            };
-            stdin_file.close();
-            child.stdin = null;
-        } else {
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
-            return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWriteError;
-        }
-    }
-
-    const stdout = child.stdout.?.readToEndAlloc(allocator, max_response_size + 64) catch {
-        _ = child.kill() catch {};
-        _ = child.wait() catch {};
-        return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlReadError;
-    };
-    errdefer allocator.free(stdout);
-
-    const stderr_raw = if (child.stderr) |stderr_file|
-        stderr_file.readToEndAlloc(allocator, 16 * 1024) catch null
-    else
-        null;
-    defer if (stderr_raw) |buf| allocator.free(buf);
-
-    var stderr_copy: ?[]u8 = try duplicateTrimmedStderr(allocator, stderr_raw);
-    defer if (stderr_copy) |buf| allocator.free(buf);
-
-    const term = child.wait() catch return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlWaitError;
-    switch (term) {
-        .exited => |code| if (code != 0 and !(cancel_flag != null and cancel_flag.?.load(.acquire))) {
-            if (stderr_out) |out| {
-                out.* = stderr_copy;
-                stderr_copy = null;
-            }
-            return error.CurlFailed;
-        },
-        else => return if (cancel_flag != null and cancel_flag.?.load(.acquire)) error.CurlInterrupted else error.CurlFailed,
-    }
-
-    if (cancel_flag != null and cancel_flag.?.load(.acquire)) return error.CurlInterrupted;
-
-    const status_sep = std.mem.lastIndexOfScalar(u8, stdout, '\n') orelse {
-        if (stderr_out) |out| {
-            out.* = stderr_copy;
-            stderr_copy = null;
-        }
-        return error.CurlParseError;
-    };
-    const status_raw = std.mem.trim(u8, stdout[status_sep + 1 ..], " \t\r\n");
-    if (status_raw.len != 3) {
-        if (stderr_out) |out| {
-            out.* = stderr_copy;
-            stderr_copy = null;
-        }
-        return error.CurlParseError;
-    }
-    const status_code = std.fmt.parseInt(u16, status_raw, 10) catch {
-        if (stderr_out) |out| {
-            out.* = stderr_copy;
-            stderr_copy = null;
-        }
-        return error.CurlParseError;
-    };
-    const body_slice = stdout[0..status_sep];
-    const response_body = try allocator.dupe(u8, body_slice);
-    allocator.free(stdout);
-
-    return .{
-        .status_code = status_code,
-        .body = response_body,
-    };
-}
-
-fn duplicateTrimmedStderr(allocator: std.mem.Allocator, raw: ?[]const u8) !?[]u8 {
-    const bytes = raw orelse return null;
-    const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
-    if (trimmed.len == 0) return null;
-    const copied = try allocator.dupe(u8, trimmed);
-    return copied;
-}
-
-fn ensureTlsCaBundleLoaded(client: *std.http.Client) !void {
-    if (@atomicLoad(bool, &client.next_https_rescan_certs, .acquire)) {
-        client.ca_bundle_mutex.lock();
-        defer client.ca_bundle_mutex.unlock();
-
-        if (client.next_https_rescan_certs) {
-            client.ca_bundle.rescan(client.allocator) catch |err| switch (err) {
-                error.OutOfMemory => return error.OutOfMemory,
-                else => return error.CertificateBundleLoadFailure,
-            };
-            @atomicStore(bool, &client.next_https_rescan_certs, false, .release);
-        }
-    }
-}
-
-fn isTlsSetupError(err: anyerror) bool {
-    return err == error.TlsInitializationFailed or err == error.CertificateBundleLoadFailure;
-}
-
-fn buildHttpRequestErrorMessage(allocator: std.mem.Allocator, prefix: []const u8, err: anyerror) ![]u8 {
-    if (isTlsSetupError(err)) {
-        return std.fmt.allocPrint(
-            allocator,
-            "{s}: {s}. Ensure system CA certificates are available in the runtime, or use an endpoint with a publicly trusted certificate chain.",
-            .{ prefix, @errorName(err) },
-        );
-    }
-    return std.fmt.allocPrint(allocator, "{s}: {}", .{ prefix, err });
+    var timeout_buf: [20]u8 = undefined;
+    const timeout_str = try std.fmt.bufPrint(&timeout_buf, "{d}", .{timeout_secs});
+    const response = try http_util.curlRequestWithStatusAndHeaders(allocator, .{
+        .method = method_enum,
+        .url = url,
+        .body = body,
+        .headers = header_lines.items,
+        .max_time = timeout_str,
+        .max_response_bytes = max_response_size,
+        .resolve_entry = resolve_entry,
+    });
+    allocator.free(response.headers);
+    return .{ .status_code = response.status_code, .body = response.body };
 }
 
 fn validateMethod(method: []const u8) ?std.http.Method {
@@ -477,67 +277,6 @@ fn validateMethod(method: []const u8) ?std.http.Method {
     if (std.ascii.eqlIgnoreCase(method, "HEAD")) return .HEAD;
     if (std.ascii.eqlIgnoreCase(method, "OPTIONS")) return .OPTIONS;
     return null;
-}
-
-/// Disable auto-follow redirects so every hop can be explicitly validated.
-fn buildRequestOptions(
-    extra_headers: []const std.http.Header,
-    connection: ?*std.http.Client.Connection,
-) std.http.Client.RequestOptions {
-    return .{
-        .extra_headers = extra_headers,
-        .redirect_behavior = .unhandled,
-        .connection = connection,
-    };
-}
-
-/// Parse headers from a JSON object string: {"Key": "Value", ...}
-/// Returns array of [2][]const u8 pairs. Caller owns memory.
-fn parseHeaders(allocator: std.mem.Allocator, headers_json: ?[]const u8) ![]const [2][]const u8 {
-    const json = headers_json orelse return &.{};
-    if (json.len < 2) return &.{};
-
-    var list: std.ArrayList([2][]const u8) = .empty;
-    errdefer {
-        for (list.items) |h| {
-            allocator.free(h[0]);
-            allocator.free(h[1]);
-        }
-        list.deinit(allocator);
-    }
-
-    // Simple JSON object parser: find "key": "value" pairs
-    var pos: usize = 0;
-    while (pos < json.len) {
-        // Find next key (quoted string)
-        const key_start = std.mem.indexOfScalarPos(u8, json, pos, '"') orelse break;
-        const key_end = std.mem.indexOfScalarPos(u8, json, key_start + 1, '"') orelse break;
-        const key = json[key_start + 1 .. key_end];
-
-        // Skip to colon and value
-        pos = key_end + 1;
-        const colon = std.mem.indexOfScalarPos(u8, json, pos, ':') orelse break;
-        pos = colon + 1;
-
-        // Skip whitespace
-        while (pos < json.len and (json[pos] == ' ' or json[pos] == '\t' or json[pos] == '\n')) : (pos += 1) {}
-
-        if (pos >= json.len or json[pos] != '"') {
-            pos += 1;
-            continue;
-        }
-        const val_start = pos;
-        const val_end = std.mem.indexOfScalarPos(u8, json, val_start + 1, '"') orelse break;
-        const value = json[val_start + 1 .. val_end];
-        pos = val_end + 1;
-
-        try list.append(allocator, .{
-            try allocator.dupe(u8, key),
-            try allocator.dupe(u8, value),
-        });
-    }
-
-    return list.toOwnedSlice(allocator);
 }
 
 /// Redact sensitive headers for display output.
@@ -682,20 +421,6 @@ test "isSensitiveHeader treats oversized names as sensitive" {
     var long_name: [300]u8 = undefined;
     @memset(long_name[0..], 'a');
     try std.testing.expect(isSensitiveHeader(long_name[0..]));
-}
-
-test "http_request disables automatic redirects" {
-    const opts = buildRequestOptions(&.{}, null);
-    try std.testing.expect(opts.redirect_behavior == .unhandled);
-    try std.testing.expect(opts.connection == null);
-}
-
-test "http_request request options keep provided connection" {
-    const fake_ptr_value = @as(usize, @alignOf(std.http.Client.Connection));
-    const fake_connection: *std.http.Client.Connection = @ptrFromInt(fake_ptr_value);
-    const opts = buildRequestOptions(&.{}, fake_connection);
-    try std.testing.expect(opts.connection != null);
-    try std.testing.expectEqual(@intFromPtr(fake_connection), @intFromPtr(opts.connection.?));
 }
 
 // ── execute-level tests ──────────────────────────────────────
@@ -884,48 +609,4 @@ test "validateMethod rejects empty string" {
 test "validateMethod rejects CONNECT TRACE" {
     try std.testing.expect(validateMethod("CONNECT") == null);
     try std.testing.expect(validateMethod("TRACE") == null);
-}
-
-test "isTlsSetupError detects TLS setup failures" {
-    try std.testing.expect(isTlsSetupError(error.TlsInitializationFailed));
-    try std.testing.expect(isTlsSetupError(error.CertificateBundleLoadFailure));
-    try std.testing.expect(!isTlsSetupError(error.EndOfStream));
-}
-
-test "buildHttpRequestErrorMessage includes TLS hint" {
-    const msg = try buildHttpRequestErrorMessage(std.testing.allocator, "HTTP request failed", error.TlsInitializationFailed);
-    defer std.testing.allocator.free(msg);
-    try std.testing.expect(std.mem.indexOf(u8, msg, "system CA certificates") != null);
-}
-
-test "duplicateTrimmedStderr trims non-empty stderr" {
-    const copied = (try duplicateTrimmedStderr(std.testing.allocator, "\n curl: (6) Could not resolve host \n")).?;
-    defer std.testing.allocator.free(copied);
-    try std.testing.expectEqualStrings("curl: (6) Could not resolve host", copied);
-}
-
-test "duplicateTrimmedStderr ignores empty stderr" {
-    try std.testing.expect((try duplicateTrimmedStderr(std.testing.allocator, "  \n\t  ")) == null);
-    try std.testing.expect((try duplicateTrimmedStderr(std.testing.allocator, null)) == null);
-}
-
-// ── parseHeaders tests ──────────────────────────────────────
-
-test "parseHeaders basic" {
-    const headers = try parseHeaders(std.testing.allocator, "{\"Content-Type\": \"application/json\"}");
-    defer {
-        for (headers) |h| {
-            std.testing.allocator.free(h[0]);
-            std.testing.allocator.free(h[1]);
-        }
-        std.testing.allocator.free(headers);
-    }
-    try std.testing.expectEqual(@as(usize, 1), headers.len);
-    try std.testing.expectEqualStrings("Content-Type", headers[0][0]);
-    try std.testing.expectEqualStrings("application/json", headers[0][1]);
-}
-
-test "parseHeaders null returns empty" {
-    const headers = try parseHeaders(std.testing.allocator, null);
-    try std.testing.expectEqual(@as(usize, 0), headers.len);
 }

--- a/src/update.zig
+++ b/src/update.zig
@@ -198,7 +198,7 @@ pub fn getLatestRelease(allocator: std.mem.Allocator) !ReleaseInfo {
     // Use curl subprocess approach (from http_util pattern)
     const result = std_compat.process.Child.run(.{
         .allocator = allocator,
-        .argv = &.{ "curl", "-sf", "--max-time", "30", url },
+        .argv = &.{ "curl", "-q", "-sf", "--proto", "=https", "--max-time", "30", url },
         .max_output_bytes = 10 * 1024 * 1024,
     }) catch |err| {
         log.err("curl failed: {}", .{err});
@@ -359,7 +359,21 @@ inline fn logDownloadToFileError(comptime fmt: []const u8, args: anytype) void {
 }
 
 fn downloadToFile(allocator: std.mem.Allocator, url: []const u8, file: *std_compat.fs.File) !usize {
-    const argv = &[_][]const u8{ "curl", "-sfL", "--max-time", "60", url };
+    // Production updates are HTTPS-only. Tests use a local file URL so they can
+    // exercise streaming deterministically without a network dependency.
+    const allowed_protocols = if (builtin.is_test) "=file,https" else "=https";
+    const argv = &[_][]const u8{
+        "curl",
+        "-q",
+        "-sfL",
+        "--proto",
+        allowed_protocols,
+        "--proto-redir",
+        allowed_protocols,
+        "--max-time",
+        "60",
+        url,
+    };
     var child = std_compat.process.Child.init(argv, allocator);
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Ignore;

--- a/src/voice.zig
+++ b/src/voice.zig
@@ -368,11 +368,15 @@ fn curlPostFromFile(
 ) ![]u8 {
     const data_arg = try std.fmt.allocPrint(allocator, "@{s}", .{file_path});
     defer allocator.free(data_arg);
+    var curl_config = try http_util.prepareProtectedCurlConfig(allocator, url, null);
+    defer curl_config.deinit();
 
     var argv_buf: [32][]const u8 = undefined;
     var argc: usize = 0;
 
     argv_buf[argc] = "curl";
+    argc += 1;
+    argv_buf[argc] = "-q";
     argc += 1;
     argv_buf[argc] = "-s";
     argc += 1;
@@ -403,7 +407,9 @@ fn curlPostFromFile(
     argc += 1;
     argv_buf[argc] = data_arg;
     argc += 1;
-    argv_buf[argc] = url;
+    argv_buf[argc] = "--config";
+    argc += 1;
+    argv_buf[argc] = curl_config.path();
     argc += 1;
 
     var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);


### PR DESCRIPTION
## Problem

On `aarch64-linux-android` (Termux), Zig 0.16's stdlib HTTP path can fail DNS resolution with `error.NameServerFailure`, while the installed curl resolves the same endpoints successfully. The original patch routed only part of the traffic through curl and did not preserve the full `std.http` request/response contract.

## What changed

- Route every buffered `ProxyHttpClient.fetch` call site through an Android curl adapter; non-Android `ProxyHttpClient.fetch` behavior remains on `std.http`.
- Preserve the exact HTTP method, request body, caller content type, status code, response headers, response-size limit, response writer, timeout, and proxy selection.
- Keep URL, proxy credentials, query tokens, and request headers out of process argv by using exclusive mode-0600 curl config/header files.
- Disable user curl config loading with first-argument `-q`, restrict protocols, suppress curl's implicit form content type, and never return or log raw curl stderr.
- Consolidate the duplicated buffered curl implementations into one executor with bounded streaming and cancellation/process-lifetime handling.
- Preserve explicit/config proxy semantics: environment proxies still honor `NO_PROXY`, while a process-wide config override cannot be silently bypassed by it.
- Follow redirects only for header-free GETs. Requests with caller headers or bodies return redirects unhandled so credentials and methods are not forwarded unsafely.
- Route the old buffered bypasses in auth, channels, vector/memory backends, and SkillForge through `ProxyHttpClient.fetch`.
- Reuse the secure executor in the HTTP request tool and API memory backend. The browser tool now returns redirects for separate validation instead of following an unvalidated redirect into a private address.
- Keep direct streaming curl URLs/proxies out of argv and ignore `.curlrc`; provider timeout arguments and safe direct-connect resolve pins are now honored.

The branch also includes the current `main` via a normal merge commit.

## Security notes

- Sensitive request data is stored only in short-lived mode-0600 files and request bodies are sent through stdin.
- Curl stderr is drained for process safety but not exposed because it can echo credentialed proxy or URL values.
- A configured HTTP/SOCKS proxy remains a separate trust boundary: curl can delegate the proxy's upstream DNS lookup even when a direct connection would use `--resolve` pinning.

## Scope boundaries

- `SseConnection` is a persistent, long-lived transport and cannot use the buffered adapter. Signal's supported default local daemon path does not need DNS; a remote Signal SSE hostname on Android still needs a dedicated persistent curl transport.
- Provider paths that perform the SSRF-safe libc DNS preflight before curl still fail closed on affected Termux systems when that preflight cannot resolve the host. This patch does not bypass that security check; an Android-safe resolver/pinning design is separate work.
- The current revision was not smoke-tested on an Android device in this review environment. The original reporter's earlier revision was tested on Termux, but the hardened revision still needs target-device confirmation.

## Validation

- `zig fmt --check src/`
- `git diff --check`
- `zig build test --summary all` — 13/13 steps, 7363 passed, 9 skipped, 0 failures/leaks
- `zig build -Doptimize=ReleaseSmall`
- Pre-push hook reran the full test suite successfully

An Android cross-build was not available locally because the required Android NDK/Zig libc sysroot file was not installed.

## Related upstream

- https://github.com/ziglang/zig/issues/22031
- https://github.com/ziglang/zig/issues/26016
