### PR TITLE
feat(streaming): native tool calls during SSE streaming

### DIFF
--- a/src/agent/root.zig
+++ b/src/agent/root.zig
@@ -2022,7 +2022,10 @@ pub const Agent = struct {
             defer prompt_tools_arena.deinit();
             const prompt_tools = try self.filterToolsForPromptText(prompt_tools_arena.allocator());
             const prompt_is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
-            const prompt_native_tools_enabled = !prompt_is_streaming and self.provider.supportsNativeTools();
+            const prompt_native_tools_enabled = if (prompt_is_streaming)
+                self.provider.supportsStreamingNativeTools()
+            else
+                self.provider.supportsNativeTools();
 
             const capabilities_section = capabilities_mod.buildPromptSection(
                 self.allocator,
@@ -2200,7 +2203,10 @@ pub const Agent = struct {
 
             const timer_start = std_compat.time.milliTimestamp();
             const is_streaming = self.stream_callback != null and self.stream_ctx != null and self.provider.supportsStreaming();
-            const native_tools_enabled = !is_streaming and self.provider.supportsNativeTools();
+            const native_tools_enabled = if (is_streaming)
+                self.provider.supportsStreamingNativeTools()
+            else
+                self.provider.supportsNativeTools();
             const include_reasoning = self.reasoning_mode != .off;
 
             // Filter tool specs for this turn (arena-owned; may be self.tool_specs directly if no groups).
@@ -2216,7 +2222,7 @@ pub const Agent = struct {
                 turn_max_tokens,
             );
 
-            // Call provider: streaming (no retries, no native tools) or blocking with retry
+            // Call provider: streaming (native tools only when parser-supported) or blocking with retry
             var response: ChatResponse = undefined;
             var response_attempt: u32 = 1;
             providers.clearLastApiErrorDetail();
@@ -2231,7 +2237,7 @@ pub const Agent = struct {
                         .model = turn_model_name,
                         .temperature = self.temperature,
                         .max_tokens = request_max_tokens,
-                        .tools = null,
+                        .tools = if (native_tools_enabled) turn_tool_specs else null,
                         .timeout_secs = self.message_timeout_secs,
                         .reasoning_effort = self.reasoning_effort,
                         .include_reasoning = include_reasoning,
@@ -2268,7 +2274,7 @@ pub const Agent = struct {
                                 .model = turn_model_name,
                                 .temperature = self.temperature,
                                 .max_tokens = retry_max_tokens,
-                                .tools = null,
+                                .tools = if (native_tools_enabled) turn_tool_specs else null,
                                 .timeout_secs = self.message_timeout_secs,
                                 .reasoning_effort = self.reasoning_effort,
                                 .include_reasoning = include_reasoning,
@@ -2291,7 +2297,7 @@ pub const Agent = struct {
                 response = ChatResponse{
                     .content = stream_result.content,
                     .reasoning_content = stream_result.reasoning_content,
-                    .tool_calls = &.{},
+                    .tool_calls = stream_result.tool_calls,
                     .usage = stream_result.usage,
                     .model = stream_result.model,
                 };
@@ -10889,6 +10895,230 @@ test "Agent system prompt keeps parameters when streaming disables native tool s
     try std.testing.expect(std.mem.indexOf(u8, captured, "**shell**: shell") != null);
     try std.testing.expect(std.mem.indexOf(u8, captured, "Parameters: `{}`") != null);
     try std.testing.expect(std.mem.indexOf(u8, captured, "mcp_secret_lookup") == null);
+}
+
+test "Agent system prompt omits parameters when streaming native tools are supported" {
+    const StreamingNativeToolCapture = struct {
+        captured_system: ?[]u8 = null,
+        saw_tools: bool = false,
+        capture_alloc: std.mem.Allocator,
+
+        fn chatWithSystem(_: *anyopaque, allocator_: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator_.dupe(u8, "ok");
+        }
+
+        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            return error.ShouldNotUseBlockingChat;
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn supportsStreaming(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn supportsStreamingNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn streamChat(
+            ptr: *anyopaque,
+            allocator_: std.mem.Allocator,
+            request: providers.ChatRequest,
+            model: []const u8,
+            _: f64,
+            callback: providers.StreamCallback,
+            callback_ctx: *anyopaque,
+        ) anyerror!providers.StreamChatResult {
+            try std.testing.expect(request.tools != null);
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.saw_tools = request.tools.?.len > 0;
+            for (request.messages) |msg| {
+                if (msg.role == .system) {
+                    if (self.captured_system) |old| self.capture_alloc.free(old);
+                    self.captured_system = try self.capture_alloc.dupe(u8, msg.content);
+                    break;
+                }
+            }
+            callback(callback_ctx, providers.StreamChunk.textDelta("ok"));
+            callback(callback_ctx, providers.StreamChunk.finalChunk());
+            return .{
+                .content = try allocator_.dupe(u8, "ok"),
+                .model = try allocator_.dupe(u8, model),
+            };
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "streaming-native-tool-capture";
+        }
+
+        fn deinitFn(_: *anyopaque) void {}
+    };
+
+    const allocator = std.testing.allocator;
+    var provider_state = StreamingNativeToolCapture{ .capture_alloc = allocator };
+    defer if (provider_state.captured_system) |captured| allocator.free(captured);
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = StreamingNativeToolCapture.chatWithSystem,
+        .chat = StreamingNativeToolCapture.chat,
+        .supportsNativeTools = StreamingNativeToolCapture.supportsNativeTools,
+        .getName = StreamingNativeToolCapture.getName,
+        .deinit = StreamingNativeToolCapture.deinitFn,
+        .supports_streaming = StreamingNativeToolCapture.supportsStreaming,
+        .supports_streaming_native_tools = StreamingNativeToolCapture.supportsStreamingNativeTools,
+        .stream_chat = StreamingNativeToolCapture.streamChat,
+    };
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &provider_vtable };
+
+    const runtime_tools = [_]Tool{
+        try makeMockFilterTool(allocator, "shell"),
+        try makeMockFilterTool(allocator, "mcp_secret_lookup"),
+    };
+    defer for (runtime_tools) |t| freeMockFilterTool(t, allocator);
+
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .default_model = "openai/gpt-4.1-mini",
+        .allocator = allocator,
+    };
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, provider, &runtime_tools, null, noop.observer());
+    defer agent.deinit();
+    agent.tool_filter_groups = &.{
+        .{ .mode = .dynamic, .tools = &.{"mcp_secret_*"}, .keywords = &.{"secret"} },
+    };
+
+    const StreamSink = struct {
+        fn onChunk(_: *anyopaque, _: providers.StreamChunk) void {}
+    };
+    var stream_ctx: u8 = 0;
+    agent.stream_callback = StreamSink.onChunk;
+    agent.stream_ctx = @ptrCast(&stream_ctx);
+
+    const response = try agent.turn("hello");
+    defer allocator.free(response);
+
+    try std.testing.expect(provider_state.saw_tools);
+    try std.testing.expect(provider_state.captured_system != null);
+    const captured = provider_state.captured_system.?;
+    try std.testing.expect(std.mem.indexOf(u8, captured, "**shell**: shell") != null);
+    try std.testing.expect(std.mem.indexOf(u8, captured, "Parameters: `{}`") == null);
+    try std.testing.expect(std.mem.indexOf(u8, captured, "mcp_secret_lookup") == null);
+}
+
+test "Agent executes native tool calls returned from streaming provider" {
+    const StreamingToolCallProvider = struct {
+        calls: usize = 0,
+
+        fn chatWithSystem(_: *anyopaque, allocator_: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return allocator_.dupe(u8, "ok");
+        }
+
+        fn chat(_: *anyopaque, _: std.mem.Allocator, _: providers.ChatRequest, _: []const u8, _: f64) anyerror!providers.ChatResponse {
+            return error.ShouldNotUseBlockingChat;
+        }
+
+        fn supportsNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn supportsStreaming(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn supportsStreamingNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+
+        fn streamChat(
+            ptr: *anyopaque,
+            allocator_: std.mem.Allocator,
+            request: providers.ChatRequest,
+            model: []const u8,
+            _: f64,
+            callback: providers.StreamCallback,
+            callback_ctx: *anyopaque,
+        ) anyerror!providers.StreamChatResult {
+            try std.testing.expect(request.tools != null);
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.calls += 1;
+
+            if (self.calls == 1) {
+                const tool_calls = try allocator_.alloc(providers.ToolCall, 1);
+                tool_calls[0] = .{
+                    .id = try allocator_.dupe(u8, "call_stream_shell"),
+                    .name = try allocator_.dupe(u8, "shell"),
+                    .arguments = try allocator_.dupe(u8, "{}"),
+                };
+                callback(callback_ctx, providers.StreamChunk.textDelta("calling shell"));
+                callback(callback_ctx, providers.StreamChunk.finalChunk());
+                return .{
+                    .content = try allocator_.dupe(u8, "calling shell"),
+                    .tool_calls = tool_calls,
+                    .model = try allocator_.dupe(u8, model),
+                };
+            }
+
+            callback(callback_ctx, providers.StreamChunk.textDelta("done"));
+            callback(callback_ctx, providers.StreamChunk.finalChunk());
+            return .{
+                .content = try allocator_.dupe(u8, "done"),
+                .model = try allocator_.dupe(u8, model),
+            };
+        }
+
+        fn getName(_: *anyopaque) []const u8 {
+            return "streaming-tool-call-provider";
+        }
+
+        fn deinitFn(_: *anyopaque) void {}
+    };
+
+    const allocator = std.testing.allocator;
+    var provider_state = StreamingToolCallProvider{};
+    const provider_vtable = Provider.VTable{
+        .chatWithSystem = StreamingToolCallProvider.chatWithSystem,
+        .chat = StreamingToolCallProvider.chat,
+        .supportsNativeTools = StreamingToolCallProvider.supportsNativeTools,
+        .getName = StreamingToolCallProvider.getName,
+        .deinit = StreamingToolCallProvider.deinitFn,
+        .supports_streaming = StreamingToolCallProvider.supportsStreaming,
+        .supports_streaming_native_tools = StreamingToolCallProvider.supportsStreamingNativeTools,
+        .stream_chat = StreamingToolCallProvider.streamChat,
+    };
+    const provider = Provider{ .ptr = @ptrCast(&provider_state), .vtable = &provider_vtable };
+
+    const runtime_tools = [_]Tool{
+        try makeMockFilterTool(allocator, "shell"),
+    };
+    defer for (runtime_tools) |t| freeMockFilterTool(t, allocator);
+
+    var cfg = Config{
+        .workspace_dir = "/tmp",
+        .config_path = "/tmp/config.json",
+        .default_model = "openai/gpt-4.1-mini",
+        .allocator = allocator,
+    };
+    cfg.agent.max_tool_iterations = 2;
+    var noop = observability.NoopObserver{};
+    var agent = try Agent.fromConfig(allocator, &cfg, provider, &runtime_tools, null, noop.observer());
+    defer agent.deinit();
+
+    const StreamSink = struct {
+        fn onChunk(_: *anyopaque, _: providers.StreamChunk) void {}
+    };
+    var stream_ctx: u8 = 0;
+    agent.stream_callback = StreamSink.onChunk;
+    agent.stream_ctx = @ptrCast(&stream_ctx);
+
+    const response = try agent.turn("call shell");
+    defer allocator.free(response);
+
+    try std.testing.expectEqual(@as(usize, 2), provider_state.calls);
+    try std.testing.expectEqualStrings("done", response);
 }
 
 test "buildProviderMessagesForTurn adds priority hint without mutating history" {

--- a/src/providers/anthropic.zig
+++ b/src/providers/anthropic.zig
@@ -1056,6 +1056,14 @@ test "supportsStreamingImpl returns true" {
     try std.testing.expect(prov.supportsStreaming());
 }
 
+test "supportsStreamingNativeTools returns false until input_json_delta is parsed" {
+    var p = AnthropicProvider.init(std.testing.allocator, "key", null);
+    const prov = p.provider();
+    try std.testing.expect(prov.supportsNativeTools());
+    try std.testing.expect(prov.supportsStreaming());
+    try std.testing.expect(!prov.supportsStreamingNativeTools());
+}
+
 test "vtable stream_chat is not null" {
     try std.testing.expect(AnthropicProvider.vtable.stream_chat != null);
 }

--- a/src/providers/compatible.zig
+++ b/src/providers/compatible.zig
@@ -1144,6 +1144,7 @@ pub const OpenAiCompatibleProvider = struct {
         .deinit = deinitImpl,
         .stream_chat = streamChatImpl,
         .supports_streaming = supportsStreamingImpl,
+        .supports_streaming_native_tools = supportsStreamingNativeToolsImpl,
     };
 
     fn buildSingleTurnMessages(
@@ -1301,6 +1302,11 @@ pub const OpenAiCompatibleProvider = struct {
     fn supportsStreamingImpl(ptr: *anyopaque) bool {
         const self: *OpenAiCompatibleProvider = @ptrCast(@alignCast(ptr));
         return !self.disable_streaming and self.api_mode != .responses;
+    }
+
+    fn supportsStreamingNativeToolsImpl(ptr: *anyopaque) bool {
+        const self: *OpenAiCompatibleProvider = @ptrCast(@alignCast(ptr));
+        return self.native_tools and supportsStreamingImpl(ptr);
     }
 
     fn chatWithSystemImpl(
@@ -2279,6 +2285,27 @@ test "supportsNativeTools returns true for compatible" {
     var p = OpenAiCompatibleProvider.init(std.testing.allocator, "test", "https://example.com", "key", .bearer, null);
     const prov = p.provider();
     try std.testing.expect(prov.supportsNativeTools());
+}
+
+test "supportsStreamingNativeTools follows native tools and streaming" {
+    var p = OpenAiCompatibleProvider.init(std.testing.allocator, "test", "https://example.com", "key", .bearer, null);
+    var prov = p.provider();
+    try std.testing.expect(prov.supportsNativeTools());
+    try std.testing.expect(prov.supportsStreaming());
+    try std.testing.expect(prov.supportsStreamingNativeTools());
+
+    p.native_tools = false;
+    prov = p.provider();
+    try std.testing.expect(!prov.supportsNativeTools());
+    try std.testing.expect(prov.supportsStreaming());
+    try std.testing.expect(!prov.supportsStreamingNativeTools());
+
+    p.native_tools = true;
+    p.disable_streaming = true;
+    prov = p.provider();
+    try std.testing.expect(prov.supportsNativeTools());
+    try std.testing.expect(!prov.supportsStreaming());
+    try std.testing.expect(!prov.supportsStreamingNativeTools());
 }
 
 test "capNonStreamingMaxTokens caps request max_tokens above provider limit" {

--- a/src/providers/openai.zig
+++ b/src/providers/openai.zig
@@ -217,6 +217,7 @@ pub const OpenAiProvider = struct {
         .deinit = deinitImpl,
         .stream_chat = streamChatImpl,
         .supports_streaming = supportsStreamingImpl,
+        .supports_streaming_native_tools = supportsStreamingNativeToolsImpl,
     };
 
     fn streamChatImpl(
@@ -259,6 +260,10 @@ pub const OpenAiProvider = struct {
     }
 
     fn supportsStreamingImpl(_: *anyopaque) bool {
+        return true;
+    }
+
+    fn supportsStreamingNativeToolsImpl(_: *anyopaque) bool {
         return true;
     }
 
@@ -528,6 +533,14 @@ test "supportsNativeTools returns true" {
     var p = OpenAiProvider.init(std.testing.allocator, "key", null, null);
     const prov = p.provider();
     try std.testing.expect(prov.supportsNativeTools());
+}
+
+test "supportsStreamingNativeTools returns true" {
+    var p = OpenAiProvider.init(std.testing.allocator, "key", null, null);
+    const prov = p.provider();
+    try std.testing.expect(prov.supportsStreaming());
+    try std.testing.expect(prov.supportsNativeTools());
+    try std.testing.expect(prov.supportsStreamingNativeTools());
 }
 
 test "parseTextResponse multiple choices returns first" {

--- a/src/providers/reliable.zig
+++ b/src/providers/reliable.zig
@@ -369,6 +369,7 @@ pub const ReliableProvider = struct {
         .supports_vision = supportsVisionImpl,
         .supports_vision_for_model = supportsVisionForModelImpl,
         .supports_streaming = supportsStreamingImpl,
+        .supports_streaming_native_tools = supportsStreamingNativeToolsImpl,
         .stream_chat = streamChatImpl,
         .getName = getNameImpl,
         .deinit = deinitImpl,
@@ -604,6 +605,11 @@ pub const ReliableProvider = struct {
             if (entry.provider.supportsStreaming()) return true;
         }
         return false;
+    }
+
+    fn supportsStreamingNativeToolsImpl(ptr: *anyopaque) bool {
+        const self: *ReliableProvider = @ptrCast(@alignCast(ptr));
+        return self.inner.supportsStreamingNativeTools();
     }
 
     fn streamChatImpl(

--- a/src/providers/root.zig
+++ b/src/providers/root.zig
@@ -272,6 +272,7 @@ pub const StreamCallback = *const fn (ctx: *anyopaque, chunk: StreamChunk) void;
 pub const StreamChatResult = struct {
     content: ?[]const u8 = null,
     reasoning_content: ?[]const u8 = null,
+    tool_calls: []const ToolCall = &.{},
     usage: TokenUsage = .{},
     model: []const u8 = "",
 };
@@ -304,6 +305,8 @@ pub fn emitChatResponseAsStream(
 ) StreamChatResult {
     const reasoning_content = response.reasoning_content;
     response.reasoning_content = null;
+    const tool_calls = response.tool_calls;
+    response.tool_calls = &.{};
     if (response.content) |content| {
         if (content.len > 0) {
             callback(callback_ctx, StreamChunk.textDelta(content));
@@ -314,6 +317,7 @@ pub fn emitChatResponseAsStream(
     return .{
         .content = response.content,
         .reasoning_content = reasoning_content,
+        .tool_calls = tool_calls,
         .usage = response.usage,
         .model = response.model,
     };
@@ -409,6 +413,8 @@ pub const Provider = struct {
         chat_with_tools: ?*const fn (ptr: *anyopaque, allocator: std.mem.Allocator, req: ChatRequest) anyerror!ChatResponse = null,
         /// Optional: returns true if provider supports streaming. Default: false.
         supports_streaming: ?*const fn (ptr: *anyopaque) bool = null,
+        /// Optional: returns true if streaming responses can return native tool calls.
+        supports_streaming_native_tools: ?*const fn (ptr: *anyopaque) bool = null,
         /// Optional: returns true if provider supports vision/image input. Default: false.
         supports_vision: ?*const fn (ptr: *anyopaque) bool = null,
         /// Optional: returns true if provider supports vision for a specific model.
@@ -470,6 +476,12 @@ pub const Provider = struct {
         return false;
     }
 
+    /// Returns true if provider can parse native tool calls from streaming responses.
+    pub fn supportsStreamingNativeTools(self: Provider) bool {
+        if (self.vtable.supports_streaming_native_tools) |f| return f(self.ptr);
+        return false;
+    }
+
     /// Returns true if provider supports vision/image input.
     pub fn supportsVision(self: Provider) bool {
         if (self.vtable.supports_vision) |f| return f(self.ptr);
@@ -516,6 +528,7 @@ pub fn assertProviderInterface(comptime T: type) void {
     _ = vt.chat;
     _ = vt.supportsNativeTools;
     _ = vt.supports_vision;
+    _ = vt.supports_streaming_native_tools;
     _ = vt.getName;
     _ = vt.deinit;
 }
@@ -644,6 +657,35 @@ test "provider supportsStreaming returns false when vtable is null" {
     };
     const provider = Provider{ .ptr = @ptrCast(&dummy), .vtable = &vtable };
     try std.testing.expect(!provider.supportsStreaming());
+}
+
+test "provider supportsStreamingNativeTools returns false when vtable is null" {
+    const DummyProvider = struct {
+        fn chatWithSystem(_: *anyopaque, _: std.mem.Allocator, _: ?[]const u8, _: []const u8, _: []const u8, _: f64) anyerror![]const u8 {
+            return "";
+        }
+        fn chat(_: *anyopaque, _: std.mem.Allocator, _: ChatRequest, _: []const u8, _: f64) anyerror!ChatResponse {
+            return .{};
+        }
+        fn supNativeTools(_: *anyopaque) bool {
+            return true;
+        }
+        fn getName(_: *anyopaque) []const u8 {
+            return "dummy";
+        }
+        fn deinitFn(_: *anyopaque) void {}
+    };
+    var dummy: u8 = 0;
+    const vtable = Provider.VTable{
+        .chatWithSystem = DummyProvider.chatWithSystem,
+        .chat = DummyProvider.chat,
+        .supportsNativeTools = DummyProvider.supNativeTools,
+        .getName = DummyProvider.getName,
+        .deinit = DummyProvider.deinitFn,
+    };
+    const provider = Provider{ .ptr = @ptrCast(&dummy), .vtable = &vtable };
+    try std.testing.expect(provider.supportsNativeTools());
+    try std.testing.expect(!provider.supportsStreamingNativeTools());
 }
 
 test "provider supportsVision returns false when vtable supports_vision is null" {
@@ -820,6 +862,7 @@ test "ChatResponse reasoning_content can be set" {
 test "StreamChatResult defaults" {
     const result = StreamChatResult{};
     try std.testing.expect(result.content == null);
+    try std.testing.expectEqual(@as(usize, 0), result.tool_calls.len);
     try std.testing.expect(result.usage.prompt_tokens == 0);
     try std.testing.expect(result.usage.completion_tokens == 0);
     try std.testing.expectEqualStrings("", result.model);
@@ -893,6 +936,14 @@ test "emitChatResponseAsStream frees unused chat response fields" {
     defer if (result.content) |content| allocator.free(content);
     defer if (result.reasoning_content) |reasoning| allocator.free(reasoning);
     defer if (result.model.len > 0) allocator.free(result.model);
+    defer {
+        for (result.tool_calls) |tc| {
+            allocator.free(tc.id);
+            allocator.free(tc.name);
+            allocator.free(tc.arguments);
+        }
+        allocator.free(result.tool_calls);
+    }
 
     try std.testing.expectEqual(@as(usize, 1), ctx.text_count);
     try std.testing.expect(ctx.saw_final);
@@ -902,6 +953,10 @@ test "emitChatResponseAsStream frees unused chat response fields" {
     try std.testing.expectEqualStrings("hello", result.content.?);
     try std.testing.expectEqualStrings("private reasoning", result.reasoning_content.?);
     try std.testing.expectEqualStrings("test-model", result.model);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.len);
+    try std.testing.expectEqualStrings("tool-1", result.tool_calls[0].id);
+    try std.testing.expectEqualStrings("read_file", result.tool_calls[0].name);
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", result.tool_calls[0].arguments);
 }
 
 test "Provider.streamChat fallback emits single chunk and final" {

--- a/src/providers/router.zig
+++ b/src/providers/router.zig
@@ -158,6 +158,7 @@ pub const RouterProvider = struct {
         .supports_vision = supportsVisionImpl,
         .supports_vision_for_model = supportsVisionForModelImpl,
         .supports_streaming = supportsStreamingImpl,
+        .supports_streaming_native_tools = supportsStreamingNativeToolsImpl,
         .stream_chat = streamChatImpl,
         .getName = getNameImpl,
         .deinit = deinitImpl,
@@ -244,6 +245,14 @@ pub const RouterProvider = struct {
         const provider_idx = resolved[0];
         if (provider_idx >= self.providers.len) return false;
         return self.providers[provider_idx].supportsStreaming();
+    }
+
+    fn supportsStreamingNativeToolsImpl(ptr: *anyopaque) bool {
+        const self: *RouterProvider = @ptrCast(@alignCast(ptr));
+        const resolved = self.resolve(self.default_model);
+        const provider_idx = resolved[0];
+        if (provider_idx >= self.providers.len) return false;
+        return self.providers[provider_idx].supportsStreamingNativeTools();
     }
 
     fn streamChatImpl(

--- a/src/providers/sse.zig
+++ b/src/providers/sse.zig
@@ -41,6 +41,179 @@ fn finalizeStreamResult(
     };
 }
 
+const ToolCallSlot = struct {
+    index: usize,
+    id: ?[]u8 = null,
+    name: ?[]u8 = null,
+    arguments: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn deinit(self: *ToolCallSlot, allocator: std.mem.Allocator) void {
+        if (self.id) |id| allocator.free(id);
+        if (self.name) |name| allocator.free(name);
+        self.arguments.deinit(allocator);
+        self.* = .{ .index = self.index };
+    }
+};
+
+const ToolCallAccumulator = struct {
+    slots: std.ArrayListUnmanaged(ToolCallSlot) = .empty,
+
+    fn deinit(self: *ToolCallAccumulator, allocator: std.mem.Allocator) void {
+        for (self.slots.items) |*slot| {
+            slot.deinit(allocator);
+        }
+        self.slots.deinit(allocator);
+        self.* = .{};
+    }
+
+    fn ensureSlot(self: *ToolCallAccumulator, allocator: std.mem.Allocator, index: usize) !*ToolCallSlot {
+        for (self.slots.items) |*slot| {
+            if (slot.index == index) return slot;
+        }
+        try self.slots.append(allocator, .{ .index = index });
+        return &self.slots.items[self.slots.items.len - 1];
+    }
+
+    fn sortSlotsByIndex(self: *ToolCallAccumulator) void {
+        var i: usize = 1;
+        while (i < self.slots.items.len) : (i += 1) {
+            var j = i;
+            while (j > 0 and self.slots.items[j - 1].index > self.slots.items[j].index) : (j -= 1) {
+                std.mem.swap(ToolCallSlot, &self.slots.items[j - 1], &self.slots.items[j]);
+            }
+        }
+    }
+
+    fn appendFromJsonPayload(self: *ToolCallAccumulator, allocator: std.mem.Allocator, json_str: []const u8) !void {
+        const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_str, .{}) catch return;
+        defer parsed.deinit();
+
+        if (parsed.value != .object) return;
+        const choices = parsed.value.object.get("choices") orelse return;
+        if (choices != .array) return;
+
+        for (choices.array.items) |choice| {
+            if (choice != .object) continue;
+            const delta = choice.object.get("delta") orelse continue;
+            if (delta != .object) continue;
+            const tool_calls = delta.object.get("tool_calls") orelse continue;
+            if (tool_calls != .array) continue;
+
+            for (tool_calls.array.items, 0..) |tool_call, fallback_index| {
+                if (tool_call != .object) continue;
+                const index = if (tool_call.object.get("index")) |idx|
+                    switch (idx) {
+                        .integer => |n| @as(usize, @intCast(@max(0, n))),
+                        else => fallback_index,
+                    }
+                else
+                    fallback_index;
+
+                const slot = try self.ensureSlot(allocator, index);
+
+                if (tool_call.object.get("id")) |id_val| {
+                    if (id_val == .string and id_val.string.len > 0 and slot.id == null) {
+                        slot.id = try allocator.dupe(u8, id_val.string);
+                    }
+                }
+
+                const function = tool_call.object.get("function") orelse continue;
+                if (function != .object) continue;
+
+                if (function.object.get("name")) |name_val| {
+                    if (name_val == .string and name_val.string.len > 0) {
+                        if (slot.name) |old| allocator.free(old);
+                        slot.name = try allocator.dupe(u8, name_val.string);
+                    }
+                }
+
+                if (function.object.get("arguments")) |args_val| {
+                    if (args_val == .string and args_val.string.len > 0) {
+                        try slot.arguments.appendSlice(allocator, args_val.string);
+                    }
+                }
+            }
+        }
+    }
+
+    fn toOwnedToolCalls(self: *ToolCallAccumulator, allocator: std.mem.Allocator) ![]const root.ToolCall {
+        self.sortSlotsByIndex();
+
+        var valid_count: usize = 0;
+        for (self.slots.items) |slot| {
+            if (slot.name) |name| {
+                if (name.len > 0) valid_count += 1;
+            }
+        }
+        if (valid_count == 0) return &.{};
+
+        var calls = try allocator.alloc(root.ToolCall, valid_count);
+        var out_i: usize = 0;
+        errdefer {
+            for (calls[0..out_i]) |tc| {
+                allocator.free(tc.id);
+                allocator.free(tc.name);
+                allocator.free(tc.arguments);
+            }
+            allocator.free(calls);
+        }
+
+        for (self.slots.items) |slot| {
+            const name = slot.name orelse continue;
+            if (name.len == 0) continue;
+
+            calls[out_i] = blk: {
+                const id = if (slot.id) |id_value|
+                    try allocator.dupe(u8, id_value)
+                else
+                    try std.fmt.allocPrint(allocator, "call_{d}", .{slot.index});
+                errdefer allocator.free(id);
+
+                const owned_name = try allocator.dupe(u8, name);
+                errdefer allocator.free(owned_name);
+
+                const arguments = if (slot.arguments.items.len > 0)
+                    try allocator.dupe(u8, slot.arguments.items)
+                else
+                    try allocator.dupe(u8, "{}");
+                errdefer allocator.free(arguments);
+
+                break :blk .{
+                    .id = id,
+                    .name = owned_name,
+                    .arguments = arguments,
+                };
+            };
+            out_i += 1;
+        }
+
+        return calls;
+    }
+};
+
+fn finalizeStreamResultWithToolCalls(
+    allocator: std.mem.Allocator,
+    accumulated: []const u8,
+    stream_usage: ?root.TokenUsage,
+    tool_call_accumulator: *ToolCallAccumulator,
+) !root.StreamChatResult {
+    var result = try finalizeStreamResult(allocator, accumulated, stream_usage);
+    errdefer {
+        if (result.content) |content| allocator.free(content);
+        if (result.reasoning_content) |reasoning| allocator.free(reasoning);
+        if (result.model.len > 0) allocator.free(result.model);
+        for (result.tool_calls) |tc| {
+            allocator.free(tc.id);
+            allocator.free(tc.name);
+            allocator.free(tc.arguments);
+        }
+        if (result.tool_calls.len > 0) allocator.free(result.tool_calls);
+    }
+
+    result.tool_calls = try tool_call_accumulator.toOwnedToolCalls(allocator);
+    return result;
+}
+
 fn parseCurlVersionComponent(component: []const u8) ?u32 {
     var end: usize = 0;
     while (end < component.len and std.ascii.isDigit(component[end])) : (end += 1) {}
@@ -183,20 +356,7 @@ fn appendDeltaContent(
 /// - `data: {JSON}` → extracts `choices[0].delta.content` → `.delta`
 /// - Empty lines, comments (`:`) → `.skip`
 pub fn parseSseLine(allocator: std.mem.Allocator, line: []const u8) !SseLineResult {
-    const trimmed = std_compat.mem.trimRight(u8, line, "\r");
-
-    if (trimmed.len == 0) return .skip;
-    if (trimmed[0] == ':') return .skip;
-
-    // SSE uses "data:" with an optional single leading space before the value.
-    const prefix = "data:";
-    if (!std.mem.startsWith(u8, trimmed, prefix)) return .skip;
-
-    const data = if (trimmed.len > prefix.len and trimmed[prefix.len] == ' ')
-        trimmed[prefix.len + 1 ..]
-    else
-        trimmed[prefix.len..];
-
+    const data = extractSseDataPayload(line) orelse return .skip;
     if (data.len == 0) return .skip;
 
     if (std.mem.eql(u8, data, "[DONE]")) return .done;
@@ -207,6 +367,32 @@ pub fn parseSseLine(allocator: std.mem.Allocator, line: []const u8) !SseLineResu
         return .skip;
     };
     return .{ .delta = content };
+}
+
+fn extractSseDataPayload(line: []const u8) ?[]const u8 {
+    const trimmed = std_compat.mem.trimRight(u8, line, "\r");
+
+    if (trimmed.len == 0) return null;
+    if (trimmed[0] == ':') return null;
+
+    // SSE uses "data:" with an optional single leading space before the value.
+    const prefix = "data:";
+    if (!std.mem.startsWith(u8, trimmed, prefix)) return null;
+
+    return if (trimmed.len > prefix.len and trimmed[prefix.len] == ' ')
+        trimmed[prefix.len + 1 ..]
+    else
+        trimmed[prefix.len..];
+}
+
+fn accumulateToolCallsFromSseLine(
+    accumulator: *ToolCallAccumulator,
+    allocator: std.mem.Allocator,
+    line: []const u8,
+) !void {
+    const data = extractSseDataPayload(line) orelse return;
+    if (std.mem.eql(u8, data, "[DONE]")) return;
+    try accumulator.appendFromJsonPayload(allocator, data);
 }
 
 /// Extract `usage` object from an OpenAI-compatible streaming chunk.
@@ -420,7 +606,7 @@ pub fn curlStream(
     argc += 1;
 
     if (log_enabled) {
-        debug_log.info("curl argc={d}, body_len={d}, header_file={}", .{ argc, body.len, prepared_headers.uses_temp_file });
+        debug_log.debug("curl argc={d}, body_len={d}, header_file={}", .{ argc, body.len, prepared_headers.uses_temp_file });
     }
 
     var child = std_compat.process.Child.init(argv_buf[0..argc], allocator);
@@ -429,12 +615,12 @@ pub fn curlStream(
     child.stderr_behavior = .Ignore;
 
     if (log_enabled) {
-        debug_log.info("spawning curl process...", .{});
+        debug_log.debug("spawning curl process...", .{});
     }
     try child.spawn();
     if (log_enabled) {
         const pid: i64 = if (@import("builtin").os.tag == .windows) @intCast(@intFromPtr(child.id)) else child.id;
-        debug_log.info("curl process spawned, pid={d}", .{pid});
+        debug_log.debug("curl process spawned, pid={d}", .{pid});
     }
 
     if (child.stdin) |stdin_file| {
@@ -466,30 +652,32 @@ pub fn curlStream(
     var total_stdout: usize = 0;
     var stream_usage: ?root.TokenUsage = null;
     var in_reasoning = false;
+    var tool_call_accumulator = ToolCallAccumulator{};
+    defer tool_call_accumulator.deinit(allocator);
 
     outer: while (true) {
         const n = stdout_file.read(&read_buf) catch |err| {
             if (log_enabled) {
-                debug_log.info("stdout read error: {}", .{err});
+                debug_log.debug("stdout read error: {}", .{err});
             }
             break;
         };
         if (n == 0) {
             if (log_enabled) {
-                debug_log.info("stdout read returned 0 bytes (EOF)", .{});
+                debug_log.debug("stdout read returned 0 bytes (EOF)", .{});
             }
             break;
         }
         total_stdout += n;
 
         if (log_enabled) {
-            debug_log.info("stdout read {d} bytes", .{n});
+            debug_log.debug("stdout read {d} bytes", .{n});
         }
 
         // Check if this is JSON (starts with '{')
         if (total_stdout == n and read_buf[0] == '{') {
             if (log_enabled) {
-                debug_log.info("Detected JSON response, not SSE", .{});
+                debug_log.debug("Detected JSON response, not SSE", .{});
             }
             // This is a JSON error, not SSE
             const json_response = try allocator.dupe(u8, read_buf[0..n]);
@@ -514,8 +702,9 @@ pub fn curlStream(
         for (read_buf[0..n]) |byte| {
             if (byte == '\n') {
                 if (log_enabled) {
-                    debug_log.info("parsing SSE line: len={d}", .{line_buf.items.len});
+                    debug_log.debug("parsing SSE line: len={d}", .{line_buf.items.len});
                 }
+                try accumulateToolCallsFromSseLine(&tool_call_accumulator, allocator, line_buf.items);
                 const result = parseSseLine(allocator, line_buf.items) catch {
                     line_buf.clearRetainingCapacity();
                     continue;
@@ -529,7 +718,7 @@ pub fn curlStream(
                     .usage => |u| stream_usage = u,
                     .done => {
                         if (log_enabled) {
-                            debug_log.info("SSE stream done", .{});
+                            debug_log.debug("SSE stream done", .{});
                         }
                         saw_done = true;
                         break :outer;
@@ -543,11 +732,12 @@ pub fn curlStream(
     }
 
     if (log_enabled) {
-        debug_log.info("stdout stream ended, saw_done={}, accumulated_len={d}, total_stdout={d}", .{ saw_done, accumulated.items.len, total_stdout });
+        debug_log.debug("stdout stream ended, saw_done={}, accumulated_len={d}, total_stdout={d}", .{ saw_done, accumulated.items.len, total_stdout });
     }
 
     // Parse a trailing line when the stream ends without a final '\n'.
     if (!saw_done and line_buf.items.len > 0) {
+        try accumulateToolCallsFromSseLine(&tool_call_accumulator, allocator, line_buf.items);
         const trailing = parseSseLine(allocator, line_buf.items) catch null;
         line_buf.clearRetainingCapacity();
         if (trailing) |result| {
@@ -568,12 +758,12 @@ pub fn curlStream(
         const n = stdout_file.read(&read_buf) catch break;
         if (n == 0) break;
         if (log_enabled) {
-            debug_log.info("drained {d} more stdout bytes", .{n});
+            debug_log.debug("drained {d} more stdout bytes", .{n});
         }
     }
 
     if (log_enabled) {
-        debug_log.info("waiting for curl process to exit...", .{});
+        debug_log.debug("waiting for curl process to exit...", .{});
     }
     const term = child.wait() catch |err| {
         log.err("curlStream child.wait failed: {}", .{err});
@@ -581,12 +771,12 @@ pub fn curlStream(
             log.warn("curlStream proceeding despite wait failure after partial stream output", .{});
             try closeReasoningBlock(allocator, &accumulated, &in_reasoning, callback, ctx);
             callback(ctx, root.StreamChunk.finalChunk());
-            return finalizeStreamResult(allocator, accumulated.items, stream_usage);
+            return finalizeStreamResultWithToolCalls(allocator, accumulated.items, stream_usage, &tool_call_accumulator);
         }
         return error.CurlWaitError;
     };
     if (log_enabled) {
-        debug_log.info("curl process terminated: {}", .{term});
+        debug_log.debug("curl process terminated: {}", .{term});
     }
     switch (term) {
         .exited => |code| if (code != 0) {
@@ -594,7 +784,7 @@ pub fn curlStream(
                 log.warn("curlStream exit code {d} after partial stream output; returning accumulated output", .{code});
                 try closeReasoningBlock(allocator, &accumulated, &in_reasoning, callback, ctx);
                 callback(ctx, root.StreamChunk.finalChunk());
-                return finalizeStreamResult(allocator, accumulated.items, stream_usage);
+                return finalizeStreamResultWithToolCalls(allocator, accumulated.items, stream_usage, &tool_call_accumulator);
             }
             return error.CurlFailed;
         },
@@ -603,7 +793,7 @@ pub fn curlStream(
                 log.warn("curlStream abnormal termination after partial stream output; returning accumulated output", .{});
                 try closeReasoningBlock(allocator, &accumulated, &in_reasoning, callback, ctx);
                 callback(ctx, root.StreamChunk.finalChunk());
-                return finalizeStreamResult(allocator, accumulated.items, stream_usage);
+                return finalizeStreamResultWithToolCalls(allocator, accumulated.items, stream_usage, &tool_call_accumulator);
             }
             return error.CurlFailed;
         },
@@ -612,7 +802,7 @@ pub fn curlStream(
     // Signal stream completion only after curl exits successfully.
     try closeReasoningBlock(allocator, &accumulated, &in_reasoning, callback, ctx);
     callback(ctx, root.StreamChunk.finalChunk());
-    return finalizeStreamResult(allocator, accumulated.items, stream_usage);
+    return finalizeStreamResultWithToolCalls(allocator, accumulated.items, stream_usage, &tool_call_accumulator);
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -993,6 +1183,200 @@ test "parseSseLine empty choices" {
 
 test "parseSseLine invalid JSON" {
     try std.testing.expectError(error.InvalidSseJson, parseSseLine(std.testing.allocator, "data: not-json{{{"));
+}
+
+test "extractSseDataPayload strips data framing" {
+    try std.testing.expectEqualStrings("{\"ok\":true}", extractSseDataPayload("data: {\"ok\":true}").?);
+    try std.testing.expectEqualStrings("{\"ok\":true}", extractSseDataPayload("data:{\"ok\":true}\r").?);
+    try std.testing.expect(extractSseDataPayload("") == null);
+    try std.testing.expect(extractSseDataPayload(":keep-alive") == null);
+    try std.testing.expect(extractSseDataPayload("event: message") == null);
+}
+
+test "ToolCallAccumulator combines chunked OpenAI tool call deltas" {
+    // Regression: OpenAI-compatible streaming can emit function.arguments across
+    // multiple delta.tool_calls chunks before finish_reason="tool_calls".
+    const allocator = std.testing.allocator;
+    var accumulator = ToolCallAccumulator{};
+    defer accumulator.deinit(allocator);
+
+    try accumulator.appendFromJsonPayload(allocator,
+        \\{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"shell","arguments":"{\"command\":\""}}]}}]}
+    );
+    try accumulator.appendFromJsonPayload(allocator,
+        \\{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ls\"}"}}]}}]}
+    );
+
+    const tool_calls = try accumulator.toOwnedToolCalls(allocator);
+    defer {
+        for (tool_calls) |tc| {
+            allocator.free(tc.id);
+            allocator.free(tc.name);
+            allocator.free(tc.arguments);
+        }
+        if (tool_calls.len > 0) allocator.free(tool_calls);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", tool_calls[0].id);
+    try std.testing.expectEqualStrings("shell", tool_calls[0].name);
+    try std.testing.expectEqualStrings("{\"command\":\"ls\"}", tool_calls[0].arguments);
+}
+
+test "ToolCallAccumulator preserves parallel OpenAI tool call indexes" {
+    const allocator = std.testing.allocator;
+    var accumulator = ToolCallAccumulator{};
+    defer accumulator.deinit(allocator);
+
+    try accumulator.appendFromJsonPayload(allocator,
+        \\{"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_b","function":{"name":"read_file","arguments":"{\"path\":\"README.md\"}"}},{"index":0,"id":"call_a","function":{"name":"shell","arguments":"{\"command\":\"pwd\"}"}}]}}]}
+    );
+
+    const tool_calls = try accumulator.toOwnedToolCalls(allocator);
+    defer {
+        for (tool_calls) |tc| {
+            allocator.free(tc.id);
+            allocator.free(tc.name);
+            allocator.free(tc.arguments);
+        }
+        if (tool_calls.len > 0) allocator.free(tool_calls);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), tool_calls.len);
+    try std.testing.expectEqualStrings("call_a", tool_calls[0].id);
+    try std.testing.expectEqualStrings("shell", tool_calls[0].name);
+    try std.testing.expectEqualStrings("call_b", tool_calls[1].id);
+    try std.testing.expectEqualStrings("read_file", tool_calls[1].name);
+}
+
+test "ToolCallAccumulator skips malformed and nameless calls" {
+    const allocator = std.testing.allocator;
+    var accumulator = ToolCallAccumulator{};
+    defer accumulator.deinit(allocator);
+
+    try accumulator.appendFromJsonPayload(allocator, "not-json{{{");
+    try accumulator.appendFromJsonPayload(allocator,
+        \\{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_missing","function":{"arguments":"{}"}}]}}]}
+    );
+
+    const tool_calls = try accumulator.toOwnedToolCalls(allocator);
+    defer if (tool_calls.len > 0) allocator.free(tool_calls);
+
+    try std.testing.expectEqual(@as(usize, 0), tool_calls.len);
+}
+
+test "ToolCallAccumulator captures tool calls alongside text deltas" {
+    const allocator = std.testing.allocator;
+    const line =
+        \\data: {"choices":[{"delta":{"content":"working","tool_calls":[{"index":0,"id":"call_1","function":{"name":"shell","arguments":"{}"}}]}}]}
+    ;
+
+    const result = try parseSseLine(allocator, line);
+    switch (result) {
+        .delta => |content| {
+            defer content.deinit(allocator);
+            try std.testing.expectEqualStrings("working", content.text);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    var accumulator = ToolCallAccumulator{};
+    defer accumulator.deinit(allocator);
+    try accumulateToolCallsFromSseLine(&accumulator, allocator, line);
+
+    const tool_calls = try accumulator.toOwnedToolCalls(allocator);
+    defer {
+        for (tool_calls) |tc| {
+            allocator.free(tc.id);
+            allocator.free(tc.name);
+            allocator.free(tc.arguments);
+        }
+        if (tool_calls.len > 0) allocator.free(tool_calls);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", tool_calls[0].id);
+    try std.testing.expectEqualStrings("shell", tool_calls[0].name);
+    try std.testing.expectEqualStrings("{}", tool_calls[0].arguments);
+}
+
+test "accumulateToolCallsFromSseLine handles trailing data line without newline" {
+    const allocator = std.testing.allocator;
+    var accumulator = ToolCallAccumulator{};
+    defer accumulator.deinit(allocator);
+
+    try accumulateToolCallsFromSseLine(&accumulator, allocator,
+        \\data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"shell","arguments":"{}"}}]}}]}
+    );
+
+    const tool_calls = try accumulator.toOwnedToolCalls(allocator);
+    defer {
+        for (tool_calls) |tc| {
+            allocator.free(tc.id);
+            allocator.free(tc.name);
+            allocator.free(tc.arguments);
+        }
+        if (tool_calls.len > 0) allocator.free(tool_calls);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), tool_calls.len);
+    try std.testing.expectEqualStrings("call_0", tool_calls[0].id);
+    try std.testing.expectEqualStrings("shell", tool_calls[0].name);
+}
+
+test "finalizeStreamResultWithToolCalls attaches accumulated calls" {
+    const allocator = std.testing.allocator;
+    var accumulator = ToolCallAccumulator{};
+    defer accumulator.deinit(allocator);
+
+    try accumulator.appendFromJsonPayload(allocator,
+        \\{"choices":[{"delta":{"content":"ignored","tool_calls":[{"index":0,"id":"call_1","function":{"name":"shell","arguments":"{}"}}]}}]}
+    );
+
+    const result = try finalizeStreamResultWithToolCalls(allocator, "visible", null, &accumulator);
+    defer {
+        if (result.content) |content| allocator.free(content);
+        if (result.reasoning_content) |reasoning| allocator.free(reasoning);
+        for (result.tool_calls) |tc| {
+            allocator.free(tc.id);
+            allocator.free(tc.name);
+            allocator.free(tc.arguments);
+        }
+        if (result.tool_calls.len > 0) allocator.free(result.tool_calls);
+    }
+
+    try std.testing.expectEqualStrings("visible", result.content.?);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", result.tool_calls[0].id);
+    try std.testing.expectEqualStrings("shell", result.tool_calls[0].name);
+    try std.testing.expectEqualStrings("{}", result.tool_calls[0].arguments);
+}
+
+test "finalizeStreamResultWithToolCalls supports tool-call-only response" {
+    const allocator = std.testing.allocator;
+    var accumulator = ToolCallAccumulator{};
+    defer accumulator.deinit(allocator);
+
+    try accumulator.appendFromJsonPayload(allocator,
+        \\{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"shell","arguments":"{}"}}]}}]}
+    );
+
+    const result = try finalizeStreamResultWithToolCalls(allocator, "", null, &accumulator);
+    defer {
+        if (result.content) |content| allocator.free(content);
+        if (result.reasoning_content) |reasoning| allocator.free(reasoning);
+        for (result.tool_calls) |tc| {
+            allocator.free(tc.id);
+            allocator.free(tc.name);
+            allocator.free(tc.arguments);
+        }
+        if (result.tool_calls.len > 0) allocator.free(result.tool_calls);
+    }
+
+    try std.testing.expect(result.content == null);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", result.tool_calls[0].id);
+    try std.testing.expectEqualStrings("shell", result.tool_calls[0].name);
 }
 
 test "extractDeltaContent with content" {


### PR DESCRIPTION
## Summary

Decouple native tool-call support from the streaming path so that providers which support native tools during streaming can actually emit them.

Previously the agent loop disabled native tools whenever a stream callback was attached, forcing tools into a prompt-injection format that several models could not reliably emit. Worse, the streaming protocol (`StreamChunk` / `StreamChatResult`) had no field to carry tool calls, so even when a provider parsed them from the SSE deltas they were dropped at the agent boundary.

## Background

The streaming implementation predates native tool support in the OpenAI-compatible protocol. When streaming was added, the response protocol was text-delta-only (`StreamChunk{ delta, is_final, token_count }`), and the streaming call site passed `.tools = null`. The explicit `native_tools_enabled = !is_streaming and ...` gate was added later (during a logging refactor) and codified a limitation that had already become structural rather than intentional — streaming tool-call deltas have been a documented part of the OpenAI-compatible protocol for years.

This restores provider-protocol parity for the streaming path.

## Changes

- **providers/root**: add `tool_calls` to `StreamChatResult` and a `supportsStreamingNativeTools()` vtable slot, defaulting to `false` (conservative — providers must opt in).
- **providers/sse**: add a `ToolCallAccumulator` that parses `delta.tool_calls` (OpenAI-compatible format, including parallel calls indexed by `index`) across SSE chunks and emits a complete `tool_calls` slice on the final `StreamChatResult`.
- **providers/{openai,compatible}**: opt in to streaming native tools.
- **providers/{router,reliable}**: delegate the capability conservatively to the underlying provider.
- **providers/anthropic**: explicitly report `false`. Anthropic streaming tool-use uses a different event shape (`input_json_delta` content blocks) and is left as a follow-up to keep this PR focused.
- **agent/root**: gate native tools on `supportsStreamingNativeTools()` when streaming (rather than on `!is_streaming`), and propagate `stream_result.tool_calls` into the agent loop instead of dropping them.

## Tests

- Regression tests asserting native tools are requested during streaming when the provider advertises the capability.
- Regression tests asserting `tool_calls` emitted on the streaming path reach the agent loop (not dropped).
- `ToolCallAccumulator` unit tests for delta accumulation, parallel-indexed calls, and malformed-input safety.

## Validation

```
zig build test --summary all
Build Summary: 13/13 steps succeeded; 7362/7371 tests passed (9 skipped)
```

0 failures, 0 leaks (`std.testing.allocator`).

`zig fmt --check src/` clean.

## Security / Risk

- No change to tool execution policy, allowlists, or sandboxing. The shell tool's existing security gates (command allowlist, redirection policy, risk classification) apply identically to tool calls arriving via the streaming path.
- No secrets, tokens, or payloads are logged.
- Conservative capability default (`false`): only OpenAI-compatible providers opt in. Adding the capability to a provider that does not actually parse `delta.tool_calls` would silently drop tool calls, so the opt-in is intentional per provider.

## Scope

Provider streaming protocol only. No config schema, vtable signatures beyond the new `supportsStreamingNativeTools()` slot, or user-facing setup changes. Anthropic streaming tool-use is explicitly out of scope for this PR.