### PR TITLE
feat(providers): add Eden AI as an OpenAI-compatible gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Every subsystem is a **vtable interface** — swap implementations with a config
 
 | Subsystem | Interface | Ships with | Extend |
 |-----------|-----------|------------|--------|
-| **AI Models** | `Provider` | 50+ providers (OpenRouter, Anthropic, OpenAI, Azure OpenAI, Gemini, Vertex AI, Ollama, Venice, NEAR AI Cloud, Atlas Cloud, Evolink, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, and many OpenAI-compatible endpoints) | `custom:https://your-api.com` — any OpenAI-compatible API |
+| **AI Models** | `Provider` | 50+ providers (OpenRouter, Anthropic, OpenAI, Azure OpenAI, Gemini, Vertex AI, Ollama, Venice, NEAR AI Cloud, Atlas Cloud, Evolink, Eden AI, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, and many OpenAI-compatible endpoints) | `custom:https://your-api.com` — any OpenAI-compatible API |
 | **Channels** | `Channel` | CLI, Telegram, Signal, Discord, Slack, iMessage, Matrix, WhatsApp, Webhook, IRC, Lark/Feishu, OneBot, Line, DingTalk, Email, Nostr, QQ, MaixCam, Mattermost | Any messaging API |
 | **Memory** | `Memory` | SQLite with hybrid search (FTS5 + vector cosine similarity), Markdown, ClickHouse, PostgreSQL, Redis, LanceDB, Lucid, LRU, API | Any persistence backend |
 | **Tools** | `Tool` | shell, file_read, file_write, file_edit, file_edit_hashed, file_read_hashed, file_append, memory_store, memory_recall, memory_forget, memory_list, browser_open, screenshot, composio, http_request, web_fetch, web_search, delegate, schedule, hardware_info, hardware_memory, pushover, message, spawn, git, image, i2c, spi, and more | Any capability |

--- a/config.example.json
+++ b/config.example.json
@@ -15,6 +15,9 @@
       "evolink": {
         "api_key": "YOUR_EVOLINK_API_KEY"
       },
+      "edenai": {
+        "api_key": "YOUR_EDENAI_API_KEY"
+      },
       "azure": {
         "api_key": "YOUR_AZURE_OPENAI_API_KEY",
         "base_url": "https://your-resource.openai.azure.com"

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -32,7 +32,7 @@ NullClaw uses a vtable-driven pluggable architecture. Most capabilities are exte
 
 | Subsystem | Interface | Built-in implementations (partial) | Extension approach |
 |---|---|---|---|
-| AI Models | `Provider` | OpenRouter, Anthropic, OpenAI, Azure OpenAI, Gemini, Vertex AI, Ollama, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, Venice, NEAR AI Cloud, Atlas Cloud, Evolink, and many OpenAI-compatible endpoints | Add provider implementation + register |
+| AI Models | `Provider` | OpenRouter, Anthropic, OpenAI, Azure OpenAI, Gemini, Vertex AI, Ollama, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, Venice, NEAR AI Cloud, Atlas Cloud, Evolink, Eden AI, and many OpenAI-compatible endpoints | Add provider implementation + register |
 | Channels | `Channel` | CLI, Telegram, Signal, Discord, Slack, Matrix, WhatsApp, Nostr, IRC, Lark, Line, DingTalk, Email, OneBot, QQ, MaixCam, Mattermost, iMessage, Web, Teams, Max | Add channel implementation + register |
 | Memory | `Memory` | SQLite (hybrid retrieval), Markdown, ClickHouse, PostgreSQL, Redis, LanceDB, Lucid, LRU, API, None | Add memory backend |
 | Tools | `Tool` | shell, file_read, file_write, file_edit, file_edit_hashed, file_read_hashed, file_append, http_request, web_fetch, web_search, delegate, screenshot, browser_open, and 20+ more | Add tool implementation |

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -117,7 +117,7 @@ Example:
 ### `models.providers`
 
 - Defines LLM provider connection parameters and API keys.
-- Common providers: `openrouter`, `openai`, `anthropic`, `groq`, `nearai`, `atlas-cloud`, `evolink`.
+- Common providers: `openrouter`, `openai`, `anthropic`, `groq`, `nearai`, `atlas-cloud`, `evolink`, `edenai`.
 
 Example:
 
@@ -128,6 +128,7 @@ Example:
       "openrouter": { "api_key": "sk-or-..." },
       "nearai": { "api_key": "YOUR_NEARAI_API_KEY" },
       "atlas-cloud": { "api_key": "YOUR_ATLASCLOUD_API_KEY" },
+      "edenai": { "api_key": "YOUR_EDENAI_API_KEY" },
       "evolink": { "api_key": "YOUR_EVOLINK_API_KEY" },
       "anthropic": { "api_key": "sk-ant-..." },
       "openai": { "api_key": "sk-..." }

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -18,7 +18,7 @@ NullClaw 采用 vtable 可插拔架构。多数能力通过接口实现并在工
 
 | 子系统 | 接口 | 内置实现（节选） | 扩展方式 |
 |---|---|---|---|
-| AI Models | `Provider` | OpenRouter、Anthropic、OpenAI、Azure OpenAI、Gemini、Vertex AI、Ollama、Groq、Mistral、xAI、DeepSeek、Together、Fireworks、Perplexity、Cohere、Bedrock、Venice、NEAR AI Cloud、Atlas Cloud、Evolink，以及众多 OpenAI-compatible endpoints | 添加 provider 实现并注册 |
+| AI Models | `Provider` | OpenRouter、Anthropic、OpenAI、Azure OpenAI、Gemini、Vertex AI、Ollama、Groq、Mistral、xAI、DeepSeek、Together、Fireworks、Perplexity、Cohere、Bedrock、Venice、NEAR AI Cloud、Atlas Cloud、Evolink、Eden AI，以及众多 OpenAI-compatible endpoints | 添加 provider 实现并注册 |
 | Channels | `Channel` | CLI、Telegram、Signal、Discord、Slack、Matrix、WhatsApp、Nostr、IRC、Lark、Line、DingTalk、Email、OneBot、QQ、MaixCam、Mattermost、iMessage、Web | 添加 channel 实现并注册 |
 | Memory | `Memory` | SQLite（hybrid 检索）、Markdown、ClickHouse、PostgreSQL、Redis、LanceDB、Lucid、LRU、API、None | 新增 memory backend |
 | Tools | `Tool` | shell、file_read、file_write、file_edit、file_edit_hashed、file_read_hashed、file_append、http_request、web_fetch、web_search、delegate、screenshot、browser_open 等 35+ | 新增 tool 实现 |

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -102,7 +102,7 @@ nullclaw onboard --interactive
 ### `models.providers`
 
 - 定义各 LLM provider 的连接参数与 API Key。
-- 常见 provider：`openrouter`、`openai`、`anthropic`、`groq`、`nearai`、`atlas-cloud`、`evolink` 等。
+- 常见 provider：`openrouter`、`openai`、`anthropic`、`groq`、`nearai`、`atlas-cloud`、`evolink`、`edenai` 等。
 
 示例：
 
@@ -113,6 +113,7 @@ nullclaw onboard --interactive
       "openrouter": { "api_key": "sk-or-..." },
       "nearai": { "api_key": "YOUR_NEARAI_API_KEY" },
       "atlas-cloud": { "api_key": "YOUR_ATLASCLOUD_API_KEY" },
+      "edenai": { "api_key": "YOUR_EDENAI_API_KEY" },
       "evolink": { "api_key": "YOUR_EVOLINK_API_KEY" },
       "anthropic": { "api_key": "sk-ant-..." },
       "openai": { "api_key": "sk-..." }

--- a/src/integrations.zig
+++ b/src/integrations.zig
@@ -105,6 +105,7 @@ const all_integrations_list = [_]IntegrationEntry{
     .{ .name = "NEAR AI Cloud", .description = "OpenAI-compatible inference gateway", .category = .ai_model, .status = .available },
     .{ .name = "Atlas Cloud", .description = "OpenAI-compatible inference gateway", .category = .ai_model, .status = .available },
     .{ .name = "Evolink", .description = "OpenAI-compatible multi-model gateway", .category = .ai_model, .status = .available },
+    .{ .name = "Eden AI", .description = "EU multi-provider gateway", .category = .ai_model, .status = .available },
     .{ .name = "Vercel AI", .description = "Vercel AI Gateway", .category = .ai_model, .status = .available },
     .{ .name = "Cloudflare AI", .description = "Cloudflare AI Gateway", .category = .ai_model, .status = .available },
     .{ .name = "Moonshot", .description = "Kimi & Kimi Coding", .category = .ai_model, .status = .available },

--- a/src/model_refs.zig
+++ b/src/model_refs.zig
@@ -70,6 +70,7 @@ const known_url_model_provider_namespaces = std.StaticStringMap(void).initCompti
     .{ "nearai", {} },
     .{ "atlas-cloud", {} },
     .{ "evolink", {} },
+    .{ "edenai", {} },
     .{ "vercel-ai", {} },
     .{ "poe", {} },
     .{ "xiaomi", {} },

--- a/src/onboard.zig
+++ b/src/onboard.zig
@@ -124,6 +124,7 @@ pub const known_providers = [_]ProviderInfo{
     .{ .key = "nearai", .label = "NEAR AI Cloud", .default_model = "zai-org/GLM-5.1-FP8", .env_var = "NEARAI_API_KEY" },
     .{ .key = "atlas-cloud", .label = "Atlas Cloud", .default_model = "qwen/qwen3-32b", .env_var = "ATLASCLOUD_API_KEY" },
     .{ .key = "evolink", .label = "Evolink", .default_model = "gpt-5.2", .env_var = "EVOLINK_API_KEY" },
+    .{ .key = "edenai", .label = "Eden AI (EU gateway)", .default_model = "anthropic/claude-sonnet-5", .env_var = "EDENAI_API_KEY" },
     .{ .key = "moonshot", .label = "Moonshot (Kimi)", .default_model = "kimi-k2.5", .env_var = "MOONSHOT_API_KEY" },
     .{ .key = "xiaomi", .label = "Xiaomi MiMo", .default_model = "mimo-v2-pro", .env_var = "MIMO_API_KEY" },
     .{ .key = "synthetic", .label = "Synthetic", .default_model = "synthetic-model", .env_var = "SYNTHETIC_API_KEY" },
@@ -484,6 +485,7 @@ const models_dev_providers = [_]ModelsDevProvider{
     .{ .canonical = "bedrock", .key = "amazon-bedrock" },
     .{ .canonical = "copilot", .key = "github-copilot" },
     .{ .canonical = "poe", .key = "poe" },
+    .{ .canonical = "edenai", .key = "edenai" },
 };
 
 const NativeModelCatalog = struct {

--- a/src/provider_names.zig
+++ b/src/provider_names.zig
@@ -10,6 +10,7 @@ pub fn canonicalProviderName(name: []const u8) []const u8 {
     if (std.mem.eql(u8, name, "novita-ai")) return "novita";
     if (std.mem.eql(u8, name, "xiaomi-mimo") or std.mem.eql(u8, name, "mimo")) return "xiaomi";
     if (std.mem.eql(u8, name, "atlas") or std.mem.eql(u8, name, "atlascloud")) return "atlas-cloud";
+    if (std.mem.eql(u8, name, "eden-ai") or std.mem.eql(u8, name, "eden_ai")) return "edenai";
     return name;
 }
 
@@ -23,6 +24,7 @@ pub fn canonicalProviderNameIgnoreCase(name: []const u8) []const u8 {
     if (std.ascii.eqlIgnoreCase(name, "novita-ai")) return "novita";
     if (std.ascii.eqlIgnoreCase(name, "xiaomi-mimo") or std.ascii.eqlIgnoreCase(name, "mimo")) return "xiaomi";
     if (std.ascii.eqlIgnoreCase(name, "atlas") or std.ascii.eqlIgnoreCase(name, "atlascloud")) return "atlas-cloud";
+    if (std.ascii.eqlIgnoreCase(name, "eden-ai") or std.ascii.eqlIgnoreCase(name, "eden_ai")) return "edenai";
     return name;
 }
 
@@ -49,6 +51,8 @@ test "canonicalProviderName handles supported aliases" {
     try std.testing.expectEqualStrings("xiaomi", canonicalProviderName("mimo"));
     try std.testing.expectEqualStrings("atlas-cloud", canonicalProviderName("atlas"));
     try std.testing.expectEqualStrings("atlas-cloud", canonicalProviderName("atlascloud"));
+    try std.testing.expectEqualStrings("edenai", canonicalProviderName("eden-ai"));
+    try std.testing.expectEqualStrings("edenai", canonicalProviderName("eden_ai"));
 }
 
 test "providerNamesMatch handles aliases without broadening custom providers" {
@@ -56,6 +60,7 @@ test "providerNamesMatch handles aliases without broadening custom providers" {
     try std.testing.expect(providerNamesMatch("gemini", "google"));
     try std.testing.expect(providerNamesMatch("xiaomi", "mimo"));
     try std.testing.expect(providerNamesMatch("atlas-cloud", "atlascloud"));
+    try std.testing.expect(providerNamesMatch("edenai", "eden-ai"));
     try std.testing.expect(!providerNamesMatch("custom:https://Example.com/v1", "custom:https://example.com/v1"));
 }
 
@@ -63,5 +68,6 @@ test "providerNamesMatchIgnoreCase preserves case-insensitive matching" {
     try std.testing.expect(providerNamesMatchIgnoreCase("azure", "AZURE-OPENAI"));
     try std.testing.expect(providerNamesMatchIgnoreCase("xiaomi", "MIMO"));
     try std.testing.expect(providerNamesMatchIgnoreCase("Atlas-Cloud", "ATLAS"));
+    try std.testing.expect(providerNamesMatchIgnoreCase("EdenAI", "EDEN-AI"));
     try std.testing.expect(providerNamesMatchIgnoreCase("CustomGW", "customgw"));
 }

--- a/src/providers/api_key.zig
+++ b/src/providers/api_key.zig
@@ -325,6 +325,7 @@ fn providerEnvCandidates(name: []const u8) [3][]const u8 {
         .{ "nearai", .{ "NEARAI_API_KEY", "NEARAI_CLOUD_API_KEY", "NEAR_AI_API_KEY" } },
         .{ "atlas-cloud", .{ "ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY", "ATLAS_API_KEY" } },
         .{ "evolink", .{ "EVOLINK_API_KEY", "", "" } },
+        .{ "edenai", .{ "EDENAI_API_KEY", "", "" } },
         .{ "poe", .{ "POE_API_KEY", "", "" } },
         .{ "moonshot", .{ "MOONSHOT_API_KEY", "", "" } },
         .{ "kimi", .{ "MOONSHOT_API_KEY", "", "" } },
@@ -426,6 +427,12 @@ test "atlas cloud env candidates include documented ATLASCLOUD_API_KEY" {
 test "evolink env candidate is EVOLINK_API_KEY" {
     const candidates = providerEnvCandidates("evolink");
     try std.testing.expectEqualStrings("EVOLINK_API_KEY", candidates[0]);
+}
+
+test "edenai env candidate is EDENAI_API_KEY across aliases" {
+    try std.testing.expectEqualStrings("EDENAI_API_KEY", providerEnvCandidates("edenai")[0]);
+    try std.testing.expectEqualStrings("EDENAI_API_KEY", providerEnvCandidates("eden-ai")[0]);
+    try std.testing.expectEqualStrings("EDENAI_API_KEY", providerEnvCandidates("eden_ai")[0]);
 }
 
 test "azure aliases share Azure env candidate" {

--- a/src/providers/factory.zig
+++ b/src/providers/factory.zig
@@ -86,6 +86,7 @@ const compat_providers = [_]CompatProvider{
     .{ .name = "nearai", .url = "https://cloud-api.near.ai/v1", .display = "NEAR AI Cloud" },
     .{ .name = "atlas-cloud", .url = "https://api.atlascloud.ai/v1", .display = "Atlas Cloud" },
     .{ .name = "evolink", .url = "https://direct.evolink.ai/v1", .display = "Evolink" },
+    .{ .name = "edenai", .url = "https://api.edenai.run/v3", .display = "Eden AI" },
     .{ .name = "vercel", .url = "https://ai-gateway.vercel.sh/v1", .display = "Vercel AI Gateway" },
     .{ .name = "vercel-ai", .url = "https://ai-gateway.vercel.sh/v1", .display = "Vercel AI Gateway" },
     .{ .name = "together", .url = "https://api.together.xyz", .display = "Together AI" },
@@ -593,6 +594,8 @@ test "classifyProvider identifies known providers" {
     try std.testing.expect(classifyProvider("atlas") == .compatible_provider);
     try std.testing.expect(classifyProvider("atlascloud") == .compatible_provider);
     try std.testing.expect(classifyProvider("evolink") == .compatible_provider);
+    try std.testing.expect(classifyProvider("edenai") == .compatible_provider);
+    try std.testing.expect(classifyProvider("eden-ai") == .compatible_provider);
     try std.testing.expect(classifyProvider("poe") == .compatible_provider);
     try std.testing.expect(classifyProvider("custom:https://example.com") == .compatible_provider);
     try std.testing.expect(classifyProvider("openai-codex") == .openai_codex_provider);
@@ -635,6 +638,8 @@ test "compatibleProviderUrl returns correct URLs" {
     try std.testing.expectEqualStrings("https://api.venice.ai", compatibleProviderUrl("venice").?);
     try std.testing.expectEqualStrings("https://cloud-api.near.ai/v1", compatibleProviderUrl("nearai").?);
     try std.testing.expectEqualStrings("https://api.atlascloud.ai/v1", compatibleProviderUrl("atlas-cloud").?);
+    try std.testing.expectEqualStrings("https://api.edenai.run/v3", compatibleProviderUrl("edenai").?);
+    try std.testing.expectEqualStrings("https://api.edenai.run/v3", compatibleProviderUrl("eden-ai").?);
     try std.testing.expectEqualStrings("https://api.atlascloud.ai/v1", compatibleProviderUrl("atlas").?);
     try std.testing.expectEqualStrings("https://api.atlascloud.ai/v1", compatibleProviderUrl("atlascloud").?);
     try std.testing.expectEqualStrings("https://direct.evolink.ai/v1", compatibleProviderUrl("evolink").?);


### PR DESCRIPTION
## What

Adds Eden AI as an OpenAI-compatible gateway provider, following the shape of #922 (NEAR AI Cloud and Atlas Cloud). No new provider implementation, it goes through `OpenAiCompatibleProvider` like the other gateways.

Eden AI routes to many upstream vendors behind one key, and it is EU based with an EU endpoint, which is mostly why people reach for it.

## The models.dev part

This is the bit worth pointing at. Eden AI has been in models.dev since anomalyco/models.dev#4506 merged on 12 August, so the `models_dev_providers` entry means the onboarding model list comes from that catalog and stays current on its own. There is no hardcoded model list to maintain here, and no second URL to fetch like NEAR AI Cloud and Atlas Cloud need.

## Changes

- `providers/factory.zig`: `edenai` in `compat_providers`, base `https://api.edenai.run/v3`. `chatCompletionsUrl` appends `/chat/completions`, which is the real endpoint.
- `providers/api_key.zig`: `EDENAI_API_KEY`.
- `provider_names.zig`: `eden-ai` and `eden_ai` canonicalise to `edenai`.
- `onboard.zig`: one row in `known_providers` and the `models_dev_providers` mapping.
- `model_refs.zig`: `edenai` in `known_url_model_provider_namespaces`. Model ids carry a vendor segment, `anthropic/claude-sonnet-5`, so this is the same case as Atlas Cloud's `qwen/...` ids. The prefix stripping #922 added to `normalizeProviderModel` already covers the rest.
- `integrations.zig`, `config.example.json`, `README.md`, and `docs/en` plus `docs/zh` for configuration and architecture.

## Two judgement calls

I put the row in Tier 4 next to the other recently added gateways rather than Tier 1, even though Eden AI is a multi-provider gateway. Putting a newcomer above Anthropic and OpenAI in the onboarding menu is not mine to decide, and #922 landed in Tier 4 too. Move it if you disagree.

I did not add a separate `edenai-eu` entry for the EU endpoint. It is reachable today with a per-provider `base_url` in config, the way the Azure example does it, and that keeps the diff small. Worth flagging one consequence though: `shouldUseModelsDevCatalog` returns false as soon as `base_url` is set, so an EU user loses the models.dev catalog for the model list. If you would rather have a proper twin entry, the `moonshot-cn` and `zai-cn` pattern fits it exactly and I am happy to send that instead.

## Validation

Local, zig 0.16.0, the version `nullbuilder` installs:

- `zig fmt --check src/` clean, which is the `pre-commit` hook.
- `zig build test --summary all` green, the `pre-push` hook. **7375 tests pass on `main` before the change and 7376 after**, the extra one being the new env-alias test. The 8 other assertions went into existing tests rather than new blocks.
- `zig build -Doptimize=ReleaseSmall` clean.
- Not just unit tests: the endpoint the code builds, `https://api.edenai.run/v3/chat/completions`, was exercised with a live key, and `anthropic/claude-sonnet-5`, the default model in the row, returns 200. I picked that id off the live catalog rather than a docs page.

I do work at Eden AI.
