### PR TITLE
fix(scheduler): persist paired token to disk during /pair

### DIFF
--- a/src/cron.zig
+++ b/src/cron.zig
@@ -14,6 +14,7 @@ const signal = @import("channels/signal.zig");
 const Config = @import("config.zig").Config;
 const process_util = @import("tools/process_util.zig");
 const security_policy = @import("security/policy.zig");
+const secrets = @import("security/secrets.zig");
 
 const log = std.log.scoped(.cron);
 const DEFAULT_CRON_SHELL_TIMEOUT_NS: u64 = 60 * std.time.ns_per_s;
@@ -1800,12 +1801,26 @@ fn readGatewayUrl(allocator: std.mem.Allocator) ?[]const u8 {
 }
 
 /// Read the paired bearer token from paired_token in the config directory (if present).
+/// Supports both plaintext tokens (backward compat) and tokens encrypted at rest
+/// via SecretStore ("enc2:" prefix).
 fn readPairedToken(allocator: std.mem.Allocator) ?[]const u8 {
     const dir = config_paths.defaultConfigDir(allocator) catch return null;
     defer allocator.free(dir);
     const token_path = config_paths.pathFromConfigDir(allocator, dir, "paired_token") catch return null;
     defer allocator.free(token_path);
     const raw = fs_compat.readFileAlloc(std_compat.fs.cwd(), allocator, token_path, 4096) catch return null;
+
+    // Decrypt if the token was encrypted at rest by the gateway's /pair handler.
+    if (secrets.SecretStore.isEncrypted(raw)) {
+        var store = secrets.SecretStore.init(dir, true);
+        const decrypted = store.decryptSecret(allocator, raw) catch {
+            allocator.free(raw);
+            return null;
+        };
+        allocator.free(raw);
+        return trimOwnedRight(allocator, decrypted);
+    }
+
     return trimOwnedRight(allocator, raw);
 }
 
@@ -4121,4 +4136,69 @@ test "cron rejects obviously malformed expressions" {
         const result = nextRunForCronExpression(input, 0);
         try std.testing.expect(std.meta.isError(result));
     }
+}
+
+test "paired token roundtrip: encrypt at rest then decrypt on read" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try std_compat.fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+
+    const test_token = "test-tok-abc123";
+
+    // Set up SecretStore and encrypt the token as the gateway would.
+    var store = secrets.SecretStore.init(base, true);
+    const encrypted = try store.encryptSecret(allocator, test_token);
+    defer allocator.free(encrypted);
+    try std.testing.expect(secrets.SecretStore.isEncrypted(encrypted));
+
+    // Write the encrypted token to paired_token file (as the gateway does).
+    const token_path = try std_compat.fs.path.join(allocator, &.{ base, "paired_token" });
+    defer allocator.free(token_path);
+    const file = try fs_compat.createPath(token_path, .{});
+    defer file.close();
+    try file.writeAll(encrypted);
+
+    // Read it back and decrypt (as cron does).
+    const raw = try fs_compat.readFileAlloc(std_compat.fs.cwd(), allocator, token_path, 4096);
+    defer allocator.free(raw);
+    try std.testing.expect(secrets.SecretStore.isEncrypted(raw));
+
+    var read_store = secrets.SecretStore.init(base, true);
+    const decrypted = try read_store.decryptSecret(allocator, raw);
+    defer allocator.free(decrypted);
+
+    try std.testing.expectEqualStrings(test_token, decrypted);
+}
+
+test "paired token: plaintext backward compat" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try std_compat.fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+
+    const test_token = "old-plaintext-token";
+
+    // Write a plaintext token (backward compat — no "enc2:" prefix).
+    const token_path = try std_compat.fs.path.join(allocator, &.{ base, "paired_token" });
+    defer allocator.free(token_path);
+    const file = try fs_compat.createPath(token_path, .{});
+    defer file.close();
+    try file.writeAll(test_token);
+
+    // Read it back — should not be treated as encrypted.
+    const raw = try fs_compat.readFileAlloc(std_compat.fs.cwd(), allocator, token_path, 4096);
+    defer allocator.free(raw);
+    try std.testing.expect(!secrets.SecretStore.isEncrypted(raw));
+
+    // decryptSecret on plaintext returns it as-is.
+    var store = secrets.SecretStore.init(base, true);
+    const result = try store.decryptSecret(allocator, raw);
+    defer allocator.free(result);
+
+    try std.testing.expectEqualStrings(test_token, result);
 }

--- a/src/gateway.zig
+++ b/src/gateway.zig
@@ -39,6 +39,7 @@ const root_mod = @import("root.zig");
 const PairingGuard = @import("security/pairing.zig").PairingGuard;
 const constantTimeEq = @import("security/pairing.zig").constantTimeEq;
 const isPublicBindHost = @import("security/pairing.zig").isPublicBind;
+const secrets = @import("security/secrets.zig");
 const channels = @import("channels/root.zig");
 const telegram_update_ingress = @import("channels/telegram_update_ingress.zig");
 const bus_mod = @import("bus.zig");
@@ -789,6 +790,22 @@ pub fn formatPairSuccessResponse(buf: []u8, token: []const u8, expires_in_secs: 
         "{{\"status\":\"paired\",\"token\":\"{s}\",\"expires_in\":{d}}}",
         .{ token, expires_in_secs },
     ) catch null;
+}
+
+/// Persist the paired token to disk (encrypted at rest via SecretStore) so the
+/// cron/schedule tool can authenticate against gateway admin routes.
+fn persistPairedToken(allocator: std.mem.Allocator, cfg: *const Config, token: []const u8) !void {
+    const config_dir = std_compat.fs.path.dirname(cfg.config_path) orelse ".";
+    var store = secrets.SecretStore.init(config_dir, cfg.secrets.encrypt);
+    const encrypted = try store.encryptSecret(allocator, token);
+    defer allocator.free(encrypted);
+
+    const token_path = try std_compat.fs.path.join(allocator, &.{ config_dir, "paired_token" });
+    defer allocator.free(token_path);
+
+    const file = try fs_compat.createPath(token_path, .{});
+    defer file.close();
+    try file.writeAll(encrypted);
 }
 
 fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {
@@ -6302,6 +6319,13 @@ pub fn run(
                                     response_status = "500 Internal Server Error";
                                     response_body = "{\"error\":\"pairing response failed\"}";
                                 }
+
+                                // Persist the paired token so cron/schedule can authenticate.
+                                if (config_opt) |cfg| {
+                                    persistPairedToken(allocator, cfg, token) catch |err| {
+                                        log.warn("failed to persist paired token: {}", .{err});
+                                    };
+                                }
                             },
                             .missing_code => {
                                 response_status = "400 Bad Request";
@@ -10666,4 +10690,45 @@ test "run rejects unsafe public bind before address resolution" {
     // gateway allocation for a non-loopback host.
     const result = run(failing.allocator(), "example.com", 3000, &cfg, null, null);
     try std.testing.expectError(error.PublicBindRequiresTunnel, result);
+}
+
+test "persistPairedToken writes encrypted token to paired_token file" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try std_compat.fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.json", .{base});
+    defer allocator.free(config_path);
+
+    const test_token = "paired-test-token-xyz";
+
+    // Create a minimal Config with encryption enabled.
+    var cfg = Config{
+        .config_path = config_path,
+        .workspace_dir = base,
+        .allocator = allocator,
+        .secrets = .{ .encrypt = true },
+    };
+
+    // Call persistPairedToken.
+    try persistPairedToken(allocator, &cfg, test_token);
+
+    // Verify the file was created and is encrypted.
+    const token_path = try std_compat.fs.path.join(allocator, &.{ base, "paired_token" });
+    defer allocator.free(token_path);
+
+    const raw = try fs_compat.readFileAlloc(std_compat.fs.cwd(), allocator, token_path, 4096);
+    defer allocator.free(raw);
+
+    try std.testing.expect(secrets.SecretStore.isEncrypted(raw));
+
+    // Verify the encrypted content decrypts back to the original token.
+    var store = secrets.SecretStore.init(base, true);
+    const decrypted = try store.decryptSecret(allocator, raw);
+    defer allocator.free(decrypted);
+
+    try std.testing.expectEqualStrings(test_token, decrypted);
 }


### PR DESCRIPTION
## Fixes #839

The `/pair` endpoint generates a token and stores its hash in memory, but never writes it to disk. The cron/schedule tool reads from `{config_dir}/paired_token` to authenticate against gateway admin routes, but since the file never exists, `readPairedToken()` returns `null` and the gateway returns 401.

## Changes

### `src/gateway.zig` (write path)
- After successful pairing in the `.paired => |token|` handler, persist the token to `{config_dir}/paired_token` encrypted at rest via `SecretStore.encryptSecret()` (ChaCha20-Poly1305)
- Failure to persist is logged as a warning but doesn't break the pairing response — the in-memory token still works for the current session

### `src/cron.zig` (read path)
- Updated `readPairedToken()` to detect encrypted tokens via `SecretStore.isEncrypted()` and decrypt them before returning
- **Backward compatible**: plaintext tokens (from older versions or manual setup) still work unchanged

### Tests
- Roundtrip test: encrypt → write file → read → decrypt → matches original token
- Backward compat test: plaintext token file → read → works without encryption
- gateway integration test: `persistPairedToken()` creates encrypted file that decrypts back

## Verification
- Code compiles cleanly (0 compilation errors from changes)
- Pre-existing linker errors (`R_X86_64_PC64` in `crt1.o`) are a system GCC 16 / Zig 0.16 toolchain issue, unrelated to these changes