### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,4 +968,4 @@ MIT — see [LICENSE](LICENSE)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=nullclaw/nullclaw&type=date&legend=top-left)](https://www.star-history.com/#nullclaw/nullclaw&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nullclaw/nullclaw&type=date&legend=top-left)](https://star-history.dera.page/#nullclaw/nullclaw&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart on the README is currently broken because it depends on the GitHub stargazer API, which is subject to access restrictions. This change points the chart at star-history.dera.page, a reliable token-free alternative, so the chart renders correctly again.

The chart URL was verified against the repository's remote (nullclaw/nullclaw), so no owner update was needed.