### PR TITLE
discord: run typing thread on the heavy runtime stack

### DIFF
--- a/src/channels/discord.zig
+++ b/src/channels/discord.zig
@@ -378,7 +378,12 @@ pub const DiscordChannel = struct {
             .channel_id = key_copy,
         };
 
-        task.thread = try std.Thread.spawn(.{ .stack_size = thread_stacks.AUXILIARY_LOOP_STACK_SIZE }, typingLoop, .{task});
+        // typingLoop performs full HTTPS requests (http.Client + TLS) every
+        // interval, which needs far more headroom than the auxiliary-loop
+        // stack. std.crypto.tls.Client.init alone does large inline memcpys
+        // that overflow a 512KB stack and crash the whole process. Use the
+        // heavy runtime stack for this thread.
+        task.thread = try std.Thread.spawn(.{ .stack_size = thread_stacks.HEAVY_RUNTIME_STACK_SIZE }, typingLoop, .{task});
         errdefer {
             task.stop_requested.store(true, .release);
             if (task.thread) |t| t.join();

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -384,7 +384,6 @@ pub const WsClient = struct {
         const opcode: Opcode = @enumFromInt(hdr[0] & 0x0F);
         const is_masked = (hdr[1] & 0x80) != 0;
         var payload_len: u64 = hdr[1] & 0x7F;
-
         if (payload_len == 126) {
             var ext: [2]u8 = undefined;
             try self.readExact(&ext);


### PR DESCRIPTION
## Summary

The Discord typing-indicator thread runs on `AUXILIARY_LOOP_STACK_SIZE` (512KB) but performs full HTTPS requests (`std.http.Client` → `std.crypto.tls`). `tls.Client.init` does large inline memcpys that overflow a 512KB stack, aborting the whole process the moment a turn triggers typing.

In a release build this surfaces as a SEGV with no log. Symptom: the gateway appears to go permanently deaf after handling one message (see #977) — because the process has actually crashed on the typing thread and systemd restarts it, landing on a fresh session that survives until the next typing-triggering turn.

## Fix

Run the typing thread on `HEAVY_RUNTIME_STACK_SIZE` (2MB), the same size used for session turns and other threads that do HTTPS.

## Reproduction

1. Run `nullclaw gateway` with a Discord channel.
2. Send any message that triggers typing (i.e., any normal turn).
3. Process aborts in `tls.Client.init` (`memcpyFast` on the typing thread's `typingLoop` → `sendTypingIndicator` → `http.Client.request` stack).

Debug-build backtrace confirms the overflow at `std/crypto/tls/Client.zig:195` (`init`) called from `std/http/Client.zig:342` on the typing thread.

## Testing

- Built `ReleaseSafe` and `ReleaseSmall` on linux/aarch64.
- With the fix, a Discord bot survives many consecutive typing-triggering turns (previously crashed on the first). Multi-message DM conversations now complete without restart.

Relates to #977 (this fixes the crash component; there may be a separate frame-delivery issue tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
