### PR TITLE
fix(providers): use pinned curl path for proxied requests

### DIFF
--- a/src/providers/helpers.zig
+++ b/src/providers/helpers.zig
@@ -502,12 +502,33 @@ pub fn convertToolsResponses(buf: *std.ArrayListUnmanaged(u8), allocator: std.me
 /// HTTP POST with optional LLM timeout (seconds). 0 = no limit.
 /// Automatically reads proxy from HTTPS_PROXY, HTTP_PROXY, or ALL_PROXY environment variables.
 pub fn curlPostTimed(allocator: std.mem.Allocator, url: []const u8, body: []const u8, headers: []const []const u8, timeout_secs: u64) ![]u8 {
-    _ = timeout_secs;
     const resolve_entry = http_util.buildSafeResolveEntryForRemoteUrl(allocator, url) catch |err| switch (err) {
         error.InvalidUrl, error.HostResolutionFailed, error.LocalAddressBlocked => return err,
         error.OutOfMemory => return error.OutOfMemory,
     };
     defer if (resolve_entry) |entry| allocator.free(entry);
+
+    var timeout_buf: [32]u8 = undefined;
+    const max_time: ?[]const u8 = if (timeout_secs > 0)
+        try std.fmt.bufPrint(&timeout_buf, "{d}", .{timeout_secs})
+    else
+        null;
+
+    // A pinned resolve entry lets curl keep credential headers in a mode-0600
+    // temporary file instead of argv. Prefer that path because std.http proxy
+    // support is not available on every target libc/architecture combination.
+    if (resolve_entry) |entry| {
+        return http_util.curlPostWithProxyAndResolve(
+            allocator,
+            url,
+            body,
+            headers,
+            null,
+            max_time,
+            entry,
+        );
+    }
+
     // Provider requests often carry Authorization/x-api-key credentials.
     // Use std.http so secrets are never exposed through child process argv.
     return http_util.httpPostJsonWithProxy(allocator, url, body, headers, null);


### PR DESCRIPTION
## Summary
- route non-streaming provider POSTs through the existing secure curl path when a safe pinned resolve entry is available
- keep credential headers out of argv by reusing the mode-0600 temporary header file
- preserve the std.http fallback when no pinned resolve entry is available
- pass the configured provider timeout to curl instead of discarding it

## Why
On MIPS32 OpenWrt behind an explicit HTTP proxy, streaming provider requests worked because they use curl, while both DeepSeek non-streaming models consistently failed through the std.http proxy path with `CompatibleApiError`. This also prevented the non-streaming reliability/model-fallback chain from being usable on that target.

## Validation
- `zig fmt src/providers/helpers.zig`
- MIPS32r2 static build: `zig build -Dtarget=mipsel-linux-musleabi -Dcpu=mips32r2 -Doptimize=ReleaseSmall -Dembedded_wasm3=false`
- real-device forced non-streaming calls succeeded for both `deepseek-v4-flash` and `deepseek-chat` through the HTTP proxy
- full test build compiled and ran 7,381 tests: 7,369 passed, 10 skipped; two pre-existing environment-sensitive DNS/curl tests failed on the macOS host